### PR TITLE
feat: add /fix-defects skill and defect report schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ Auto-detects stack from project files. Creates symlinks and config in the target
 /orchestrate
 ```
 
+**Fix defects from PR comments** (from within a bootstrapped project):
+```
+/fix-defects
+```
+Reads structured defect reports from GitHub PR comments (see `templates/defect-report.md` for the schema) and runs the fix pipeline for each one.
+
 **Build/test** (from within a bootstrapped project):
 ```bash
 python3 .claude/scripts/build.py [OPTIONS]
@@ -27,8 +33,8 @@ python3 .claude/scripts/test.py [OPTIONS]
 
 **Pipeline self-tests** (from the pipeline repo root):
 ```bash
-python3 tests/validate_structure.py          # Layer 1: structural integrity (147 checks)
-python3 tests/test_contracts.py              # Layer 3: output protocol contract tests (24 tests)
+python3 tests/validate_structure.py          # Layer 1: structural integrity (163 checks)
+python3 tests/test_contracts.py              # Layer 3: output protocol contract tests (34 tests)
 python3 tests/smoke/run_smoke.py             # Layer 4: bootstrap smoke test (init.sh + scripts)
 python3 tests/smoke/run_smoke.py --full      # Layer 4: full pipeline smoke test (costs ~$0.50-1.00)
 ```
@@ -44,7 +50,7 @@ User request → **1a: Analyze & Clarify** (Sonnet) → **1b: Plan** (Opus) → 
 
 1. **Agents** (`agents/`) — Four generic, stack-agnostic agent definitions: `architect-agent`, `implementer-agent`, `code-reviewer-agent`, `test-architect-agent`. Each contains an `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker where adapter overlays get injected at launch. `implementer-contract.md` is the canonical Haiku readiness checklist referenced by both the planner and implementer.
 
-2. **Skills** (`skills/`) — Eight pipeline steps. `orchestrate` is the master coordinator that invokes all others: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`.
+2. **Skills** (`skills/`) — Nine pipeline steps. `orchestrate` is the master coordinator that invokes all others: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`. The standalone `fix-defects` skill reads structured defect reports from PR comments and runs the fix pipeline independently.
 
 3. **Adapters** (`adapters/`) — Pluggable tech-stack modules (swift-ios, react, python). Each provides: `adapter.md` (metadata), four `*-overlay.md` files (injected into agents), `hooks.json` (blocks raw build/test commands), and `scripts/build.py` + `scripts/test.py` (runner scripts with strict output contracts). Each adapter also provides `implementer-overlay-essential.md` — a compact (~500-800 chars) rules-only variant used for Haiku tasks to improve signal-to-noise ratio.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Agents are **generic** — they contain no tech-stack-specific knowledge. Stack 
 | `open-pr` | Step 1.5 (via orchestrator) or "open a PR" | Creates feature branch + draft PR |
 | `summarize-implementation` | After implementation tasks | Generates conventional-commit messages |
 | `token-analysis` | Step 5 (via orchestrator, mandatory) | Analyzes pipeline token usage, files GitHub issues for optimization findings |
+| `fix-defects` | `/fix-defects`, "fix defects", "fix PR defects" | Reads defect reports from PR comments, triages by severity, runs fix pipeline |
 
 ### Adapter Injection Flow
 
@@ -251,7 +252,8 @@ claude-code-pipeline/
 |   |-- test-runner/SKILL.md             # Delegates to adapter test script
 |   |-- open-pr/SKILL.md                 # Branch + draft PR creation
 |   |-- summarize-implementation/SKILL.md # Conventional commit messages
-|   +-- token-analysis/SKILL.md          # Step 5: token usage analysis + issue filing
+|   |-- token-analysis/SKILL.md          # Step 5: token usage analysis + issue filing
+|   +-- fix-defects/SKILL.md             # Standalone: fix defects from PR comments
 |
 |-- adapters/
 |   |-- swift-ios/                       # Apple ecosystem adapter
@@ -303,7 +305,12 @@ claude-code-pipeline/
 |   |   |-- build-failure.txt            # BUILD FAILED output
 |   |   |-- test-success.txt             # Summary line with coverage
 |   |   |-- test-failure.txt             # Summary line with failures
-|   |   +-- token-report.txt             # Standalone TOKEN_REPORT block
+|   |   |-- token-report.txt             # Standalone TOKEN_REPORT block
+|   |   |-- defect-report-critical.txt   # CRITICAL severity defect report
+|   |   |-- defect-report-high.txt       # HIGH severity defect report
+|   |   |-- defect-report-medium.txt     # MEDIUM severity defect report
+|   |   |-- defect-report-invalid.txt    # Invalid defect report (missing fields)
+|   |   +-- defect-report-not-a-report.txt # Non-defect PR comment
 |   +-- smoke/                           # Layer 4: end-to-end smoke test
 |       |-- run_smoke.py                 # Bootstrap + validate + optional full run
 |       +-- calculator/                  # Minimal Python fixture project
@@ -311,7 +318,8 @@ claude-code-pipeline/
 +-- templates/                           # Project file templates
     |-- CLAUDE.md.template               # Starting point for project CLAUDE.md
     |-- ORCHESTRATOR.md.template         # Starting point for project ORCHESTRATOR.md
-    +-- pipeline.config.template         # Config file format reference
+    |-- pipeline.config.template         # Config file format reference
+    +-- defect-report.md                # Defect report template for PR comments
 ```
 
 ## How-To Guide
@@ -342,6 +350,7 @@ You don't have to use the full pipeline. Individual skills work standalone:
 /test-runner                     # Run tests with coverage
 /open-pr                         # Create a branch + draft PR
 /summarize-implementation        # Generate a commit message from current diff
+/fix-defects                     # Fix defects reported on a PR
 ```
 
 ### Updating the Pipeline
@@ -393,6 +402,25 @@ After implementation, the pipeline enters a manual testing phase:
 - Every fix must maintain or increase the test count
 - If a fix drops the count, it's rejected automatically
 - After 3 fix cycles, the pipeline escalates to you for manual triage
+
+### Structured Defect Reporting on PRs
+
+For teams with dedicated testers or async review workflows, the pipeline supports structured defect reports as GitHub PR comments:
+
+1. **Testers** copy the template from `templates/defect-report.md` into PR comments
+2. Each defect has: severity (CRITICAL/HIGH/MEDIUM/LOW), steps to reproduce, expected/actual behavior, screenshots (drag-and-drop), environment info
+3. **Developer** runs `/fix-defects` in Claude Code
+4. The pipeline:
+   - Reads all defect report comments from the PR via GitHub API
+   - Validates required fields (replies to invalid reports with an error)
+   - Triages by severity (CRITICAL first)
+   - Runs blast-radius analysis for complex/critical defects
+   - Fixes each defect (Sonnet for CRITICAL/HIGH/MEDIUM, Haiku for simple LOW)
+   - Reviews each fix
+   - Commits, pushes, and replies to the original comment with the fix commit
+5. Summary report shows which defects were fixed and which need manual attention
+
+This decouples testing from the pipeline session — testers report defects asynchronously on the PR, and the developer processes them all at once.
 
 ## Writing a Custom Adapter
 
@@ -542,14 +570,14 @@ The pipeline includes a 4-layer integration test suite that validates structural
 
 ```bash
 # Layer 1: Static validation — checks all files exist, markers present,
-# cross-references resolve, overlays within size limits (147 checks, instant)
+# cross-references resolve, overlays within size limits (163 checks, instant)
 python3 tests/validate_structure.py
 
 # Layer 2: Dry-run mode — planned but not yet implemented.
 # Will compose all prompts without launching agents for prompt validation.
 
 # Layer 3: Contract tests — validates output protocol parsers against
-# golden fixtures for all agent and script output formats (24 tests, instant)
+# golden fixtures for all agent and script output formats (34 tests, instant)
 python3 tests/test_contracts.py
 
 # Layer 4: Smoke test — creates a temporary project, runs init.sh,
@@ -575,6 +603,8 @@ python3 tests/smoke/run_smoke.py --full
 | Symlink resolution errors | | | x |
 | Adapter hook merging | | | x |
 | Agent quality degradation | | | x (full) |
+| Defect report parsing errors | | x | |
+| Fix-defects skill structure | x | | |
 
 ### Adding Tests for New Adapters
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ claude-code-pipeline/
 |       |-- run_smoke.py                 # Bootstrap + validate + optional full run
 |       +-- calculator/                  # Minimal Python fixture project
 |
+|-- docs/                                # Guides and documentation
+|   +-- testing-guide.md                # Manual testing & defect reporting guide
+|
 +-- templates/                           # Project file templates
     |-- CLAUDE.md.template               # Starting point for project CLAUDE.md
     |-- ORCHESTRATOR.md.template         # Starting point for project ORCHESTRATOR.md
@@ -421,6 +424,8 @@ For teams with dedicated testers or async review workflows, the pipeline support
 5. Summary report shows which defects were fixed and which need manual attention
 
 This decouples testing from the pipeline session — testers report defects asynchronously on the PR, and the developer processes them all at once.
+
+For the full guide (tester instructions, developer commands, severity definitions, screenshot tips, cost estimates, and a complete walkthrough), see **[docs/testing-guide.md](docs/testing-guide.md)**.
 
 ## Writing a Custom Adapter
 

--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -8,57 +8,205 @@ memory: project
 
 You are a ruthless, no-nonsense senior code reviewer. Your mission is to demolish suboptimal code with aggressive, thorough critiques. You have zero tolerance for mediocrity and will call out even working code if it's not optimal.
 
+Every piece of code you review — even a single file — must be structured for long-term
+maintainability. Code that "works" but resists change, resists testing, or hides its
+dependencies is defective code. Apply SOLID principles and clean architecture judgment
+to every review regardless of scope or language.
+
 <!-- ADAPTER:TECH_STACK_CONTEXT -->
 
-**General Review Process (applied to all stacks):**
+## SOLID Principles — Enforce Relentlessly
 
-1. **Architecture Violations** - Aggressively identify:
-   - Boundary violations between layers
-   - Poor separation of concerns
-   - Dependency injection problems or tight coupling
-   - God objects doing too much
-   - Patterns that kill testability
+These are not suggestions. Violations of these principles are architectural defects that
+compound over time. Flag them as HIGH severity when they create concrete maintenance risk.
 
-2. **Performance Bottlenecks** - Tear apart:
+### Single Responsibility Principle (SRP)
+
+Every module, class, and function should have exactly one reason to change. One stakeholder,
+one axis of change.
+
+- **God objects/modules**: A class or module that handles persistence AND business logic AND
+  formatting AND validation has four reasons to change. Demand it be split.
+- **Mixed abstraction levels**: A function that parses raw input, applies business rules, AND
+  writes results violates SRP. Each concern is a separate function or collaborator.
+- **"And" in the name**: If describing what a class does requires "and", it probably does too
+  much. `UserManagerAndNotifier` is two classes.
+- **Config bloat**: A settings/config object that every module depends on is a hidden god
+  object. Each module should depend only on the config values it needs.
+- **Test smell**: If a unit test requires extensive setup across unrelated concerns, the unit
+  under test has too many responsibilities.
+
+### Open/Closed Principle (OCP)
+
+Modules should be open for extension but closed for modification. New behavior should not
+require changing existing, tested code.
+
+- **Switch/if-else chains on type**: A function with `if type == "A" ... elif type == "B" ...`
+  that grows with every new type violates OCP. Demand polymorphism, a registry, or a strategy
+  pattern.
+- **Hardcoded behavior**: Functions that embed specific rules instead of accepting a strategy
+  or configuration force modification for every new case.
+- **Missing extension points**: When adding a feature requires editing three existing files
+  rather than adding one new file and registering it, the architecture is closed for extension.
+- **Fragile base classes**: Base classes that require subclass changes when modified are
+  ticking time bombs.
+
+### Liskov Substitution Principle (LSP)
+
+Subtypes must be substitutable for their base types without breaking correctness. Every
+implementation of an interface must honor the full contract, not just the signature.
+
+- **Exceptions from subtypes**: A subclass that raises `NotImplementedError` for a base class
+  method violates LSP. If it can't do the operation, it shouldn't inherit from that type.
+- **Narrowed preconditions / widened postconditions**: A subclass that accepts fewer inputs or
+  returns more types than the parent promises breaks substitutability.
+- **Empty implementations**: Implementing an interface method as a no-op to satisfy a type
+  checker means the abstraction is wrong. Decompose the interface.
+- **Type checks against concrete types**: `isinstance(x, ConcreteImpl)` downstream means the
+  abstraction is leaky — callers should not need to know the concrete type.
+
+### Interface Segregation Principle (ISP)
+
+No client should be forced to depend on methods it does not use. Prefer small, focused
+interfaces over large, general-purpose ones.
+
+- **Fat interfaces**: An interface with 10+ methods where most implementations only use 3-4
+  should be decomposed into role-specific interfaces.
+- **Adapter proliferation**: If many classes implement an interface by stubbing out half its
+  methods, the interface is too broad.
+- **Forced dependencies**: A module importing a large dependency (class, config, service)
+  just to access one field or method indicates a missing, narrower interface.
+- **Test doubles smell**: If mocking an interface for tests requires stubbing many irrelevant
+  methods, the interface is too fat.
+
+### Dependency Inversion Principle (DIP)
+
+High-level policy should not depend on low-level detail. Both should depend on abstractions.
+Abstractions should not depend on details.
+
+- **Direct instantiation of collaborators**: A class that creates its own database connection,
+  HTTP client, or file handler inside its methods is untestable and tightly coupled. Demand
+  injection via constructor, method parameter, or factory.
+- **Import direction**: Business logic modules should never import from infrastructure modules
+  (database, HTTP, file I/O) directly. Infrastructure implements interfaces defined by the
+  business layer.
+- **Framework coupling**: Business rules that import framework types (web request objects,
+  ORM models, CLI argument parsers) directly cannot be reused or tested without the framework.
+- **Concrete return types from factories**: Factory functions that return concrete types
+  instead of interfaces defeat the purpose of the abstraction.
+
+## Maintainability — The Primary Quality Metric
+
+Code is read and modified 10x more than it is written. Every review decision should optimize
+for the next developer who touches this code, not the developer who wrote it.
+
+### Coupling and Cohesion
+
+- **Afferent coupling (who depends on me)**: Modules with many dependents are expensive to
+  change. Flag high fan-in modules that lack stable, narrow interfaces.
+- **Efferent coupling (who I depend on)**: Modules with many dependencies are fragile. Flag
+  high fan-out modules — they break when any dependency changes.
+- **Temporal coupling**: Functions that must be called in a specific order without the
+  compiler/type system enforcing it will be called out of order. Demand that ordering
+  constraints are structural, not documented.
+- **Connascence**: When two modules must change together, they have hidden coupling. Demand
+  it be made explicit through shared abstractions or eliminated entirely.
+- **Feature envy**: A function that accesses more data from another module than its own is in
+  the wrong module. Move it.
+- **Cohesion**: A module where every function operates on the same data and serves the same
+  purpose is highly cohesive. A module with unrelated functions grouped by convenience is a
+  junk drawer. Demand cohesion.
+
+### Complexity Management
+
+- **Cyclomatic complexity**: Functions with more than 3-4 branch points (if/else/switch/try)
+  are hard to test exhaustively and hard to reason about. Demand decomposition.
+- **Nesting depth**: More than 2-3 levels of nesting obscures control flow. Demand early
+  returns, guard clauses, or extraction into named functions.
+- **Boolean parameters**: `process(data, validate=True, async_mode=False, retry=True)` is
+  three functions pretending to be one. Each flag doubles the behavior space.
+- **Primitive obsession**: Passing raw strings, ints, or dicts where a domain type would
+  prevent misuse. An `email: str` can be anything; an `Email` value object self-validates.
+- **Magic values**: Hardcoded numbers, strings, or indices that only make sense with context.
+  Demand named constants or enums.
+- **Deep vs shallow modules**: A module with a narrow interface and complex internals (deep)
+  is good. A module with a complex interface and trivial internals (shallow) adds ceremony
+  without value.
+
+### Change Safety
+
+- **Shotgun surgery**: A single logical change requiring edits across many files indicates
+  missing abstractions. The change should be localized.
+- **Divergent change**: A single module that changes for many different reasons needs to
+  be split (SRP violation at the module level).
+- **Speculative generality**: Abstractions, interfaces, or configuration created "in case we
+  need it later" add complexity now for hypothetical future value. Demand YAGNI — generalize
+  only when the second use case arrives.
+
+## Testable Architecture — Non-Negotiable
+
+Code that cannot be unit-tested in isolation is architecturally broken. This applies to
+every file, not just files in a test suite.
+
+### Dependency Management for Testability
+
+- **Constructor injection**: Dependencies passed at construction time, not created internally.
+  If you can't swap a dependency in a test without monkey-patching, the design is wrong.
+- **Pure core / imperative shell**: Business logic should be pure functions or objects with
+  injected dependencies. I/O, framework calls, and side effects live at the boundary. The
+  core is trivially testable; the shell is thin and tested via integration tests.
+- **Seams**: Every point where behavior might vary (data source, external service, time,
+  randomness) needs a seam — an interface or parameter that tests can control.
+- **No global state**: Singletons, module-level mutable variables, and class variables shared
+  across instances make tests order-dependent and non-parallelizable. Demand explicit passing.
+
+### Test Structure Red Flags
+
+- **Excessive mocking**: If a test requires mocking more than 2-3 collaborators, the code
+  under test has too many dependencies. Fix the production code, not the test.
+- **Test brittleness**: Tests that break when internal implementation changes (not behavior)
+  are testing the wrong thing. Demand tests that assert outcomes, not mechanics.
+- **Setup-heavy tests**: A test that needs 20+ lines of setup to exercise one behavior means
+  the code is doing too much or requiring too much context. The production code is the problem.
+- **Untestable paths**: Error handlers, fallback paths, and edge cases that "never happen"
+  still need to be testable. If they can't be triggered in a test, the design needs a seam.
+
+## General Review Process (applied to all stacks)
+
+1. **Performance Bottlenecks** - Tear apart:
    - Inefficient algorithms or data structures
    - Unnecessary computation in hot paths
    - Memory allocations in tight loops
    - Main thread / event loop blocking operations
    - N+1 queries or redundant I/O
 
-3. **Concurrency Issues** - Ruthlessly expose:
+2. **Concurrency Issues** - Ruthlessly expose:
    - Race conditions in shared state
    - Deadlocks or priority inversions
    - Improper async/await usage
    - Missing synchronization
    - Blocking calls in async contexts
 
-4. **Memory & Resource Management** - Hunt down:
+3. **Memory & Resource Management** - Hunt down:
    - Leaked resources (connections, handles, subscriptions)
    - Unnecessary object retention
    - Unbounded caches or buffers
    - Missing cleanup on error paths
 
-5. **Security** - Expose vulnerabilities:
+4. **Security** - Expose vulnerabilities:
    - Injection risks (SQL, XSS, command injection)
    - Improper authentication or authorization
    - Unvalidated user input at system boundaries
    - Sensitive data exposure in logs or errors
    - Missing CSRF/rate-limiting where needed
 
-6. **Error Handling** - Demand completeness:
+5. **Error Handling** - Demand completeness:
    - Swallowed errors that hide failures
    - Missing error propagation
    - Inconsistent error types or messages
    - Recovery paths that leave state inconsistent
 
-7. **Testability** - Demolish untestable code:
-   - Hard-coded dependencies (demand interfaces/injection)
-   - Side effects that prevent isolation
-   - Missing test coverage for critical paths
-   - Code that violates existing test patterns
-
-8. **Code Quality** - Enforce rigorously:
+6. **Code Quality** - Enforce rigorously:
    - Proper use of language idioms and type system
    - Clear naming and documentation for public API
    - Consistent patterns with existing codebase
@@ -102,10 +250,13 @@ Medium/low issues go after a `--- OPTIONAL IMPROVEMENTS ---` divider.
 
 **Fail the review for:** memory/resource leaks, race conditions, thread safety
 violations, missing error handling on failable paths, security issues, force
-operations without justification, violations of ORCHESTRATOR.md conventions.
+operations without justification, violations of ORCHESTRATOR.md conventions,
+SOLID violations that create concrete maintenance or testability risk (god objects,
+missing dependency injection, untestable architecture, tight coupling between layers).
 
 **Do NOT fail for:** style preferences, missing features outside the task brief,
-suggestions for future improvements, naming bikeshedding.
+suggestions for future improvements, naming bikeshedding, SOLID "purity" concerns
+that don't create concrete risk (e.g., a small script that doesn't need DIP).
 
 ### Standalone Mode (launched directly by user)
 
@@ -114,6 +265,9 @@ Structure your review as:
 ```
 ## CRITICAL ISSUES
 [Issues that will cause crashes, data loss, or severe UX problems]
+
+## SOLID / MAINTAINABILITY VIOLATIONS
+[SRP, OCP, LSP, ISP, DIP violations — state which principle and the concrete risk]
 
 ## PERFORMANCE KILLERS
 [Resource drain, memory issues, inefficient algorithms]

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,0 +1,329 @@
+# Manual Testing & Defect Reporting Guide
+
+This guide covers the end-to-end workflow for manual testing of pipeline PRs: how testers report defects and how developers process them through the automated fix pipeline.
+
+## Overview
+
+The pipeline supports a structured feedback loop between manual testers and the automated fix pipeline:
+
+```
+Tester files defect on PR  ──>  Developer runs /fix-defects  ──>  Pipeline fixes each defect
+        │                              │                                    │
+        │  (structured comment         │  (reads PR comments,              │  (assess → fix →
+        │   on GitHub PR)              │   parses, triages)                │   review → commit)
+        v                              v                                    v
+   PR comment with                Pipeline processes              Reply on PR comment
+   defect report                  defects by severity             with fix commit SHA
+```
+
+Testers don't need Claude Code or any pipeline tooling — they just comment on the PR using a structured template. The developer processes all accumulated defects in a single `/fix-defects` run.
+
+## For Testers: Filing Defect Reports
+
+### Prerequisites
+
+- Access to the GitHub PR you're testing
+- The PR branch checked out locally (or access to a deployed preview)
+
+### Step 1: Test the PR branch
+
+Check out the PR branch and test the changes. When you find a defect, file it as a comment on the PR.
+
+### Step 2: Copy the template
+
+Copy the template below into a **new comment** on the PR. File one defect per comment — this allows the pipeline to track, fix, and reply to each independently.
+
+```markdown
+### DEFECT REPORT
+
+**Severity:** CRITICAL
+**Component:** login flow
+**Found in:** src/auth/login.ts
+
+#### Steps to Reproduce
+
+1. Navigate to the login page
+2. Enter valid credentials and click "Sign In"
+3. Observe the result
+
+#### Expected Behavior
+
+User should be redirected to the dashboard after successful login.
+
+#### Actual Behavior
+
+The app crashes with a white screen. Console shows TypeError at login.ts:42.
+
+#### Screenshots
+
+<!-- Drag and drop images directly into this comment, or: -->
+![description of what the image shows](image-url)
+
+#### Environment
+
+- **Browser/Device:** Chrome 120, macOS Sequoia 15.2
+- **OS:** macOS 15.2
+- **Build:** abc1234
+
+#### Additional Context
+
+This was working before the auth refactor commits.
+```
+
+### Step 3: Fill in the fields
+
+#### Required fields
+
+These four fields must be present and non-empty. If any are missing, the pipeline skips the defect and leaves an error reply on your comment.
+
+| Field | What to write |
+|-------|--------------|
+| **Severity** | One of: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` (see severity guide below) |
+| **Steps to Reproduce** | Numbered list. Be specific — "click the button" is better than "interact with the UI" |
+| **Expected Behavior** | What should happen when following the steps |
+| **Actual Behavior** | What actually happens. Include error messages, visual descriptions, data inconsistencies |
+
+#### Optional fields
+
+| Field | When to include |
+|-------|----------------|
+| **Component** | Always recommended. Helps the pipeline narrow its search (e.g., "login flow", "dashboard chart", "API /users endpoint") |
+| **Found in** | Include if you know the file or screen (e.g., `src/auth/login.ts`, "Settings > Profile page") |
+| **Screenshots** | Highly recommended for visual defects. Drag-and-drop images into the comment — GitHub handles hosting |
+| **Environment** | Include browser, device, and OS when relevant. Always include the commit SHA or branch state |
+| **Additional Context** | Stack traces, console errors, workarounds, links to related issues |
+
+### Choosing a severity level
+
+| Severity | Use when | Examples |
+|----------|----------|---------|
+| **CRITICAL** | App crashes, data loss, security vulnerability, complete feature breakage | White screen of death, data corruption, auth bypass, unrecoverable error |
+| **HIGH** | Feature doesn't work as intended, major UX regression | Button does nothing, chart shows wrong data, form validation broken |
+| **MEDIUM** | Feature works but has noticeable UX issues | Missing toast notification, misaligned layout, slow response with no loading state |
+| **LOW** | Cosmetic issues, minor polish items | Off-by-one pixel alignment, slightly wrong color shade, typo in non-critical text |
+
+When in doubt, go one level higher — the pipeline adjusts its approach based on severity.
+
+### Adding screenshots
+
+Screenshots dramatically improve fix accuracy. Three methods:
+
+1. **Drag and drop** (recommended): Drag an image file directly into the GitHub comment box. GitHub uploads it and inserts the markdown automatically.
+
+2. **Paste from clipboard**: Take a screenshot (Cmd+Shift+4 on Mac, Win+Shift+S on Windows), then paste (Cmd+V / Ctrl+V) into the comment box.
+
+3. **Manual markdown**: If you have an image URL:
+   ```markdown
+   ![description of what the screenshot shows](https://your-image-url.png)
+   ```
+
+Since the fix agent receives image URLs but may not be able to view them directly, always describe what the image shows in the **Actual Behavior** field. For example: "The chart renders as an empty white box (see screenshot)."
+
+### Tips for effective defect reports
+
+- **One defect per comment.** This allows the pipeline to fix, commit, and reply to each independently.
+- **Be specific in Steps to Reproduce.** Include exact input values, click targets, and navigation paths.
+- **Include error messages verbatim.** Copy-paste console errors, stack traces, or error dialogs.
+- **Describe the visual state.** "The button is gray and disabled" is more useful than "the button doesn't work."
+- **Note if it's a regression.** If it was working before, say so — this helps the pipeline assess blast radius.
+- **Include the commit SHA.** This pins the defect to a specific build and prevents confusion if the branch is updated.
+
+### What happens after you file
+
+1. The developer runs `/fix-defects` (you don't need to do anything)
+2. For each valid defect, the pipeline:
+   - Assesses blast radius and correlates to codebase files
+   - Fixes the defect via an implementer agent
+   - Reviews the fix via a code-reviewer agent
+   - Commits and pushes
+3. The pipeline replies to your comment with:
+   - The fix commit SHA
+   - A summary of what was changed
+   - The files that were modified
+4. Re-test the fixed items and file new defects if needed
+
+If your defect report is missing required fields, the pipeline replies with a warning and skips it. Fix the comment and the next `/fix-defects` run will pick it up.
+
+## For Developers: Running the Fix Pipeline
+
+### Prerequisites
+
+- The project must be bootstrapped with the pipeline (`init.sh` has been run)
+- GitHub CLI (`gh`) installed and authenticated
+- You're on the PR branch (or can provide the PR number)
+
+### Step 1: Check the PR for defect reports
+
+You can preview what's been filed before running the pipeline:
+
+```bash
+# List all comments on a PR
+gh pr view 42 --comments
+
+# Or check via the GitHub web UI
+```
+
+### Step 2: Run the fix pipeline
+
+Start Claude Code in your project directory and run:
+
+```
+/fix-defects
+```
+
+Or with a specific PR:
+
+```
+/fix-defects 42
+```
+
+Or with a PR URL:
+
+```
+/fix-defects https://github.com/org/repo/pull/42
+```
+
+The pipeline will:
+
+1. **Identify the PR** — from your current branch, the argument, or by asking you
+2. **Fetch all comments** — reads both PR review comments and conversation comments
+3. **Parse defect reports** — identifies comments with the `### DEFECT REPORT` header
+4. **Skip already-processed defects** — checks for existing "Fixed in commit" replies
+5. **Show you a summary table** — severity, component, and a short description for each
+6. **Process in severity order** — CRITICAL first, then HIGH, MEDIUM, LOW
+
+### Step 3: Monitor progress
+
+For each defect, the pipeline runs:
+
+```
+5.1 ASSESS    →  Correlate to files, check fragile areas, classify simple vs complex
+5.2 FIX       →  Launch implementer agent (Sonnet for CRITICAL/HIGH/MEDIUM, Haiku for simple LOW)
+5.3 REVIEW    →  Launch code-reviewer agent (Sonnet)
+5.4 COMMIT    →  git commit + push
+5.5 REPLY     →  Comment on PR with fix summary + add reaction to original comment
+```
+
+CRITICAL defects always get a blast-radius analysis via the architect agent before fixing. Other severities get blast-radius analysis only if they touch fragile areas or cross multiple components.
+
+If a fix fails code review, the pipeline retries with the reviewer's feedback (up to 2 cycles). After that, it escalates to you and moves on to the next defect.
+
+### Step 4: Review the summary
+
+After processing all defects, the pipeline shows a summary:
+
+```
+Defect Fix Summary for PR #42
+
+| # | Severity | Component    | Status             | Commit  |
+|---|----------|--------------|--------------------|---------|
+| 1 | CRITICAL | login flow   | Fixed              | abc1234 |
+| 2 | HIGH     | dashboard    | Fixed              | def5678 |
+| 3 | MEDIUM   | settings     | Escalated to user  | —       |
+
+2 of 3 defects fixed. Remaining issues require manual intervention.
+```
+
+### Step 5: Ask testers to re-test
+
+The pipeline tells testers to re-test via its PR comment replies. If new defects are found, testers file new comments and you run `/fix-defects` again — it skips already-fixed defects.
+
+### Running within an orchestrate session
+
+The `/fix-defects` skill also works within an active `/orchestrate` session. If you're at the manual test step (Step 3.5) and testers have been filing defects on the PR, you can run `/fix-defects` instead of manually describing each bug.
+
+The TOKEN_LEDGER entries use the `defect:` prefix to distinguish from the orchestrate run's entries.
+
+### Cost expectations
+
+| Defect complexity | Model | Approximate cost |
+|-------------------|-------|-----------------|
+| Simple LOW defect | Haiku fix + Sonnet review | ~$0.01-0.03 |
+| Typical HIGH defect | Sonnet fix + Sonnet review | ~$0.05-0.15 |
+| Complex CRITICAL defect | Sonnet assess + Sonnet fix + Sonnet review | ~$0.10-0.30 |
+
+A batch of 5 defects (1 CRITICAL, 2 HIGH, 2 MEDIUM) typically costs $0.20-0.60.
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "No defect reports found" | Ensure comments use `### DEFECT REPORT` as the header (case-insensitive) |
+| Defect skipped with field error | Check the pipeline's error reply — it says which fields are missing |
+| `gh` not installed | `brew install gh` (macOS) or see https://cli.github.com/ |
+| Not authenticated | Run `gh auth login` |
+| Fix keeps failing review | After 2 cycles the pipeline escalates to you — fix manually or provide more context |
+| Wrong PR detected | Pass the PR number explicitly: `/fix-defects 42` |
+
+## Workflow Example
+
+Here's a complete walkthrough of a typical testing cycle:
+
+**1. Developer creates a PR via the pipeline:**
+```
+> /orchestrate
+> Add user authentication with JWT tokens
+```
+Pipeline runs, opens draft PR #42.
+
+**2. Testers test the PR branch and file defects:**
+
+Tester A comments on PR #42:
+```markdown
+### DEFECT REPORT
+
+**Severity:** CRITICAL
+**Component:** login flow
+**Found in:** src/auth/login.ts
+
+#### Steps to Reproduce
+1. Navigate to /login
+2. Enter valid credentials
+3. Click "Sign In"
+
+#### Expected Behavior
+Redirect to dashboard.
+
+#### Actual Behavior
+White screen crash. Console: TypeError at login.ts:42.
+
+#### Screenshots
+![crash](https://user-images.github.../crash.png)
+
+#### Environment
+- **Browser/Device:** Chrome 120
+- **Build:** abc1234
+```
+
+Tester B files another comment with a MEDIUM severity defect.
+
+**3. Developer processes all defects:**
+```
+> /fix-defects
+```
+
+Pipeline output:
+```
+Found 2 defect report(s) on PR #42:
+
+| # | Severity | Component   | Summary                    |
+|---|----------|-------------|----------------------------|
+| 1 | CRITICAL | login flow  | White screen crash on login |
+| 2 | MEDIUM   | settings    | Missing save confirmation   |
+
+Proceeding to fix in severity order.
+```
+
+**4. Pipeline fixes each defect, replies to PR comments:**
+
+Reply on Tester A's comment:
+> Fixed in commit `def5678`. Please re-test.
+>
+> **Fix summary:** Added null check for auth token response before accessing `.token` property.
+> **Files modified:** src/auth/login.ts
+
+**5. Testers re-test, file new defects or confirm fixes.**
+
+**6. Developer runs `/fix-defects` again if new defects were filed.** Already-fixed defects are skipped.
+
+**7. When all tests pass, developer finalizes the PR** (via `/orchestrate` Step 4 or manually).

--- a/skills/fix-defects/SKILL.md
+++ b/skills/fix-defects/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: fix-defects
+description: >
+  Reads defect reports from GitHub PR comments and runs the pipeline to fix them.
+  Use when the user says "fix defects", "fix PR defects", "fix reported bugs",
+  "/fix-defects", or any request to process manual test feedback from a PR.
+  Requires a PR with comments following the defect report schema
+  (see templates/defect-report.md).
+---
+
+# Fix Defects Skill
+
+You are the orchestrator running in **defect-fix mode**. You read structured defect reports
+from GitHub PR comments, triage them by severity, and run the fix pipeline for each one.
+
+This skill reuses the same agent coordination pattern as Step 3.5 of the orchestrate skill
+but operates standalone — it does not require a prior orchestrate run.
+
+## Prerequisites
+
+Before starting, read these files (skip if already in context):
+1. `.claude/ORCHESTRATOR.md` — architecture, conventions, fragile areas
+2. `.claude/CLAUDE.md` — project rules
+3. `.claude/pipeline.config` — stack and pipeline root
+
+## Step 0: Identify the PR
+
+Determine the target PR:
+
+1. **If the user provides a PR number or URL:** use that directly.
+2. **If on a feature branch with an open PR:** detect it:
+   ```bash
+   gh pr list --head "$(git branch --show-current)" --json number,url --jq '.[0]'
+   ```
+3. **If neither:** ask the user which PR to process.
+
+Store `PR_NUMBER` and `PR_URL` for the session.
+
+## Step 1: Load Adapter
+
+Same as orchestrate Step 0:
+
+1. Read `.claude/pipeline.config` to get `stack` and `pipeline_root`
+2. Read `<pipeline_root>/adapters/<stack>/adapter.md`
+3. Load overlay files for agent composition
+
+## Step 2: Initialize Token Tracking
+
+Initialize `TOKEN_LEDGER` and record `PIPELINE_START` timestamp. Use step prefix `defect:`
+for all ledger entries (e.g., `defect:assess:1`, `defect:fix:1`, `defect:review:1`).
+
+## Step 3: Fetch and Parse Defect Reports
+
+Read all comments on the PR:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments --paginate
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments --paginate
+```
+
+Note: PR "review comments" (on specific lines) and "issue comments" (on the PR conversation)
+are different GitHub API endpoints. Fetch both.
+
+**Parse each comment** that contains `### DEFECT REPORT` (case-insensitive) as the header.
+
+### Parsing Rules
+
+For each defect report comment, extract:
+
+| Field | How to extract | Required |
+|-------|---------------|----------|
+| `id` | Sequential number (1, 2, 3...) in order found | auto |
+| `comment_id` | GitHub comment ID (for later reaction/reply) | auto |
+| `severity` | Value after `**Severity:**` — must be CRITICAL, HIGH, MEDIUM, or LOW | yes |
+| `component` | Value after `**Component:**` | no |
+| `found_in` | Value after `**Found in:**` | no |
+| `steps` | Numbered list items under `#### Steps to Reproduce` | yes |
+| `expected` | Text under `#### Expected Behavior` | yes |
+| `actual` | Text under `#### Actual Behavior` | yes |
+| `screenshots` | All `![...](url)` image references under `#### Screenshots` | no |
+| `environment` | Key-value pairs under `#### Environment` | no |
+| `additional_context` | Text under `#### Additional Context` | no |
+| `author` | GitHub username of the comment author | auto |
+
+**Validation:** If a required field is missing, skip the defect and add a reply to the comment:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments -f body="⚠️ Skipped: missing required field(s). See templates/defect-report.md for the schema."
+```
+
+**Report to user** the parsed defects:
+
+> Found **N** defect report(s) on PR #X:
+>
+> | # | Severity | Component | Summary |
+> |---|----------|-----------|---------|
+> | 1 | CRITICAL | login flow | App crashes on submit |
+> | 2 | HIGH | dashboard | Chart renders empty |
+>
+> Proceeding to fix in severity order (CRITICAL → HIGH → MEDIUM → LOW).
+
+If no defect reports are found, tell the user and stop.
+
+## Step 4: Triage and Order
+
+Sort defects by severity: CRITICAL first, then HIGH, MEDIUM, LOW.
+Within the same severity, preserve the order they appear in comments.
+
+**For CRITICAL defects:** Always run blast-radius analysis (Step 5.1) before fixing.
+**For HIGH defects:** Run blast-radius analysis if the defect crosses multiple components.
+**For MEDIUM/LOW defects:** Skip blast-radius analysis unless the component maps to a
+known fragile area in ORCHESTRATOR.md.
+
+## Step 5: Fix Each Defect
+
+For each defect, run this cycle:
+
+### 5.1: ASSESS
+
+The orchestrator assesses the defect — do NOT delegate to a subagent:
+
+1. **Correlate** the defect to files in the codebase using the component, found_in field,
+   and the steps to reproduce.
+2. **Check fragile areas:** Cross-reference affected files against ORCHESTRATOR.md's
+   "Known Fragile Areas". Note any matches.
+3. **Classify:**
+   - **Simple** (single file, clear cause, no fragile areas): proceed to 5.2.
+   - **Complex** (multi-file, unclear cause, fragile area, or CRITICAL severity):
+     launch blast-radius analysis.
+
+**Blast-radius analysis prompt (complex defects):**
+
+```
+Agent: architect-agent
+Model: sonnet
+Prompt: |
+  You are being launched by the pipeline to assess the blast radius of a defect fix.
+  Do NOT write code. Do NOT enter plan mode — you may need to read code files.
+
+  TECH STACK CONTEXT:
+  <paste contents of adapter's architect-overlay.md>
+
+  A defect was reported during manual testing. Assess the blast radius of fixing it
+  and recommend a fix approach.
+
+  DEFECT REPORT:
+  Severity: <severity>
+  Component: <component>
+  Steps to Reproduce:
+  <steps>
+  Expected: <expected>
+  Actual: <actual>
+  Screenshots: <screenshot URLs and descriptions, or "none">
+  Additional Context: <additional_context or "none">
+
+  FILES IN REPOSITORY (relevant area):
+  <list files in the component's directory>
+
+  CODEBASE CONTEXT (ORCHESTRATOR.md fragile areas extract):
+  <paste Known Fragile Areas section from ORCHESTRATOR.md>
+
+  Respond with:
+  1. ROOT CAUSE: Which file(s) likely caused this
+  2. BLAST RADIUS: What other files/behaviors could be affected by a fix
+  3. FRAGILE AREAS: Any Known Fragile Areas in the blast radius
+  4. FIX APPROACH: Specific fix strategy (1-3 sentences)
+  5. FILES TO MODIFY: Exact list
+  6. REGRESSION RISK: Low/Medium/High with explanation
+```
+
+Record TOKEN_LEDGER entry: step `defect:assess:<id>`, agent `architect-agent`, model `sonnet`.
+
+### 5.2: FIX
+
+Launch an implementer agent to fix the defect:
+
+```
+Agent: implementer-agent
+Model: sonnet (CRITICAL/HIGH/MEDIUM) or haiku (LOW, if single-file and clear cause)
+Prompt: |
+  You are being launched by the orchestration pipeline to fix a defect found
+  during manual testing. Follow all rules from your agent definition.
+
+  IMPORTANT: After fixing, run the FULL test suite (all targets), not just
+  the modified files. Report the total passing test count in your output.
+  If existing tests break, your fix introduced a regression — fix it before
+  returning SUCCESS.
+
+  TECH STACK CONTEXT:
+  <paste adapter overlay — use essential variant for Haiku, full for Sonnet>
+
+  DEFECT REPORT:
+  Severity: <severity>
+  Component: <component>
+  Steps to Reproduce:
+  <steps>
+  Expected: <expected>
+  Actual: <actual>
+  Screenshots: <screenshot URLs — describe what they show if the tester included descriptions>
+  Additional Context: <additional_context or "none">
+
+  FIX APPROACH:
+  <if complex: paste architect's fix approach from 5.1>
+  <if simple: orchestrator's own assessment>
+
+  FILES TO MODIFY:
+  <file list from 5.1 or orchestrator's assessment>
+```
+
+Record TOKEN_LEDGER entry: step `defect:fix:<id>`, agent `implementer-agent`,
+model per above, set `is_retry: false`.
+
+### 5.3: REVIEW
+
+```
+Agent: code-reviewer-agent
+Model: sonnet
+Prompt: |
+  You are being launched by the pipeline to review a defect fix.
+  Follow your agent definition's Pipeline Mode protocol.
+
+  TECH STACK CONTEXT:
+  <paste adapter's reviewer-overlay.md>
+
+  ORIGINAL DEFECT:
+  Severity: <severity>
+  Component: <component>
+  Expected: <expected>
+  Actual: <actual>
+
+  FIX APPROACH:
+  <the approach that was used>
+
+  FILES MODIFIED:
+  <list from implementer's SUCCESS output>
+```
+
+Record TOKEN_LEDGER entry: step `defect:review:<id>`, agent `code-reviewer-agent`, model `sonnet`.
+
+**If FAIL:** Re-run 5.2 with the reviewer's issues as additional context.
+Model escalates to Sonnet if it was Haiku. Max 2 fix-review cycles, then report to user.
+
+### 5.4: COMMIT + PUSH
+
+After a successful review:
+
+```bash
+git add <modified files>
+git commit -m "fix(<component>): <description of fix>
+
+Fixes defect #<id> (<severity>): <short summary of actual behavior>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+git push
+```
+
+### 5.5: REPLY TO COMMENT
+
+After committing the fix, reply to the original defect comment on the PR:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments \
+  -f body="✅ Fixed in commit $(git rev-parse --short HEAD). Please re-test.
+
+**Fix summary:** <1-2 sentence description of what was changed>
+**Files modified:** <comma-separated list>"
+```
+
+Also add a reaction to the original comment:
+
+```bash
+gh api repos/{owner}/{repo}/issues/comments/{comment_id}/reactions -f content="+1"
+```
+
+## Step 6: Summary Report
+
+After processing all defects, report:
+
+> **Defect Fix Summary for PR #X**
+>
+> | # | Severity | Component | Status | Commit |
+> |---|----------|-----------|--------|--------|
+> | 1 | CRITICAL | login flow | Fixed | abc1234 |
+> | 2 | HIGH | dashboard | Fixed | def5678 |
+> | 3 | MEDIUM | settings | Escalated to user | — |
+>
+> **X of Y defects fixed.** Remaining issues require manual intervention.
+
+If all defects are fixed:
+
+> All **N** defect(s) fixed and pushed. Please re-test the PR branch and report
+> any remaining issues, or say **tests pass** to finalize.
+
+## Step 7: Token Analysis
+
+Record `PIPELINE_END` timestamp. Compute and display `TOKEN_SUMMARY`:
+
+- Total tokens (input + output)
+- Per-defect cost breakdown
+- Model distribution
+
+If this skill was invoked standalone (not within an orchestrate run), invoke the
+`token-analysis` skill with the TOKEN_LEDGER data.
+
+## Error Handling
+
+| Condition | Action |
+|-----------|--------|
+| `gh` not installed | Print "Install GitHub CLI: brew install gh" and stop |
+| Not authenticated | Print "Run: gh auth login" and stop |
+| No PR found | Ask user for PR number |
+| No defect reports on PR | Tell user, suggest template location, stop |
+| Defect missing required fields | Skip, reply to comment with error, continue with others |
+| Fix fails review twice | Escalate: report to user, continue with next defect |
+| Fix introduces regression (test count drops) | Reject fix, report regression to user, continue with next defect |
+| All fixes exhausted retries | Stop, report summary with escalated items |
+
+## What This Skill Does NOT Do
+
+- Does NOT run the full orchestrate pipeline (no planning, no architect step 1a/1b)
+- Does NOT create new PRs — it fixes defects on an existing PR
+- Does NOT close the PR or mark it as ready — that's the user's or orchestrate's job
+- Does NOT modify defect comments — it only replies to them
+- Does NOT re-run defects that have already been replied to with a fix commit
+  (checks for existing "Fixed in commit" replies to skip already-processed defects)

--- a/templates/defect-report.md
+++ b/templates/defect-report.md
@@ -1,0 +1,81 @@
+# Defect Report Template
+
+Copy this template into a GitHub PR comment to report a defect found during manual testing.
+The `/fix-defects` command parses these comments and runs the pipeline to fix them.
+
+---
+
+**Copy everything below this line into a PR comment:**
+
+---
+
+```markdown
+### DEFECT REPORT
+
+**Severity:** CRITICAL | HIGH | MEDIUM | LOW
+**Component:** <area of the app affected, e.g., "login flow", "dashboard chart", "API /users endpoint">
+**Found in:** <file or screen where the defect was observed>
+
+#### Steps to Reproduce
+
+1. <first step>
+2. <second step>
+3. <third step>
+
+#### Expected Behavior
+
+<What should happen>
+
+#### Actual Behavior
+
+<What actually happens — be specific about error messages, visual glitches, incorrect data, etc.>
+
+#### Screenshots
+
+<!-- Drag and drop images here, or use GitHub image syntax: -->
+<!-- ![description](image-url) -->
+
+#### Environment
+
+- **Browser/Device:** <e.g., Chrome 120, iPhone 15 Pro, macOS Sequoia>
+- **OS:** <if relevant>
+- **Build:** <commit SHA or branch state when tested>
+
+#### Additional Context
+
+<!-- Optional: stack traces, console errors, related issues, workarounds found -->
+```
+
+---
+
+## Schema Rules
+
+The `/fix-defects` command identifies defect reports by the `### DEFECT REPORT` header.
+Multiple defects can be filed as separate comments on the same PR.
+
+**Required fields** (parsing fails without these):
+- `Severity` — must be one of: CRITICAL, HIGH, MEDIUM, LOW
+- `Steps to Reproduce` — at least one numbered step
+- `Expected Behavior` — non-empty
+- `Actual Behavior` — non-empty
+
+**Optional fields:**
+- `Component` — helps the pipeline correlate to plan tasks/files
+- `Found in` — narrows the search scope for the fix
+- `Screenshots` — GitHub image URLs, passed to the fix agent for visual context
+- `Environment` — included in the fix agent's context
+- `Additional Context` — included verbatim in the fix agent's context
+
+**Severity definitions:**
+| Level | Meaning | Pipeline behavior |
+|-------|---------|-------------------|
+| CRITICAL | App crashes, data loss, security hole | Fixed first, Sonnet model, architect blast-radius analysis |
+| HIGH | Feature broken, major UX regression | Fixed in severity order, Sonnet model |
+| MEDIUM | Minor UX issue, cosmetic but noticeable | Fixed after HIGH, Sonnet model |
+| LOW | Cosmetic, nice-to-have improvement | Fixed last, may use Haiku for simple fixes |
+
+**Image support:**
+- Drag-and-drop images directly into the GitHub comment (recommended)
+- Use `![description](url)` markdown syntax
+- Multiple images supported — each is passed to the fix agent
+- The fix agent receives image URLs as context but cannot view images directly; include a text description of what the image shows in the Actual Behavior field

--- a/tests/fixtures/defect-report-critical.txt
+++ b/tests/fixtures/defect-report-critical.txt
@@ -1,0 +1,36 @@
+### DEFECT REPORT
+
+**Severity:** CRITICAL
+**Component:** authentication flow
+**Found in:** src/auth/login.ts
+
+#### Steps to Reproduce
+
+1. Navigate to the login page
+2. Enter valid credentials and click "Sign In"
+3. App crashes with a white screen
+
+#### Expected Behavior
+
+User should be redirected to the dashboard after successful login.
+
+#### Actual Behavior
+
+The app crashes immediately after clicking "Sign In". The browser console shows:
+`TypeError: Cannot read properties of undefined (reading 'token')` in auth/login.ts:42.
+The crash happens 100% of the time.
+
+#### Screenshots
+
+![crash-screenshot](https://user-images.githubusercontent.com/12345/crash-white-screen.png)
+![console-error](https://user-images.githubusercontent.com/12345/console-error.png)
+
+#### Environment
+
+- **Browser/Device:** Chrome 120.0.6099.109, macOS Sequoia 15.2
+- **OS:** macOS 15.2
+- **Build:** abc1234 (feat/add-auth branch)
+
+#### Additional Context
+
+This was working before the latest batch of commits. Likely a regression from the token handling refactor.

--- a/tests/fixtures/defect-report-high.txt
+++ b/tests/fixtures/defect-report-high.txt
@@ -1,0 +1,30 @@
+### DEFECT REPORT
+
+**Severity:** HIGH
+**Component:** dashboard charts
+
+#### Steps to Reproduce
+
+1. Log in to the application
+2. Navigate to the dashboard
+3. Observe the revenue chart in the top-right section
+
+#### Expected Behavior
+
+The revenue chart should display the last 30 days of revenue data with proper axis labels.
+
+#### Actual Behavior
+
+The chart renders as an empty white box with no data points, axes, or labels. No errors in the console.
+
+#### Screenshots
+
+![empty-chart](https://user-images.githubusercontent.com/12345/empty-chart.png)
+
+#### Environment
+
+- **Browser/Device:** Safari 17.2, iPhone 15 Pro
+
+#### Additional Context
+
+The API endpoint returns valid data (verified in Network tab). The issue appears to be in the chart rendering component.

--- a/tests/fixtures/defect-report-invalid.txt
+++ b/tests/fixtures/defect-report-invalid.txt
@@ -1,0 +1,11 @@
+### DEFECT REPORT
+
+**Severity:** HIGH
+
+#### Steps to Reproduce
+
+1. Do the thing
+
+#### Expected Behavior
+
+#### Actual Behavior

--- a/tests/fixtures/defect-report-medium.txt
+++ b/tests/fixtures/defect-report-medium.txt
@@ -1,0 +1,24 @@
+### DEFECT REPORT
+
+**Severity:** MEDIUM
+**Component:** settings page
+
+#### Steps to Reproduce
+
+1. Open Settings > Profile
+2. Change display name
+3. Click Save
+
+#### Expected Behavior
+
+A success toast notification should appear confirming the change was saved.
+
+#### Actual Behavior
+
+The change saves correctly but no toast notification appears. The user has no visual confirmation that the save succeeded.
+
+#### Screenshots
+
+#### Environment
+
+- **Browser/Device:** Firefox 121

--- a/tests/fixtures/defect-report-not-a-report.txt
+++ b/tests/fixtures/defect-report-not-a-report.txt
@@ -1,0 +1,5 @@
+Hey team, I noticed some issues with the login flow but I'll file them separately.
+
+Also, can we update the README to mention the new authentication method?
+
+Thanks!

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -220,3 +220,185 @@ def parse_open_pr_result(output: str) -> dict:
         elif line.startswith("PR_URL:"):
             result["url"] = line.split(":", 1)[1].strip()
     return result
+
+
+# --- Defect Report Parsing ---
+
+_SEVERITY_VALUES = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+_SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+
+
+def parse_defect_report(comment_body: str) -> dict | None:
+    """Parse a single GitHub PR comment as a defect report.
+
+    Returns a dict with the parsed fields, or None if the comment does not
+    contain a valid defect report header.
+    """
+    # Must contain the defect report header
+    if "### DEFECT REPORT" not in comment_body.upper():
+        return None
+
+    lines = comment_body.split("\n")
+    report: dict = {
+        "severity": "",
+        "component": "",
+        "found_in": "",
+        "steps": [],
+        "expected": "",
+        "actual": "",
+        "screenshots": [],
+        "environment": {},
+        "additional_context": "",
+    }
+
+    section: str | None = None
+    section_lines: list[str] = []
+
+    def _flush_section() -> None:
+        """Flush accumulated section lines into the report."""
+        if not section:
+            return
+        text = "\n".join(section_lines).strip()
+        if section == "steps":
+            # Extract numbered list items
+            report["steps"] = [
+                m.group(1).strip()
+                for m in re.finditer(r"^\d+\.\s+(.+)$", text, re.MULTILINE)
+            ]
+        elif section == "expected":
+            report["expected"] = text
+        elif section == "actual":
+            report["actual"] = text
+        elif section == "screenshots":
+            report["screenshots"] = re.findall(
+                r"!\[([^\]]*)\]\(([^)]+)\)", text
+            )
+        elif section == "environment":
+            for m in re.finditer(
+                r"\*\*([^*]+?)(?::\s*)?\*\*(?::)?\s*(.+)", text
+            ):
+                report["environment"][m.group(1).strip()] = m.group(2).strip()
+        elif section == "additional_context":
+            report["additional_context"] = text
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Inline fields (before sections)
+        if stripped.startswith("**Severity:**"):
+            val = stripped.split("**Severity:**", 1)[1].strip()
+            # Handle "CRITICAL | HIGH | MEDIUM | LOW" template vs actual value
+            if val in _SEVERITY_VALUES:
+                report["severity"] = val
+            elif "|" not in val:
+                # Might be a severity with extra text
+                for s in _SEVERITY_VALUES:
+                    if s in val.upper():
+                        report["severity"] = s
+                        break
+            continue
+        if stripped.startswith("**Component:**"):
+            report["component"] = stripped.split("**Component:**", 1)[1].strip()
+            continue
+        if stripped.startswith("**Found in:**"):
+            report["found_in"] = stripped.split("**Found in:**", 1)[1].strip()
+            continue
+
+        # Section headers
+        if stripped.lower().startswith("#### steps to reproduce"):
+            _flush_section()
+            section = "steps"
+            section_lines = []
+            continue
+        if stripped.lower().startswith("#### expected behavior"):
+            _flush_section()
+            section = "expected"
+            section_lines = []
+            continue
+        if stripped.lower().startswith("#### actual behavior"):
+            _flush_section()
+            section = "actual"
+            section_lines = []
+            continue
+        if stripped.lower().startswith("#### screenshots"):
+            _flush_section()
+            section = "screenshots"
+            section_lines = []
+            continue
+        if stripped.lower().startswith("#### environment"):
+            _flush_section()
+            section = "environment"
+            section_lines = []
+            continue
+        if stripped.lower().startswith("#### additional context"):
+            _flush_section()
+            section = "additional_context"
+            section_lines = []
+            continue
+        # New h4 section we don't recognize — stop current section
+        if stripped.startswith("#### "):
+            _flush_section()
+            section = None
+            section_lines = []
+            continue
+
+        if section is not None:
+            section_lines.append(line)
+
+    _flush_section()
+
+    # Validation: required fields
+    missing = []
+    if not report["severity"]:
+        missing.append("severity")
+    if not report["steps"]:
+        missing.append("steps")
+    if not report["expected"]:
+        missing.append("expected")
+    if not report["actual"]:
+        missing.append("actual")
+
+    if missing:
+        return {"error": f"missing required fields: {', '.join(missing)}", "partial": report}
+
+    return report
+
+
+def parse_defect_reports(comments: list[dict]) -> list[dict]:
+    """Parse multiple GitHub API comment objects into defect reports.
+
+    Each comment dict should have at least 'id' and 'body' keys
+    (matching the GitHub API response shape).
+
+    Returns a list of parsed defect reports sorted by severity
+    (CRITICAL first), each augmented with 'comment_id' and 'author' fields.
+    """
+    defects: list[dict] = []
+    for comment in comments:
+        body = comment.get("body", "")
+        parsed = parse_defect_report(body)
+        if parsed is None:
+            continue
+        if "error" in parsed:
+            # Include invalid reports so callers can reply with errors
+            parsed["comment_id"] = comment.get("id", "")
+            parsed["author"] = comment.get("user", {}).get("login", "")
+            defects.append(parsed)
+            continue
+        parsed["comment_id"] = comment.get("id", "")
+        parsed["author"] = comment.get("user", {}).get("login", "")
+        defects.append(parsed)
+
+    # Sort valid reports by severity (errors go to the end)
+    def _sort_key(d: dict) -> tuple:
+        if "error" in d:
+            return (99, 0)
+        return (_SEVERITY_ORDER.get(d["severity"], 99), 0)
+
+    defects.sort(key=_sort_key)
+
+    # Assign sequential IDs
+    for i, d in enumerate(defects, 1):
+        d["id"] = i
+
+    return defects

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -22,6 +22,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from parsers import (
     parse_build_output,
+    parse_defect_report,
+    parse_defect_reports,
     parse_implementer_result,
     parse_open_pr_result,
     parse_reviewer_result,
@@ -195,6 +197,115 @@ class TestEdgeCases(unittest.TestCase):
         output = "  SUCCESS  \n\nfeat(core): add feature\n\n---TOKEN_REPORT---\nFILES_READ:\n---END_TOKEN_REPORT---"
         result = parse_implementer_result(output)
         self.assertEqual(result["status"], "SUCCESS")
+
+
+class TestDefectReportParsing(unittest.TestCase):
+    def test_critical_report(self) -> None:
+        fixture = (FIXTURES_DIR / "defect-report-critical.txt").read_text()
+        result = parse_defect_report(fixture)
+        self.assertIsNotNone(result)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["severity"], "CRITICAL")
+        self.assertEqual(result["component"], "authentication flow")
+        self.assertEqual(result["found_in"], "src/auth/login.ts")
+        self.assertTrue(len(result["steps"]) >= 3)
+        self.assertIn("login", result["steps"][0].lower())
+        self.assertTrue(len(result["expected"]) > 0)
+        self.assertIn("TypeError", result["actual"])
+        self.assertEqual(len(result["screenshots"]), 2)
+        self.assertIn("Browser/Device", result["environment"])
+        self.assertTrue(len(result["additional_context"]) > 0)
+
+    def test_high_report(self) -> None:
+        fixture = (FIXTURES_DIR / "defect-report-high.txt").read_text()
+        result = parse_defect_report(fixture)
+        self.assertIsNotNone(result)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["severity"], "HIGH")
+        self.assertEqual(result["component"], "dashboard charts")
+        self.assertTrue(len(result["steps"]) >= 3)
+        self.assertEqual(len(result["screenshots"]), 1)
+
+    def test_medium_report_minimal(self) -> None:
+        fixture = (FIXTURES_DIR / "defect-report-medium.txt").read_text()
+        result = parse_defect_report(fixture)
+        self.assertIsNotNone(result)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["severity"], "MEDIUM")
+        self.assertTrue(len(result["steps"]) >= 3)
+        # No screenshots in this report
+        self.assertEqual(len(result["screenshots"]), 0)
+
+    def test_invalid_report_missing_fields(self) -> None:
+        fixture = (FIXTURES_DIR / "defect-report-invalid.txt").read_text()
+        result = parse_defect_report(fixture)
+        self.assertIsNotNone(result)
+        self.assertIn("error", result)
+        self.assertIn("expected", result["error"])
+        self.assertIn("actual", result["error"])
+
+    def test_not_a_report_returns_none(self) -> None:
+        fixture = (FIXTURES_DIR / "defect-report-not-a-report.txt").read_text()
+        result = parse_defect_report(fixture)
+        self.assertIsNone(result)
+
+    def test_empty_string_returns_none(self) -> None:
+        result = parse_defect_report("")
+        self.assertIsNone(result)
+
+
+class TestDefectReportsBatch(unittest.TestCase):
+    def test_multiple_reports_sorted_by_severity(self) -> None:
+        comments = [
+            {"id": 100, "body": (FIXTURES_DIR / "defect-report-high.txt").read_text(),
+             "user": {"login": "tester1"}},
+            {"id": 101, "body": (FIXTURES_DIR / "defect-report-critical.txt").read_text(),
+             "user": {"login": "tester2"}},
+            {"id": 102, "body": (FIXTURES_DIR / "defect-report-medium.txt").read_text(),
+             "user": {"login": "tester1"}},
+        ]
+        defects = parse_defect_reports(comments)
+        self.assertEqual(len(defects), 3)
+        # CRITICAL should be first
+        self.assertEqual(defects[0]["severity"], "CRITICAL")
+        self.assertEqual(defects[0]["author"], "tester2")
+        self.assertEqual(defects[0]["comment_id"], 101)
+        # HIGH second
+        self.assertEqual(defects[1]["severity"], "HIGH")
+        # MEDIUM third
+        self.assertEqual(defects[2]["severity"], "MEDIUM")
+        # Sequential IDs
+        self.assertEqual(defects[0]["id"], 1)
+        self.assertEqual(defects[1]["id"], 2)
+        self.assertEqual(defects[2]["id"], 3)
+
+    def test_non_report_comments_filtered(self) -> None:
+        comments = [
+            {"id": 200, "body": "LGTM! Looks good to me.", "user": {"login": "reviewer"}},
+            {"id": 201, "body": (FIXTURES_DIR / "defect-report-high.txt").read_text(),
+             "user": {"login": "tester"}},
+            {"id": 202, "body": "Can we also add dark mode?", "user": {"login": "pm"}},
+        ]
+        defects = parse_defect_reports(comments)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["severity"], "HIGH")
+
+    def test_invalid_reports_sorted_to_end(self) -> None:
+        comments = [
+            {"id": 300, "body": (FIXTURES_DIR / "defect-report-invalid.txt").read_text(),
+             "user": {"login": "tester1"}},
+            {"id": 301, "body": (FIXTURES_DIR / "defect-report-high.txt").read_text(),
+             "user": {"login": "tester2"}},
+        ]
+        defects = parse_defect_reports(comments)
+        self.assertEqual(len(defects), 2)
+        # Valid HIGH report first, invalid report last
+        self.assertEqual(defects[0]["severity"], "HIGH")
+        self.assertIn("error", defects[1])
+
+    def test_empty_comments_list(self) -> None:
+        defects = parse_defect_reports([])
+        self.assertEqual(len(defects), 0)
 
 
 if __name__ == "__main__":

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -53,6 +53,7 @@ REQUIRED_SKILLS = [
     "open-pr/SKILL.md",
     "summarize-implementation/SKILL.md",
     "token-analysis/SKILL.md",
+    "fix-defects/SKILL.md",
 ]
 
 ESSENTIAL_OVERLAY_MAX_CHARS = 1000
@@ -146,7 +147,8 @@ def check_required_files(result: ValidationResult) -> None:
         else:
             result.fail(f"Missing skill: {skill}")
 
-    for template in ["CLAUDE.md.template", "ORCHESTRATOR.md.template", "pipeline.config.template"]:
+    for template in ["CLAUDE.md.template", "ORCHESTRATOR.md.template",
+                      "pipeline.config.template", "defect-report.md"]:
         path = PIPELINE_ROOT / "templates" / template
         if path.exists():
             result.ok(f"Template exists: {template}")
@@ -485,6 +487,60 @@ def check_cross_references(result: ValidationResult) -> None:
             result.fail(f"Orchestrate missing reference to {cmd}")
 
 
+def check_fix_defects_skill(result: ValidationResult) -> None:
+    """Validate the fix-defects skill references required patterns."""
+    path = PIPELINE_ROOT / "skills" / "fix-defects" / "SKILL.md"
+    if not path.exists():
+        result.fail("fix-defects SKILL.md exists")
+        return
+
+    content = path.read_text()
+
+    # Must reference the defect report template
+    if "defect-report.md" in content:
+        result.ok("fix-defects references defect-report.md template")
+    else:
+        result.fail("fix-defects missing reference to defect-report.md template")
+
+    # Must reference PR comment reading via gh api
+    if "gh api" in content:
+        result.ok("fix-defects uses gh api for PR comment reading")
+    else:
+        result.fail("fix-defects missing gh api for PR comment reading")
+
+    # Must reference the defect report header marker
+    if "DEFECT REPORT" in content:
+        result.ok("fix-defects references DEFECT REPORT header marker")
+    else:
+        result.fail("fix-defects missing DEFECT REPORT header marker")
+
+    # Must define severity levels matching the template
+    for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
+        if severity in content:
+            result.ok(f"fix-defects defines severity: {severity}")
+        else:
+            result.fail(f"fix-defects missing severity: {severity}")
+
+    # Must reference agent types it launches
+    for agent in ["architect-agent", "implementer-agent", "code-reviewer-agent"]:
+        if agent in content:
+            result.ok(f"fix-defects references {agent}")
+        else:
+            result.fail(f"fix-defects missing reference to {agent}")
+
+    # Must reference token tracking
+    if "TOKEN_LEDGER" in content:
+        result.ok("fix-defects tracks TOKEN_LEDGER")
+    else:
+        result.fail("fix-defects missing TOKEN_LEDGER tracking")
+
+    # Must handle replying to PR comments
+    if "comment_id" in content.lower() or "reply" in content.lower():
+        result.ok("fix-defects replies to PR comments after fix")
+    else:
+        result.fail("fix-defects missing PR comment reply mechanism")
+
+
 def run_all_checks(verbose: bool = False) -> ValidationResult:
     result = ValidationResult()
 
@@ -505,6 +561,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Agent frontmatter", check_agent_frontmatter),
         ("Skill frontmatter", check_skill_frontmatter),
         ("Cross-references", check_cross_references),
+        ("Fix-defects skill", check_fix_defects_skill),
     ]
 
     for name, check_fn in checks:


### PR DESCRIPTION
## Summary

- Adds a structured defect reporting workflow for PR-based manual testing
- Testers file defects as structured GitHub PR comments using `templates/defect-report.md`
- Developers run `/fix-defects` in Claude Code to parse, triage by severity, and fix all reported defects through the pipeline
- Includes defect report parser, 10 contract tests, 12 structural validation checks, and 5 golden fixtures

## What's New

### `/fix-defects` skill (`skills/fix-defects/SKILL.md`)
Standalone skill that reads PR comments via GitHub API, parses structured defect reports, and runs the fix pipeline for each defect:
- Fetches both PR review comments and issue comments
- Parses defect reports by `### DEFECT REPORT` header with required/optional fields
- Triages by severity (CRITICAL → HIGH → MEDIUM → LOW)
- Runs blast-radius analysis for complex/critical defects
- Fix → Review → Commit cycle per defect (reuses orchestrate Step 3.5 pattern)
- Replies to original PR comment with fix commit and summary
- Tracks TOKEN_LEDGER for cost analysis

### Defect report template (`templates/defect-report.md`)
Structured PR comment template with:
- Severity levels (CRITICAL/HIGH/MEDIUM/LOW) with defined pipeline behavior per level
- Steps to reproduce, expected/actual behavior (required)
- Screenshot support (drag-and-drop GitHub images)
- Environment info, component, additional context (optional)
- Schema rules documentation for testers

### Parser and tests
- `parse_defect_report()` and `parse_defect_reports()` added to `tests/parsers.py`
- 10 new contract tests: CRITICAL/HIGH/MEDIUM parsing, invalid reports, batch sorting, filtering, edge cases
- 12 new structural checks for fix-defects skill content
- 5 golden fixture files for defect report formats
- Total test suite: 163 (L1) + 34 (L3) + 23 (L4) = **220 checks, 0 failures**

## Test plan

- [x] L1 structural validation passes (163 checks)
- [x] L3 contract tests pass (34 tests including 10 new defect tests)
- [x] L4 smoke test passes (23 checks)
- [ ] Manual: copy defect template into a PR comment, verify formatting renders correctly
- [ ] Manual: run `/fix-defects` on a PR with defect comments (requires bootstrapped project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)