### PR TITLE
feat: Azure Bicep adapter, SDK overlay system, and 7 Azure skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ A tech-stack-agnostic orchestration system for Claude Code that coordinates plan
 
 **Bootstrap into a project:**
 ```bash
-bash init.sh /path/to/project [--stack=swift-ios|react|python] [--force]
+bash init.sh /path/to/project [--stack=swift-ios|react|python|bicep] [--force]
 ```
-Auto-detects stack from project files. Creates symlinks and config in the target project's `.claude/` directory.
+Auto-detects stack from project files (including `.bicep` files for Bicep). Also auto-detects Azure SDK usage and activates the `azure-sdk` overlay when Azure packages are found in dependencies. Creates symlinks and config in the target project's `.claude/` directory.
 
 **Run the pipeline** (from within a bootstrapped project):
 ```
@@ -25,6 +25,17 @@ Auto-detects stack from project files. Creates symlinks and config in the target
 ```
 Reads structured defect reports from GitHub PR comments (see `templates/defect-report.md` for the schema) and runs the fix pipeline for each one.
 
+**Azure/Bicep skills** (from within a bootstrapped project):
+```
+/azure-login            # Verify Azure auth, subscription context, permissions
+/validate-bicep        # Lint + build + optional what-if dry run
+/deploy-bicep          # Deploy with mandatory confirmation gate
+/azure-cost-estimate   # Estimate monthly Azure costs from Bicep
+/security-scan         # PSRule/Checkov security scan
+/infra-test-runner     # ARM-TTK/Pester infrastructure tests
+/azure-drift-check     # Compare deployed state vs templates
+```
+
 **Build/test** (from within a bootstrapped project):
 ```bash
 python3 .claude/scripts/build.py [OPTIONS]
@@ -33,8 +44,8 @@ python3 .claude/scripts/test.py [OPTIONS]
 
 **Pipeline self-tests** (from the pipeline repo root):
 ```bash
-python3 tests/validate_structure.py          # Layer 1: structural integrity (163 checks)
-python3 tests/test_contracts.py              # Layer 3: output protocol contract tests (34 tests)
+python3 tests/validate_structure.py          # Layer 1: structural integrity (200 checks)
+python3 tests/test_contracts.py              # Layer 3: output protocol contract tests (43 tests)
 python3 tests/smoke/run_smoke.py             # Layer 4: bootstrap smoke test (init.sh + scripts)
 python3 tests/smoke/run_smoke.py --full      # Layer 4: full pipeline smoke test (costs ~$0.50-1.00)
 ```
@@ -50,13 +61,17 @@ User request → **1a: Analyze & Clarify** (Sonnet) → **1b: Plan** (Opus) → 
 
 1. **Agents** (`agents/`) — Four generic, stack-agnostic agent definitions: `architect-agent`, `implementer-agent`, `code-reviewer-agent`, `test-architect-agent`. Each contains an `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker where adapter overlays get injected at launch. `implementer-contract.md` is the canonical Haiku readiness checklist referenced by both the planner and implementer.
 
-2. **Skills** (`skills/`) — Nine pipeline steps. `orchestrate` is the master coordinator that invokes all others: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`. The standalone `fix-defects` skill reads structured defect reports from PR comments and runs the fix pipeline independently.
+2. **Skills** (`skills/`) — Sixteen pipeline steps. `orchestrate` is the master coordinator that invokes the core nine: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`. The standalone `fix-defects` skill reads structured defect reports from PR comments and runs the fix pipeline independently. Seven Azure/Bicep skills provide IaC-specific capabilities: `azure-login` (auth pre-flight), `validate-bicep`, `deploy-bicep`, `azure-cost-estimate`, `security-scan`, `infra-test-runner`, `azure-drift-check`.
 
-3. **Adapters** (`adapters/`) — Pluggable tech-stack modules (swift-ios, react, python). Each provides: `adapter.md` (metadata), four `*-overlay.md` files (injected into agents), `hooks.json` (blocks raw build/test commands), and `scripts/build.py` + `scripts/test.py` (runner scripts with strict output contracts). Each adapter also provides `implementer-overlay-essential.md` — a compact (~500-800 chars) rules-only variant used for Haiku tasks to improve signal-to-noise ratio.
+3. **Adapters** (`adapters/`) — Pluggable tech-stack modules (swift-ios, react, python, bicep). Each provides: `adapter.md` (metadata), four `*-overlay.md` files (injected into agents), `hooks.json` (blocks raw build/test commands), and `scripts/build.py` + `scripts/test.py` (runner scripts with strict output contracts). Each adapter also provides `implementer-overlay-essential.md` — a compact (~500-800 chars) rules-only variant used for Haiku tasks to improve signal-to-noise ratio.
+
+### Cross-Cutting Overlays
+
+In addition to adapters, the pipeline supports **cross-cutting overlays** (`overlays/`) that layer on top of any adapter. The `azure-sdk` overlay adds Azure SDK best practices (authentication, retry, Key Vault, managed identity) to any language adapter when the project uses Azure services. Overlays are auto-detected by `init.sh` (Azure packages in deps) and stored in `pipeline.config` as `overlays=azure-sdk`.
 
 ### How Adapter Injection Works
 
-The orchestrator reads `.claude/pipeline.config` → loads `adapters/<stack>/adapter.md` → for each agent launch, reads the generic agent + the relevant overlay → inserts overlay at the `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker → passes composed prompt to the Agent tool. For Haiku implementer tasks, the essential overlay variant is used instead of the full overlay.
+The orchestrator reads `.claude/pipeline.config` → loads `adapters/<stack>/adapter.md` → for each agent launch, reads the generic agent + the relevant overlay → inserts overlay at the `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker → passes composed prompt to the Agent tool. If cross-cutting overlays are configured, their content is appended after the adapter overlay at the same marker. For Haiku implementer tasks, the essential overlay variant is used instead of the full overlay.
 
 ### Model Assignment Strategy
 
@@ -88,4 +103,4 @@ Create `adapters/<stack-name>/` with these 9 files: `adapter.md`, `architect-ove
 
 ## Project Files Generated by init.sh
 
-In the target project's `.claude/`: symlinks to `agents/`, `skills/`, `scripts/`; `pipeline.config` (stack + pipeline path); merged `settings.json` (PreToolUse hooks from adapter); `CLAUDE.md` and `ORCHESTRATOR.md` from templates; `tmp/` for recovery artifacts.
+In the target project's `.claude/`: symlinks to `agents/`, `skills/`, `scripts/`; optionally `overlays/` (when Azure SDK detected); `pipeline.config` (stack + pipeline path + overlays); merged `settings.json` (PreToolUse hooks from adapter); `CLAUDE.md` and `ORCHESTRATOR.md` from templates; `tmp/` for recovery artifacts.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ bash .claude/pipeline/init.sh .
 bash .claude/pipeline/init.sh . --stack=swift-ios
 bash .claude/pipeline/init.sh . --stack=react
 bash .claude/pipeline/init.sh . --stack=python
+bash .claude/pipeline/init.sh . --stack=bicep
 ```
 
 The init script:
-1. Detects your tech stack from project files (Package.swift, package.json, pyproject.toml, etc.)
+1. Detects your tech stack from project files (Package.swift, package.json, pyproject.toml, *.bicep, etc.)
+   - Also detects Azure SDK usage in dependencies and activates the `azure-sdk` overlay automatically
 2. Creates symlinks: `.claude/agents/` -> pipeline agents, `.claude/skills/` -> pipeline skills, `.claude/scripts/` -> adapter scripts
 3. Writes `.claude/pipeline.config` with your stack and pipeline path
 4. Merges adapter hooks into `.claude/settings.json`
@@ -139,6 +141,9 @@ Then use any of these to trigger the pipeline:
 | `swift-ios` | `*.xcodeproj`, `*.xcworkspace`, `Package.swift` | Xcode / Swift PM | XCTest | xccov |
 | `react` | `package.json` with `react` dependency | npm/yarn/pnpm/bun + tsc | Jest / Vitest | istanbul / v8 |
 | `python` | `pyproject.toml`, `setup.py`, `requirements.txt` | mypy + ruff | pytest | pytest-cov |
+| `bicep` | `*.bicep`, `bicepconfig.json` | bicep build + az bicep lint | ARM-TTK / PSRule / what-if | Resource validation coverage |
+
+**Deploying to Azure?** See the **[Azure Deployment Guide](docs/azure-guide.md)** for Bicep adapter setup, Azure SDK overlay, authentication, and the 7 Azure-specific skills.
 
 ### What Each Adapter Provides
 
@@ -184,6 +189,13 @@ Agents are **generic** — they contain no tech-stack-specific knowledge. Stack 
 | `summarize-implementation` | After implementation tasks | Generates conventional-commit messages |
 | `token-analysis` | Step 5 (via orchestrator, mandatory) | Analyzes pipeline token usage, files GitHub issues for optimization findings |
 | `fix-defects` | `/fix-defects`, "fix defects", "fix PR defects" | Reads defect reports from PR comments, triages by severity, runs fix pipeline |
+| `azure-login` | `/azure-login`, auto before Azure-dependent steps | Validates Azure auth, subscription context, RBAC permissions |
+| `validate-bicep` | `/validate-bicep` | Bicep lint + build + optional what-if dry run |
+| `deploy-bicep` | `/deploy-bicep` | Deploy Bicep to Azure with mandatory confirmation gate |
+| `azure-cost-estimate` | `/azure-cost-estimate` | Estimate monthly Azure costs from Bicep templates |
+| `security-scan` | `/security-scan` | PSRule/Checkov security and compliance scanning |
+| `infra-test-runner` | `/infra-test-runner` | ARM-TTK/Pester infrastructure validation tests |
+| `azure-drift-check` | `/azure-drift-check` | Detect config drift between templates and deployed state |
 
 ### Adapter Injection Flow
 
@@ -253,7 +265,14 @@ claude-code-pipeline/
 |   |-- open-pr/SKILL.md                 # Branch + draft PR creation
 |   |-- summarize-implementation/SKILL.md # Conventional commit messages
 |   |-- token-analysis/SKILL.md          # Step 5: token usage analysis + issue filing
-|   +-- fix-defects/SKILL.md             # Standalone: fix defects from PR comments
+|   |-- fix-defects/SKILL.md             # Standalone: fix defects from PR comments
+|   |-- azure-login/SKILL.md             # Azure auth pre-flight validation
+|   |-- validate-bicep/SKILL.md          # Bicep lint + build + what-if
+|   |-- deploy-bicep/SKILL.md            # Deploy with confirmation gate
+|   |-- azure-cost-estimate/SKILL.md     # Monthly cost estimation
+|   |-- security-scan/SKILL.md           # PSRule/Checkov security scanning
+|   |-- infra-test-runner/SKILL.md       # ARM-TTK/Pester infrastructure tests
+|   +-- azure-drift-check/SKILL.md       # Configuration drift detection
 |
 |-- adapters/
 |   |-- swift-ios/                       # Apple ecosystem adapter
@@ -280,17 +299,36 @@ claude-code-pipeline/
 |   |       |-- build.py                 # tsc + build script runner
 |   |       +-- test.py                  # Jest/Vitest runner with coverage
 |   |
-|   +-- python/                          # Python adapter
-|       |-- adapter.md                   # pip/poetry/uv, pytest, mypy/ruff
-|       |-- architect-overlay.md         # Module decomposition, async, Django/FastAPI
-|       |-- implementer-overlay.md       # Type hints, dataclasses, PEP conventions
+|   |-- python/                          # Python adapter
+|   |   |-- adapter.md                   # pip/poetry/uv, pytest, mypy/ruff
+|   |   |-- architect-overlay.md         # Module decomposition, async, Django/FastAPI
+|   |   |-- implementer-overlay.md       # Type hints, dataclasses, PEP conventions
+|   |   |-- implementer-overlay-essential.md  # Compact rules-only variant for Haiku
+|   |   |-- reviewer-overlay.md          # GIL, security, resource management
+|   |   |-- test-overlay.md              # pytest fixtures, parametrize, async
+|   |   |-- hooks.json                   # Block pytest, mypy directly
+|   |   +-- scripts/
+|   |       |-- build.py                 # mypy + ruff runner
+|   |       +-- test.py                  # pytest runner with coverage
+|   |
+|   +-- bicep/                           # Azure Bicep (IaC) adapter
+|       |-- adapter.md                   # bicep CLI, ARM-TTK, PSRule, auth docs
+|       |-- architect-overlay.md         # Module decomposition, scope hierarchy
+|       |-- implementer-overlay.md       # Naming, decorators, security, modules
 |       |-- implementer-overlay-essential.md  # Compact rules-only variant for Haiku
-|       |-- reviewer-overlay.md          # GIL, security, resource management
-|       |-- test-overlay.md              # pytest fixtures, parametrize, async
-|       |-- hooks.json                   # Block pytest, mypy directly
+|       |-- reviewer-overlay.md          # Security, cost, reliability (8 categories)
+|       |-- test-overlay.md              # ARM-TTK, PSRule, what-if, Pester patterns
+|       |-- hooks.json                   # Block bicep/az deployment/PSRule
 |       +-- scripts/
-|           |-- build.py                 # mypy + ruff runner
-|           +-- test.py                  # pytest runner with coverage
+|           |-- build.py                 # bicep build + lint runner
+|           +-- test.py                  # ARM-TTK/PSRule/what-if runner
+|
+|-- overlays/                            # Cross-cutting overlays (stack-agnostic)
+|   +-- azure-sdk/                       # Azure SDK best practices overlay
+|       |-- architect-overlay.md         # Service patterns, managed identity, multi-region
+|       |-- implementer-overlay.md       # DefaultAzureCredential, retry, Key Vault
+|       |-- implementer-overlay-essential.md  # Compact rules-only variant for Haiku
+|       +-- reviewer-overlay.md          # Auth, resilience, lifecycle, security, cost
 |
 |-- tests/                               # Pipeline self-tests (4 layers)
 |   |-- validate_structure.py            # Layer 1: structural integrity (147 checks)
@@ -310,12 +348,23 @@ claude-code-pipeline/
 |   |   |-- defect-report-high.txt       # HIGH severity defect report
 |   |   |-- defect-report-medium.txt     # MEDIUM severity defect report
 |   |   |-- defect-report-invalid.txt    # Invalid defect report (missing fields)
-|   |   +-- defect-report-not-a-report.txt # Non-defect PR comment
+|   |   |-- defect-report-not-a-report.txt # Non-defect PR comment
+|   |   |-- bicep-build-success.txt      # Bicep BUILD SUCCEEDED output
+|   |   |-- bicep-build-failure.txt      # Bicep BUILD FAILED output
+|   |   |-- bicep-test-success.txt       # Bicep test Summary output
+|   |   |-- bicep-test-failure.txt       # Bicep test with failures
+|   |   |-- azure-auth-ok.txt            # AZURE AUTH OK output
+|   |   |-- azure-auth-failed.txt        # AZURE AUTH FAILED output
+|   |   |-- cost-estimate.txt            # COST ESTIMATE output
+|   |   |-- security-scan-findings.txt   # SECURITY SCAN output
+|   |   |-- drift-check-drifted.txt      # DRIFT CHECK output
+|   |   +-- deploy-success.txt           # DEPLOY SUCCEEDED output
 |   +-- smoke/                           # Layer 4: end-to-end smoke test
 |       |-- run_smoke.py                 # Bootstrap + validate + optional full run
 |       +-- calculator/                  # Minimal Python fixture project
 |
 |-- docs/                                # Guides and documentation
+|   |-- azure-guide.md                  # Azure deployment guide (Bicep, SDK, auth, skills)
 |   +-- testing-guide.md                # Manual testing & defect reporting guide
 |
 +-- templates/                           # Project file templates
@@ -354,6 +403,15 @@ You don't have to use the full pipeline. Individual skills work standalone:
 /open-pr                         # Create a branch + draft PR
 /summarize-implementation        # Generate a commit message from current diff
 /fix-defects                     # Fix defects reported on a PR
+
+# Azure skills (see docs/azure-guide.md for details)
+/azure-login                     # Verify Azure auth and subscription context
+/validate-bicep                  # Lint + build + what-if dry run
+/deploy-bicep                    # Deploy with confirmation gate
+/azure-cost-estimate             # Estimate monthly Azure costs
+/security-scan                   # PSRule/Checkov security scan
+/infra-test-runner               # ARM-TTK/Pester infrastructure tests
+/azure-drift-check               # Detect config drift vs deployed state
 ```
 
 ### Updating the Pipeline
@@ -537,6 +595,9 @@ stack=react
 # Absolute path to the pipeline repo
 pipeline_root=/path/to/claude-code-pipeline
 
+# Cross-cutting overlays (comma-separated, empty if none)
+overlays=azure-sdk
+
 # Date this config was generated
 initialized=2026-03-29T00:00:00Z
 ```
@@ -625,6 +686,7 @@ When writing a custom adapter, run `python3 tests/validate_structure.py` after c
   - **swift-ios**: Xcode 15+, `xcrun`, iOS/watchOS simulators
   - **react**: Node.js 18+, npm/yarn/pnpm/bun
   - **python**: Python 3.9+, pip/poetry/uv
+  - **bicep**: Azure CLI (`az`) + Bicep CLI, optionally PowerShell 7+ (`pwsh`) for PSRule/ARM-TTK
 
 ## FAQ
 

--- a/adapters/bicep/adapter.md
+++ b/adapters/bicep/adapter.md
@@ -1,0 +1,108 @@
+# Bicep Adapter
+
+## Stack Metadata
+
+- **Stack name:** `bicep`
+- **Display name:** Azure Bicep (IaC)
+- **Languages:** Bicep, JSON (ARM templates)
+- **Build system:** bicep CLI (`bicep build`) + az CLI (`az bicep lint`). Linting via standalone `bicep` uses `bicepconfig.json` rules during build.
+- **Test framework:** ARM-TTK / PSRule for Azure / `az deployment group what-if`
+- **Coverage tool:** Resource validation coverage (% of resources with validation rules)
+
+## Build & Test Commands
+
+- **Build (lint/compile):** `python3 .claude/scripts/build.py [--project-dir .] [--scheme <lint|build|all>]`
+- **Test:** `python3 .claude/scripts/test.py [--project-dir .] [--scheme <arm-ttk|psrule|what-if|all>] [--resource-group <name>] [--no-coverage]`
+
+## Blocked Commands
+
+These commands are blocked by hooks and must use the pipeline skills instead:
+- `bicep build` / `bicep lint` / `bicep decompile` -> use `build-runner` skill
+- `az deployment` (any subcommand) -> use `deploy-bicep` or `test-runner` skill
+- `Invoke-PSRule` / `Test-AzTemplate` -> use `test-runner` skill
+
+## Overlay Files
+
+| Overlay | Agent | Purpose |
+|---------|-------|---------|
+| `architect-overlay.md` | architect-agent | Bicep module decomposition, scope hierarchies, dependency chains |
+| `implementer-overlay.md` | implementer-agent | Bicep code quality rules, naming, decorators, security |
+| `reviewer-overlay.md` | code-reviewer-agent | Bicep-specific review checklist (security, cost, reliability) |
+| `test-overlay.md` | test-architect-agent | ARM-TTK, PSRule, what-if patterns and conventions |
+
+## Project Detection
+
+This adapter activates when the project root contains any of:
+- `*.bicep` files (in root or `modules/` directory)
+- `bicepconfig.json`
+- `main.bicep`
+
+## Azure Authentication
+
+Several pipeline skills require an authenticated Azure session. The `azure-login` skill validates auth state before any Azure-dependent operation. The pipeline **does not manage credentials** — it verifies context and provides guided remediation.
+
+### Which Skills Need Auth
+
+| Skill | Auth Required | Why |
+|-------|--------------|-----|
+| `build-runner` | No | `bicep build/lint` are local operations |
+| `test-runner` (PSRule/ARM-TTK) | No | Template validation is local |
+| `test-runner` (what-if) | **Yes** | Queries Azure Resource Manager |
+| `validate-bicep` (what-if) | **Yes** | Queries Azure Resource Manager |
+| `deploy-bicep` | **Yes** | Creates/modifies Azure resources |
+| `azure-drift-check` | **Yes** | Reads deployed resource state |
+| `infra-test-runner` (post-deploy) | **Yes** | Reads deployed resource state |
+| `azure-cost-estimate` | No | Uses public Azure Retail Pricing API |
+| `security-scan` | No | PSRule/Checkov are local operations |
+
+### Auth Methods (by scenario)
+
+**Local developer (most common):**
+```bash
+az login                                          # Interactive browser login
+az account set --subscription "My Dev Sub"        # Set target subscription
+```
+
+**Service principal (CI/CD):**
+```bash
+az login --service-principal -u <app-id> -p <secret> --tenant <tenant-id>
+```
+
+**Managed identity (Azure-hosted runners):**
+```bash
+az login --identity
+```
+
+**GitHub Actions (OIDC — recommended for CI):**
+```yaml
+- uses: azure/login@v2
+  with:
+    client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+
+### Required RBAC Roles
+
+| Operation | Minimum Role | Scope |
+|-----------|-------------|-------|
+| `what-if` / drift-check | **Reader** | Target resource group |
+| `deploy` (incremental) | **Contributor** | Target resource group |
+| `deploy` (complete mode) | **Contributor** | Target resource group |
+| Role assignments in template | **Owner** or **User Access Administrator** | Target resource group |
+
+### Subscription Safety
+
+The pipeline validates subscription context before deployment. Developers with access to multiple subscriptions (dev, staging, prod) must confirm the active subscription matches their intent. The `azure-login` skill displays the current subscription and prompts for confirmation if it appears to be a production subscription.
+
+## Common Conventions
+
+- **Parameter naming:** camelCase for parameters and variables
+- **Resource naming:** PascalCase for resource symbolic names
+- **Module pattern:** One module per logical resource group or reusable component
+- **Parameter files:** `<environment>.bicepparam` or `<environment>.parameters.json`
+- **Scoping:** `targetScope` declared at top of file; subscription-level for resource groups, resource-group-level for resources
+- **API versions:** Always explicit, prefer latest stable GA version
+- **Secrets:** Always use `@secure()` decorator; reference Key Vault where possible
+- **Environment separation:** Parameterize all environment-specific values (location, SKU, naming prefix)
+- **Tagging:** All resources must include a standard tag set (environment, owner, cost-center)

--- a/adapters/bicep/architect-overlay.md
+++ b/adapters/bicep/architect-overlay.md
@@ -1,0 +1,49 @@
+# Bicep Architect Context
+
+## Project Context
+
+This is an Azure Bicep (Infrastructure as Code) project. When planning, account for:
+- Module structure and dependency chains — circular module references are a deployment failure mode
+- Scope hierarchy: management group → subscription → resource group → resource
+- Azure resource provider API versions and feature availability by region
+- The 4-file rule: tasks touching more than 3 files must be split into smaller tasks
+
+## Module Decomposition Patterns
+
+When planning tasks that involve Bicep modules, account for their specific complexity:
+
+- **Single resource definitions** (Haiku): Adding a resource to an existing template, updating parameters, adding outputs, modifying a single module
+- **Module interface design** (Sonnet): Defining parameter/output contracts between modules, designing reusable module libraries, establishing naming conventions across templates
+- **Cross-module dependency chains** (Sonnet): Resource references across modules, deployment ordering, `existing` keyword patterns, output-to-parameter wiring
+- **Multi-subscription landing zone patterns** (Opus): Hub-spoke networking, management group hierarchies, policy assignments, cross-subscription resource references
+
+## Scope Hierarchy Patterns
+
+- **Resource-group scoped** (Haiku): Standard resource deployments with `targetScope = 'resourceGroup'` (default)
+- **Subscription scoped** (Sonnet): Resource group creation, policy assignments, role assignments at subscription level with `targetScope = 'subscription'`
+- **Management-group scoped** (Sonnet/Opus): Policy definitions, blueprint assignments, cross-subscription governance with `targetScope = 'managementGroup'`
+- **Tenant scoped** (Opus): Management group hierarchy, tenant-wide policy, cross-tenant patterns with `targetScope = 'tenant'`
+
+## Resource Dependency Patterns
+
+- **Implicit dependencies** (Haiku): Resource property references automatically create dependencies — prefer these over explicit `dependsOn`
+- **Explicit `dependsOn`** (Haiku): Only when no property reference exists between resources but ordering is still required
+- **`existing` keyword** (Haiku): Referencing pre-existing resources that are not created in this deployment
+- **Cross-scope references** (Sonnet): Using `resourceGroup()`, `subscription()`, or `tenant()` scope functions for cross-scope deployments
+- **Deployment scripts** (Sonnet): `Microsoft.Resources/deploymentScripts` for custom provisioning logic that Bicep cannot express declaratively
+
+## Common Architecture Patterns
+
+- **Hub-spoke networking** (Sonnet/Opus): Central hub VNet with shared services, spoke VNets peered to hub, NSG/UDR management
+- **Shared services module** (Sonnet): Key Vault, Log Analytics, Application Insights as a reusable module consumed by other deployments
+- **Environment parameterization** (Haiku/Sonnet): Single template set with `.bicepparam` files per environment (dev, staging, prod)
+- **Module registry** (Sonnet): Publishing reusable modules to an Azure Container Registry for cross-project consumption
+- **Conditional deployments** (Haiku): Using ternary expressions for optional resources based on parameters
+
+## Bicep-Specific Decomposition Notes
+
+- Module boundaries are natural Haiku boundaries — define the module interface (Sonnet if non-trivial), then implement each module as a separate Haiku task
+- Parameter file design is Sonnet (establishing the contract); adding individual parameter values is Haiku
+- User-defined types define contracts — designing the type is Sonnet, using it in resources is Haiku
+- Networking topology is always Sonnet or Opus; individual NSG rules or route tables are Haiku
+- Policy definitions are Sonnet; policy assignments to scopes are Haiku

--- a/adapters/bicep/hooks.json
+++ b/adapters/bicep/hooks.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in bicep) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the build-runner skill instead. Subagents: python3 .claude/scripts/build.py.\"}' ;; az) echo \"$CMD\" | head -1 | grep -qE '^[[:space:]]*az deployment' && echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the deploy-bicep or test-runner skill instead. Subagents: python3 .claude/scripts/test.py for what-if.\"}' || echo '{}' ;; pwsh|powershell) echo \"$CMD\" | head -1 | grep -qE 'Invoke-PSRule|Test-AzTemplate' && echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the test-runner skill instead. Subagents: python3 .claude/scripts/test.py.\"}' || echo '{}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for forbidden build/test/deploy commands..."
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in grep|rg) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Grep tool instead of grep/rg via Bash. Grep supports regex, glob filters, context lines, and multiple output modes.\"}' ;; cat|head|tail) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Read tool instead of cat/head/tail via Bash. Read supports offset and limit parameters for partial file reading.\"}' ;; find) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Glob tool instead of find via Bash. Glob supports patterns like **/*.bicep for recursive file discovery.\"}' ;; sed|awk) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Edit tool instead of sed/awk via Bash. Edit performs exact string replacements in files.\"}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for dedicated tool alternatives..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/bicep/implementer-overlay-essential.md
+++ b/adapters/bicep/implementer-overlay-essential.md
@@ -1,0 +1,15 @@
+# Bicep Essential Rules
+
+Critical rules for Haiku execution. Violations will fail code review.
+
+- camelCase for parameters/variables/outputs, PascalCase for resource symbolic names
+- `@description()` decorator on every parameter — no exceptions
+- `@secure()` on all secrets, passwords, connection strings, and keys
+- Always specify explicit API version on every resource (latest stable GA)
+- Use `existing` keyword for references to resources not created in this template
+- Prefer implicit dependencies over explicit `dependsOn`
+- Never hardcode resource names, secrets, or environment-specific values
+- Use modules for reusable components — one module per logical component
+- Expose only IDs, names, and endpoints in outputs — never expose secrets
+- Use ternary expressions for conditional deployments, not separate templates
+- Tag all resources: environment, owner, costCenter, project

--- a/adapters/bicep/implementer-overlay.md
+++ b/adapters/bicep/implementer-overlay.md
@@ -1,0 +1,73 @@
+# Bicep Implementer Rules
+
+## Code Quality Rules (Rule 4)
+
+Within the boundaries of what the brief asks for, write clean Bicep:
+
+### Naming Conventions
+- camelCase for parameters, variables, outputs, and module symbolic names
+- PascalCase for resource symbolic names (e.g., `resource StorageAccount`)
+- Descriptive names that indicate purpose: `storageAccountName` not `saName`
+- Resource names assembled from parameterized prefix + purpose + environment suffix
+- Never hardcode resource names — always derive from parameters
+
+### Parameter Decorators
+- `@description('...')` on every parameter — no exceptions
+- `@secure()` on all secrets, passwords, connection strings, and keys
+- `@minLength()` / `@maxLength()` for string parameters with known bounds
+- `@minValue()` / `@maxValue()` for numeric parameters with known bounds
+- `@allowed([...])` for parameters with a fixed set of valid values (e.g., SKU names, environments)
+- Use `@metadata({...})` for additional documentation when `@description` is not enough
+
+### User-Defined Types
+- Define types for complex parameter shapes instead of using multiple loose parameters
+- Use union types for constrained string values: `type environment = 'dev' | 'staging' | 'prod'`
+- Use typed objects for structured configuration: `type networkConfig = { vnetName: string, addressPrefix: string }`
+- Export types from modules when they define a public interface
+
+### Resource Definitions
+- Always specify an explicit API version on every resource (e.g., `'Microsoft.Storage/storageAccounts@2023-05-01'`)
+- Use the latest stable GA API version unless a preview feature is specifically required
+- Use `existing` keyword for references to resources not created in this template
+- Prefer implicit dependencies (property references) over explicit `dependsOn`
+- Only use `dependsOn` when no property reference creates the needed ordering
+
+### Conditional Deployments
+- Use ternary expressions for optional resources: `resource ... = if (deployFirewall) { ... }`
+- Use ternary for conditional property values: `sku: isProd ? 'Standard' : 'Basic'`
+- Never create separate template files for conditional resources — use conditionals within a single template
+
+### Output Patterns
+- Expose only IDs, names, and endpoints that downstream consumers need
+- Use `output ... = resource.id` or `output ... = resource.properties.endpoint`
+- Document outputs with `@description()` decorator
+- Never expose secrets in outputs — use Key Vault references instead
+
+### Module References
+- Local modules: `module ... './modules/storage.bicep' = { ... }`
+- Registry modules: `module ... 'br:myregistry.azurecr.io/bicep/storage:v1' = { ... }`
+- Template specs: `module ... 'ts:subscriptionId/resourceGroup/templateSpecName:version' = { ... }`
+- Always pass required parameters explicitly — never rely on defaults for environment-specific values
+
+### Secure Parameter Handling
+- Never hardcode secrets, connection strings, API keys, or passwords in templates
+- Use `@secure()` decorator on sensitive parameters
+- Reference Key Vault secrets: `getSecret('<vaultName>', '<secretName>')`
+- Use managed identity over connection strings wherever possible
+- Never output `@secure()` parameter values or sensitive resource properties
+
+### Scope Management
+- Declare `targetScope` at the top of every file that is not resource-group scoped
+- Use `scope:` property on modules for cross-scope deployments
+- Use `resourceGroup()` function for deploying to a different resource group within the same subscription
+
+## Project Conventions
+
+Key conventions for Bicep projects (the context brief overrides these if different):
+- One module per logical component or reusable resource pattern
+- Parameter files per environment: `dev.bicepparam`, `staging.bicepparam`, `prod.bicepparam`
+- Modules organized in a `modules/` directory; main entry point is `main.bicep`
+- All resources tagged with: `environment`, `owner`, `costCenter`, `project`
+- Use `var` for computed values derived from parameters — keep parameter count manageable
+- Prefer composition (modules calling modules) over monolithic templates
+- Keep templates under 200 lines; extract to modules if larger

--- a/adapters/bicep/reviewer-overlay.md
+++ b/adapters/bicep/reviewer-overlay.md
@@ -1,0 +1,87 @@
+# Bicep Code Review Rules
+
+**Your Domain Expertise:**
+- Senior Azure cloud architect with deep expertise in Infrastructure as Code
+- Master of Bicep language features, ARM template compilation, and Azure Resource Manager
+- Expert in Azure Well-Architected Framework (security, reliability, cost, operational excellence, performance)
+- Specialist in Azure networking, identity, governance, and compliance
+- Authority on Bicep module design, testing with ARM-TTK and PSRule, and deployment pipelines
+- Expert in Azure security best practices, RBAC, managed identity, and Key Vault patterns
+
+**Stack-Specific Review Categories:**
+
+1. **Security** - Aggressively identify:
+   - Hardcoded secrets, connection strings, API keys, or passwords (must use `@secure()` + Key Vault)
+   - Missing `@secure()` decorator on sensitive parameters
+   - RBAC violations: overly broad role assignments (Contributor/Owner when Reader suffices)
+   - Missing network isolation: public endpoints without private endpoints or service endpoints
+   - Missing NSG rules or overly permissive inbound rules (0.0.0.0/0 on non-gateway resources)
+   - Storage accounts without HTTPS-only enforcement or minimum TLS version
+   - Missing encryption at rest or in transit configurations
+   - Managed identity not used where available (falling back to connection strings)
+   - Missing diagnostic settings and audit logging
+
+2. **Cost Awareness** - Tear apart:
+   - Over-provisioned SKUs (Premium where Standard suffices for the workload)
+   - Missing auto-scale rules on scalable resources (App Service, VMSS, AKS)
+   - Missing auto-shutdown on development VMs
+   - Reserved capacity not considered for predictable production workloads
+   - Missing cost allocation tags (environment, costCenter, owner)
+   - Redundant resources that could be shared (multiple Key Vaults, Log Analytics workspaces)
+   - Premium storage on non-IO-intensive workloads
+
+3. **Reliability** - Ruthlessly expose:
+   - Missing availability zone configuration on zone-capable resources
+   - Single-region deployments for production workloads without justification
+   - Missing resource locks on critical infrastructure (Key Vault, databases, networking)
+   - Missing backup policies on databases and storage accounts
+   - Missing health probes on load-balanced resources
+   - No geo-redundancy on storage accounts in production
+   - Missing retry and timeout configuration on deployment scripts
+   - Single-instance resources without redundancy for production
+
+4. **Module Boundaries** - Hunt down:
+   - Monolithic templates doing too much (split by responsibility)
+   - Circular module references (restructure dependency chain)
+   - Modules with too many parameters (group into user-defined types)
+   - Tight coupling between modules (pass IDs/names, not full resource references)
+   - Missing module output contracts (consumers cannot get what they need)
+   - Modules that mix scope levels (resource-group resources mixed with subscription-level)
+
+5. **Parameter Validation** - Demand better:
+   - Missing `@description()` on any parameter
+   - Missing `@allowed()` on enum-like parameters (SKU names, tiers, environments)
+   - Missing `@minLength()` / `@maxLength()` on string parameters with known constraints
+   - Default values for environment-specific parameters (location, SKU, naming prefix should NOT have defaults)
+   - Missing `@secure()` on any parameter that could contain sensitive data
+   - Overly broad parameter types where user-defined types would be safer
+
+6. **Output Contracts** - Expose:
+   - Secrets or sensitive values exposed in outputs
+   - Missing outputs that downstream modules or deployments need
+   - Outputs returning full resource objects instead of specific properties (ID, name, endpoint)
+   - Missing `@description()` on outputs
+   - Outputs with wrong types or values that do not match what consumers expect
+
+7. **Dependency Chains** - Demolish:
+   - Explicit `dependsOn` when implicit dependency via property reference would suffice
+   - Missing dependencies causing race conditions in deployment
+   - Circular dependencies between resources
+   - Incorrect deployment ordering for resources with startup dependencies
+   - Missing `dependsOn` for resources that have no property-based relationship but require ordering
+
+8. **Naming & Conventions** - Enforce rigorously:
+   - Inconsistent naming between camelCase and other conventions
+   - Resource names that violate Azure naming rules (length, allowed characters, uniqueness scope)
+   - Missing or inconsistent tagging across resources
+   - Hardcoded resource names instead of parameterized/computed names
+   - Inconsistent API version usage across same resource types
+   - Missing `targetScope` declaration on non-resource-group-scoped templates
+
+**Coding Standards to Enforce:**
+- Consistent camelCase parameters/variables, PascalCase resource symbolic names
+- `@description()` on all parameters and outputs
+- Explicit API versions on all resources (latest stable GA)
+- Clean module boundaries with typed interfaces
+- Comprehensive tagging on all resources
+- Security-first: managed identity, Key Vault, private endpoints, encryption

--- a/adapters/bicep/scripts/build.py
+++ b/adapters/bicep/scripts/build.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Run Bicep linting and compilation, output results in pipeline contract format.
+
+Usage:
+  python build.py [--project-dir /path/to/project] [--scheme <lint|build|all>] [--verbose]
+
+The script auto-detects .bicep files and bicepconfig.json, then runs bicep lint/build.
+Output format:
+  BUILD SUCCEEDED | N warning(s)
+  BUILD FAILED | N error(s) | N warning(s)
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+import shutil
+
+
+# ---------------------------------------------------------------------------
+# Project detection
+# ---------------------------------------------------------------------------
+
+def detect_project_config(project_dir):
+    """Detect Bicep project structure and configuration."""
+    info = {
+        "has_bicepconfig": False,
+        "bicep_files": [],
+        "has_modules_dir": False,
+        "has_param_files": False,
+        "bicep_available": False,
+        "az_available": False,
+    }
+
+    info["has_bicepconfig"] = os.path.exists(
+        os.path.join(project_dir, "bicepconfig.json")
+    )
+    info["has_modules_dir"] = os.path.isdir(
+        os.path.join(project_dir, "modules")
+    )
+
+    # Find all .bicep files
+    for root, dirs, files in os.walk(project_dir):
+        # Skip hidden dirs and common non-source dirs
+        dirs[:] = [
+            d for d in dirs
+            if not d.startswith(".")
+            and d not in ("node_modules", "__pycache__", ".bicep",
+                          "out", "dist", "build", "generated", "bin", "obj")
+        ]
+        for f in files:
+            if f.endswith(".bicep"):
+                rel = os.path.relpath(os.path.join(root, f), project_dir)
+                info["bicep_files"].append(rel)
+
+    # Check for parameter files
+    for f in os.listdir(project_dir):
+        if f.endswith(".bicepparam") or f.endswith(".parameters.json"):
+            info["has_param_files"] = True
+            break
+
+    # Check tool availability
+    info["bicep_available"] = find_tool("bicep") or find_tool("az")
+    info["az_available"] = find_tool("az")
+
+    return info
+
+
+def find_tool(name):
+    """Check if a tool is available on PATH."""
+    return shutil.which(name) is not None
+
+
+def find_bicep_command():
+    """Determine the bicep CLI command to use (standalone or via az)."""
+    if find_tool("bicep"):
+        return ["bicep"]
+    if find_tool("az"):
+        return ["az", "bicep"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool runners
+# ---------------------------------------------------------------------------
+
+def run_bicep_build(project_dir, bicep_files, bicep_cmd):
+    """Compile .bicep files to ARM JSON and return (output, errors, warnings)."""
+    errors = []
+    warnings = []
+    all_output = []
+
+    for bicep_file in bicep_files:
+        cmd = bicep_cmd + ["build", bicep_file]
+        print(f"Running: {' '.join(cmd)}")
+
+        result = subprocess.run(
+            cmd, cwd=project_dir, capture_output=True, text=True, check=False
+        )
+        output = result.stdout + result.stderr
+        all_output.append(output)
+
+        parsed_errors, parsed_warnings = parse_bicep_diagnostics(
+            output, bicep_file
+        )
+        errors.extend(parsed_errors)
+        warnings.extend(parsed_warnings)
+
+        # Non-zero exit with no parsed errors means a general failure
+        if result.returncode != 0 and not parsed_errors:
+            errors.append({
+                "file": bicep_file,
+                "line": "-",
+                "msg": f"[bicep build] Compilation failed (exit code {result.returncode})",
+            })
+
+    return "\n".join(all_output), errors, warnings
+
+
+def run_bicep_lint(project_dir, bicep_files, bicep_cmd):
+    """Run bicep linter and return (output, errors, warnings).
+
+    Note: The standalone `bicep` CLI does not have a separate `lint` subcommand.
+    Linting is performed via `bicep build` when `bicepconfig.json` is present.
+    The `az bicep lint` subcommand is available in recent az CLI versions.
+    This function tries `az bicep lint` first, and falls back to `bicep build`
+    (which includes lint diagnostics from bicepconfig.json rules).
+    """
+    errors = []
+    warnings = []
+    all_output = []
+
+    # Determine lint command: only `az bicep lint` is a real subcommand
+    use_az_lint = bicep_cmd[0] == "az"
+
+    for bicep_file in bicep_files:
+        if use_az_lint:
+            cmd = ["az", "bicep", "lint", "--file", bicep_file]
+        else:
+            # Standalone bicep CLI: lint happens during build via bicepconfig.json
+            cmd = bicep_cmd + ["build", bicep_file, "--stdout"]
+        print(f"Running: {' '.join(cmd)}")
+
+        result = subprocess.run(
+            cmd, cwd=project_dir, capture_output=True, text=True, check=False
+        )
+        output = result.stdout + result.stderr
+        all_output.append(output)
+
+        parsed_errors, parsed_warnings = parse_bicep_diagnostics(
+            output, bicep_file
+        )
+        errors.extend(parsed_errors)
+        warnings.extend(parsed_warnings)
+
+    return "\n".join(all_output), errors, warnings
+
+
+def parse_bicep_diagnostics(output, default_file):
+    """
+    Parse Bicep CLI diagnostic output.
+
+    Bicep outputs diagnostics in the format:
+      path/to/file.bicep(line,col) : severity code: message
+    or:
+      /path/to/file.bicep(line,col) : error BCP001: message
+      /path/to/file.bicep(line,col) : warning no-unused-params: message
+    """
+    errors = []
+    warnings = []
+
+    # Pattern: file(line,col) : severity code: message
+    pattern = re.compile(
+        r"^(.+?)\((\d+),\d+\)\s*:\s*(error|warning|info)\s+(\S+)\s*:\s*(.+)$",
+        re.MULTILINE,
+    )
+
+    seen = set()
+    for m in pattern.finditer(output):
+        filepath, line, severity, code, message = m.groups()
+        # Shorten path
+        parts = filepath.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+        message = message.strip()[:120]
+        key = (short_path, line, message)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {
+            "file": short_path,
+            "line": line,
+            "msg": f"[{code}] {message}",
+        }
+        if severity == "error":
+            errors.append(entry)
+        elif severity == "warning":
+            warnings.append(entry)
+        # info diagnostics are skipped
+
+    return errors, warnings
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def print_table(all_errors, all_warnings, has_failures):
+    """Print results in pipeline contract format."""
+    if not has_failures and not all_errors:
+        print(f"\nBUILD SUCCEEDED  |  {len(all_warnings)} warning(s)")
+        if all_warnings:
+            print_entries(all_warnings, "Warning")
+        return
+
+    print(
+        f"\nBUILD FAILED  |  {len(all_errors)} error(s)  |  "
+        f"{len(all_warnings)} warning(s)\n"
+    )
+
+    if not all_errors:
+        print("No parseable errors found. A tool returned a non-zero exit code.")
+        print("Run the tool manually for full output.")
+        return
+
+    print_entries(all_errors, "Error")
+
+
+def print_entries(entries, label):
+    """Print a formatted table of error/warning entries."""
+    if not entries:
+        return
+
+    fw = max(len(e["file"]) for e in entries)
+    lw = max(len(str(e["line"])) for e in entries)
+
+    header = f"{'File':<{fw}}  {'Ln':>{lw}}  {label}"
+    print(header)
+    print("-" * min(len(header) + 80, 140))
+
+    for e in entries:
+        print(f"{e['file']:<{fw}}  {str(e['line']):>{lw}}  {e['msg']}")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Bicep linting and compilation in pipeline contract format."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument(
+        "--scheme",
+        default="all",
+        choices=["lint", "build", "all"],
+        help="Which checks to run (default: all)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Show full tool output")
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    print(f"Building in: {project_dir}")
+
+    if not os.path.isdir(project_dir):
+        print(f"ERROR: Project directory does not exist: {project_dir}")
+        sys.exit(1)
+
+    info = detect_project_config(project_dir)
+
+    if not info["bicep_files"]:
+        print("WARNING: No .bicep files found in project.")
+        print("\nBUILD SUCCEEDED  |  0 warning(s)")
+        sys.exit(0)
+
+    print(f"Bicep files: {len(info['bicep_files'])}")
+    if info["has_bicepconfig"]:
+        print("Config:      bicepconfig.json found")
+    if info["has_modules_dir"]:
+        print("Modules:     modules/ directory found")
+
+    bicep_cmd = find_bicep_command()
+    if not bicep_cmd:
+        print("ERROR: Neither 'bicep' nor 'az' CLI found on PATH.")
+        print("Install the Bicep CLI: https://learn.microsoft.com/azure/azure-resource-manager/bicep/install")
+        print("\nBUILD FAILED  |  1 error(s)  |  0 warning(s)\n")
+        print("File  Ln  Error")
+        print("-" * 80)
+        print("-     -   [setup] Bicep CLI not found on PATH")
+        sys.exit(1)
+
+    all_errors = []
+    all_warnings = []
+    has_failures = False
+
+    # Determine which steps to run
+    steps = []
+    if args.scheme in ("lint", "all"):
+        steps.append("lint")
+    if args.scheme in ("build", "all"):
+        steps.append("build")
+
+    for step in steps:
+        print(f"\n--- Running: bicep {step} ---")
+
+        if step == "lint":
+            output, errors, warnings = run_bicep_lint(
+                project_dir, info["bicep_files"], bicep_cmd
+            )
+        else:
+            output, errors, warnings = run_bicep_build(
+                project_dir, info["bicep_files"], bicep_cmd
+            )
+
+        if args.verbose:
+            print(output)
+
+        all_errors.extend(errors)
+        all_warnings.extend(warnings)
+        if errors:
+            has_failures = True
+
+    print_table(all_errors, all_warnings, has_failures)
+
+    if has_failures or all_errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/bicep/scripts/test.py
+++ b/adapters/bicep/scripts/test.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""
+Run Bicep infrastructure tests and output results in pipeline contract format.
+
+Usage:
+  python test.py [--project-dir /path/to/project] [--scheme <arm-ttk|psrule|what-if|all>]
+                 [--resource-group <name>] [--no-coverage]
+
+Supports ARM-TTK, PSRule for Azure, and az deployment what-if.
+Output format:
+  Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+import json
+import shutil
+
+
+# ---------------------------------------------------------------------------
+# Project detection
+# ---------------------------------------------------------------------------
+
+def detect_test_config(project_dir):
+    """Detect available test frameworks and configuration."""
+    info = {
+        "has_arm_ttk": False,
+        "has_psrule": False,
+        "has_az_cli": False,
+        "has_pester": False,
+        "bicep_files": [],
+        "test_files": [],
+        "psrule_config": None,
+        "resource_types": set(),
+    }
+
+    # Check tool availability
+    info["has_az_cli"] = find_tool("az")
+    info["has_psrule"] = _check_psrule_available()
+    info["has_arm_ttk"] = _check_arm_ttk_available()
+    info["has_pester"] = _check_pester_available()
+
+    # Find .bicep files
+    for root, dirs, files in os.walk(project_dir):
+        dirs[:] = [
+            d for d in dirs
+            if not d.startswith(".")
+            and d not in ("node_modules", "__pycache__", ".bicep")
+        ]
+        for f in files:
+            if f.endswith(".bicep"):
+                rel = os.path.relpath(os.path.join(root, f), project_dir)
+                info["bicep_files"].append(rel)
+
+    # Find test files (Pester tests)
+    for root, dirs, files in os.walk(project_dir):
+        dirs[:] = [
+            d for d in dirs
+            if not d.startswith(".")
+        ]
+        for f in files:
+            if f.endswith(".Tests.ps1"):
+                rel = os.path.relpath(os.path.join(root, f), project_dir)
+                info["test_files"].append(rel)
+
+    # Check for PSRule config
+    psrule_config = os.path.join(project_dir, "ps-rule.yaml")
+    if os.path.exists(psrule_config):
+        info["psrule_config"] = psrule_config
+
+    # Extract resource types from .bicep files for coverage calculation
+    resource_pattern = re.compile(
+        r"resource\s+\w+\s+'(Microsoft\.\w+/\w+)@"
+    )
+    for bicep_file in info["bicep_files"]:
+        try:
+            with open(os.path.join(project_dir, bicep_file), "r") as fh:
+                content = fh.read()
+            for m in resource_pattern.finditer(content):
+                info["resource_types"].add(m.group(1))
+        except Exception:
+            pass
+
+    return info
+
+
+def find_tool(name):
+    """Check if a tool is available on PATH."""
+    return shutil.which(name) is not None
+
+
+def _check_psrule_available():
+    """Check if PSRule for Azure is available."""
+    # Check dotnet tool
+    try:
+        result = subprocess.run(
+            ["dotnet", "tool", "list", "-g"],
+            capture_output=True, text=True, check=False,
+        )
+        if "psrule" in result.stdout.lower():
+            return True
+    except Exception:
+        pass
+
+    # Check PowerShell module
+    try:
+        result = subprocess.run(
+            ["pwsh", "-Command", "Get-Module -ListAvailable PSRule.Rules.Azure"],
+            capture_output=True, text=True, check=False,
+        )
+        if "PSRule.Rules.Azure" in result.stdout:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _check_arm_ttk_available():
+    """Check if ARM-TTK is available."""
+    try:
+        result = subprocess.run(
+            ["pwsh", "-Command", "Get-Module -ListAvailable arm-ttk"],
+            capture_output=True, text=True, check=False,
+        )
+        return "arm-ttk" in result.stdout.lower()
+    except Exception:
+        return False
+
+
+def _check_pester_available():
+    """Check if Pester is available."""
+    try:
+        result = subprocess.run(
+            ["pwsh", "-Command", "Get-Module -ListAvailable Pester"],
+            capture_output=True, text=True, check=False,
+        )
+        return "Pester" in result.stdout
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Test runners
+# ---------------------------------------------------------------------------
+
+def run_psrule(project_dir, bicep_files, psrule_config):
+    """Run PSRule for Azure and return (total, passed, failed, failures)."""
+    total = 0
+    passed = 0
+    failed = 0
+    failures = {}
+
+    # Build PSRule command
+    cmd_parts = [
+        "Invoke-PSRule",
+        "-InputPath", ".",
+        "-Module", "PSRule.Rules.Azure",
+        "-Baseline", "Azure.Default",
+        "-OutputFormat", "Json",
+    ]
+
+    if psrule_config:
+        cmd_parts.extend(["-Option", psrule_config])
+
+    cmd_str = " ".join(cmd_parts)
+    cmd = ["pwsh", "-Command", cmd_str]
+
+    print(f"Running: {cmd_str}")
+    result = subprocess.run(
+        cmd, cwd=project_dir, capture_output=True, text=True, check=False
+    )
+
+    output = result.stdout
+
+    # Parse JSON output
+    try:
+        # PSRule outputs one JSON object per line
+        for line in output.strip().splitlines():
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                record = json.loads(line)
+                total += 1
+                outcome = record.get("outcome", "").lower()
+                if outcome == "pass":
+                    passed += 1
+                elif outcome in ("fail", "error"):
+                    failed += 1
+                    rule_name = record.get("ruleName", "unknown")
+                    target = record.get("targetName", "unknown")
+                    reason = record.get("reason", [""])[0] if record.get("reason") else ""
+                    failures[f"{rule_name}:{target}"] = reason[:160]
+            except json.JSONDecodeError:
+                continue
+    except Exception:
+        # Fall back: try to parse text output
+        pass_count = output.count(" Pass ")
+        fail_count = output.count(" Fail ")
+        total = pass_count + fail_count
+        passed = pass_count
+        failed = fail_count
+
+    return total, passed, failed, failures
+
+
+def run_arm_ttk(project_dir, bicep_files):
+    """Run ARM-TTK template tests and return (total, passed, failed, failures)."""
+    total = 0
+    passed = 0
+    failed = 0
+    failures = {}
+
+    for bicep_file in bicep_files:
+        cmd_str = f"Test-AzTemplate -TemplatePath '{bicep_file}' -ErrorAction Continue"
+        cmd = ["pwsh", "-Command", cmd_str]
+
+        print(f"Running: Test-AzTemplate -TemplatePath '{bicep_file}'")
+        result = subprocess.run(
+            cmd, cwd=project_dir, capture_output=True, text=True, check=False
+        )
+        output = result.stdout + result.stderr
+
+        # Parse ARM-TTK output
+        # Format: [+] Test Name (N ms)  or  [-] Test Name (N ms)
+        pass_pattern = re.compile(r"\[\+\]\s+(.+?)\s+\(\d+")
+        fail_pattern = re.compile(r"\[-\]\s+(.+?)\s+\(\d+")
+
+        for m in pass_pattern.finditer(output):
+            total += 1
+            passed += 1
+
+        for m in fail_pattern.finditer(output):
+            total += 1
+            failed += 1
+            test_name = m.group(1).strip()
+            # Try to find the error message after the failure
+            failures[f"{bicep_file}::{test_name}"] = ""
+
+        # Extract failure details
+        detail_pattern = re.compile(
+            r"\[-\]\s+(.+?)\s+\(\d+.*?\n(.*?)(?=\n\[|$)", re.DOTALL
+        )
+        for m in detail_pattern.finditer(output):
+            test_name = m.group(1).strip()
+            details = m.group(2).strip()[:160]
+            key = f"{bicep_file}::{test_name}"
+            if key in failures:
+                failures[key] = details
+
+    return total, passed, failed, failures
+
+
+def run_what_if(project_dir, bicep_files, resource_group):
+    """Run az deployment what-if and return (total, passed, failed, failures)."""
+    total = 0
+    passed = 0
+    failed = 0
+    failures = {}
+
+    # Find main template (prefer main.bicep, fall back to first .bicep file)
+    template = None
+    for f in bicep_files:
+        if os.path.basename(f) == "main.bicep":
+            template = f
+            break
+    if not template and bicep_files:
+        template = bicep_files[0]
+
+    if not template:
+        return 0, 0, 0, {"setup": "No .bicep template files found"}
+
+    # Find parameter file
+    param_file = None
+    for ext in (".bicepparam", ".parameters.json"):
+        for candidate in os.listdir(project_dir):
+            if candidate.endswith(ext):
+                param_file = candidate
+                break
+        if param_file:
+            break
+
+    cmd = [
+        "az", "deployment", "group", "what-if",
+        "--resource-group", resource_group,
+        "--template-file", template,
+        "--no-pretty-print",
+        "--output", "json",
+    ]
+    if param_file:
+        cmd.extend(["--parameters", f"@{param_file}"])
+
+    print(f"Running: az deployment group what-if --template-file {template}")
+    result = subprocess.run(
+        cmd, cwd=project_dir, capture_output=True, text=True, check=False
+    )
+
+    if result.returncode != 0:
+        error_msg = result.stderr.strip()[:160] if result.stderr else "Unknown error"
+        return 1, 0, 1, {"what-if": error_msg}
+
+    # Parse what-if JSON output
+    try:
+        data = json.loads(result.stdout)
+        changes = data.get("changes", [])
+
+        for change in changes:
+            total += 1
+            change_type = change.get("changeType", "unknown")
+            resource_id = change.get("resourceId", "unknown")
+            # Extract short name
+            parts = resource_id.split("/")
+            short_name = parts[-1] if parts else resource_id
+
+            if change_type in ("Create", "Modify", "NoChange", "Ignore"):
+                passed += 1
+            elif change_type == "Delete":
+                failed += 1
+                failures[short_name] = f"Resource will be DELETED ({change_type})"
+            else:
+                passed += 1
+
+    except (json.JSONDecodeError, KeyError) as e:
+        return 1, 0, 1, {"what-if-parse": f"Failed to parse what-if output: {e}"}
+
+    return total, passed, failed, failures
+
+
+# ---------------------------------------------------------------------------
+# Coverage calculation
+# ---------------------------------------------------------------------------
+
+def calculate_coverage(test_config, total_tests):
+    """
+    Calculate resource validation coverage.
+    Coverage = % of resource types that have at least one test/rule covering them.
+    """
+    resource_types = test_config["resource_types"]
+    if not resource_types:
+        return None
+
+    # If tests ran successfully, approximate coverage based on resource count vs test count
+    # A more accurate approach would parse PSRule/ARM-TTK output for per-resource-type coverage
+    if total_tests == 0:
+        return {"overall": 0.0, "per_module": []}
+
+    covered = min(total_tests, len(resource_types))
+    overall = (covered / len(resource_types)) * 100 if resource_types else 0.0
+
+    per_module = [f"Resources: {len(resource_types)} types"]
+    if test_config["has_psrule"]:
+        per_module.append("PSRule: active")
+    if test_config["has_arm_ttk"]:
+        per_module.append("ARM-TTK: active")
+
+    return {"overall": min(overall, 100.0), "per_module": per_module}
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_table(total, passed, failed, failures, coverage=None):
+    """Print results in pipeline contract format."""
+    if total == 0:
+        print("\nNo test results found. Check diagnostic info above.")
+        return
+
+    coverage_str = f" | Coverage: {coverage['overall']:.1f}%" if coverage else ""
+    print(f"\nSummary: Total: {total}, Passed: {passed}, Failed: {failed}{coverage_str}\n")
+
+    # Per-module coverage
+    if coverage and coverage.get("per_module"):
+        print("Coverage:  " + "  |  ".join(coverage["per_module"]))
+        print()
+
+    if failed == 0:
+        print("All tests passed.")
+        return
+
+    # Print failure table
+    if not failures:
+        print(f"{failed} test(s) failed. Run tests manually for details.\n")
+        return
+
+    tw = max(len(k) for k in failures.keys()) + 2
+    header = f"{'Test':<{tw}} {'Reason'}"
+    print(header)
+    print("-" * min(len(header) + 80, 140))
+
+    for test_id, reason in failures.items():
+        if reason:
+            print(f"{test_id:<{tw}} {reason}")
+        else:
+            print(f"{test_id:<{tw}} (no details captured)")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Bicep infrastructure tests in pipeline contract format."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument(
+        "--scheme",
+        default=None,
+        choices=["arm-ttk", "psrule", "what-if", "all"],
+        help="Test framework to run (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--resource-group",
+        default=None,
+        help="Azure resource group for what-if validation",
+    )
+    parser.add_argument(
+        "--no-coverage",
+        action="store_true",
+        help="Skip coverage calculation",
+    )
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    print(f"Project dir: {project_dir}")
+
+    if not os.path.isdir(project_dir):
+        print(f"ERROR: Project directory does not exist: {project_dir}")
+        sys.exit(1)
+
+    test_config = detect_test_config(project_dir)
+
+    print(f"Bicep files: {len(test_config['bicep_files'])}")
+    print(f"Test files:  {len(test_config['test_files'])}")
+    print(f"PSRule:      {'available' if test_config['has_psrule'] else 'not found'}")
+    print(f"ARM-TTK:     {'available' if test_config['has_arm_ttk'] else 'not found'}")
+    print(f"az CLI:      {'available' if test_config['has_az_cli'] else 'not found'}")
+    print(f"Pester:      {'available' if test_config['has_pester'] else 'not found'}")
+    if test_config["resource_types"]:
+        print(f"Resources:   {len(test_config['resource_types'])} unique types")
+
+    if not test_config["bicep_files"]:
+        print("\nWARNING: No .bicep files found.")
+        print("\nSummary: Total: 0, Passed: 0, Failed: 0 | Coverage: 0.0%")
+        sys.exit(0)
+
+    # Determine which test frameworks to run
+    total = 0
+    passed = 0
+    failed = 0
+    all_failures = {}
+
+    schemes_to_run = []
+    if args.scheme:
+        if args.scheme == "all":
+            schemes_to_run = ["psrule", "arm-ttk", "what-if"]
+        else:
+            schemes_to_run = [args.scheme]
+    else:
+        # Auto-detect: run what's available
+        if test_config["has_psrule"]:
+            schemes_to_run.append("psrule")
+        if test_config["has_arm_ttk"]:
+            schemes_to_run.append("arm-ttk")
+        # Only auto-run what-if if a resource group was specified
+        if args.resource_group and test_config["has_az_cli"]:
+            schemes_to_run.append("what-if")
+
+    if not schemes_to_run:
+        print("\nWARNING: No test framework available.")
+        print("Install PSRule for Azure or ARM-TTK, or specify --resource-group for what-if.")
+        print("\nSummary: Total: 0, Passed: 0, Failed: 0 | Coverage: 0.0%")
+        sys.exit(0)
+
+    for scheme in schemes_to_run:
+        print(f"\n--- Running: {scheme} ---")
+
+        if scheme == "psrule":
+            if not test_config["has_psrule"]:
+                print("PSRule not available. Skipping.")
+                continue
+            t, p, f, failures = run_psrule(
+                project_dir,
+                test_config["bicep_files"],
+                test_config["psrule_config"],
+            )
+        elif scheme == "arm-ttk":
+            if not test_config["has_arm_ttk"]:
+                print("ARM-TTK not available. Skipping.")
+                continue
+            t, p, f, failures = run_arm_ttk(
+                project_dir, test_config["bicep_files"]
+            )
+        elif scheme == "what-if":
+            if not test_config["has_az_cli"]:
+                print("az CLI not available. Skipping.")
+                continue
+            if not args.resource_group:
+                print("No --resource-group specified. Skipping what-if.")
+                continue
+            t, p, f, failures = run_what_if(
+                project_dir, test_config["bicep_files"], args.resource_group
+            )
+        else:
+            continue
+
+        total += t
+        passed += p
+        failed += f
+        all_failures.update(failures)
+
+    # Calculate coverage
+    coverage = None
+    if not args.no_coverage:
+        coverage = calculate_coverage(test_config, total)
+
+    print_table(total, passed, failed, all_failures, coverage=coverage)
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/bicep/test-overlay.md
+++ b/adapters/bicep/test-overlay.md
@@ -1,0 +1,113 @@
+# Bicep Test Patterns
+
+## ARM-TTK (Template Test Toolkit) Patterns
+
+Validate ARM template correctness and best practices:
+
+### Test Structure
+- ARM-TTK tests run against compiled ARM JSON (Bicep compiles to ARM before validation)
+- Tests organized by category: deployment template tests, parameter file tests, createUIDefinition tests
+- Run via PowerShell: `Test-AzTemplate -TemplatePath ./main.bicep`
+- Each test returns Pass/Fail with descriptive messages
+
+### Built-in Test Categories
+- **Template validation**: Valid JSON structure, required properties, correct API versions
+- **Parameter validation**: Every parameter used, no hardcoded values, secure handling
+- **Resource validation**: Correct resource types, valid locations, proper dependencies
+- **Output validation**: No secrets in outputs, valid output expressions
+
+### Custom ARM-TTK Tests
+- Place custom test scripts in `arm-ttk/testcases/deploymentTemplate/` directory
+- Test functions follow naming convention: `<TestName>.test.ps1`
+- Use `Test-AzTemplate -Test <TestName>` to run specific tests
+
+## PSRule for Azure Patterns
+
+Cloud-native validation using Azure Well-Architected Framework rules:
+
+### Configuration
+- Configure in `ps-rule.yaml` at project root:
+  ```yaml
+  binding:
+    targetType:
+      - type
+      - resourceType
+  rule:
+    include:
+      - Azure.*
+  configuration:
+    AZURE_BICEP_FILE_EXPANSION: true
+    AZURE_PARAMETER_FILE_EXPANSION: true
+  ```
+
+### Rule Categories
+- **Security baseline**: Encryption, network isolation, identity, access control
+- **Cost optimization**: SKU selection, scaling configuration, resource sharing
+- **Reliability**: Availability zones, redundancy, backup, health checks
+- **Operational excellence**: Diagnostics, monitoring, tagging, naming
+
+### Custom Rules
+- Define in `.ps-rule/` directory with `.Rule.yaml` or `.Rule.ps1` extension
+- Reference Azure resource types for targeting
+- Use `Assert` for validation conditions with descriptive failure messages
+
+### Baselines
+- Use `Azure.Default` baseline for standard checks
+- Create custom baselines to include/exclude specific rules
+- Override rule configuration per environment via parameter files
+
+## What-If Dry Run Patterns
+
+Validate deployment impact without making changes:
+
+### Running What-If
+- Resource group scope: `az deployment group what-if --resource-group <rg> --template-file main.bicep --parameters @dev.bicepparam`
+- Subscription scope: `az deployment sub what-if --location <loc> --template-file main.bicep`
+- Interpret change types:
+  - **Create**: New resource will be provisioned
+  - **Delete**: Existing resource will be removed (danger — verify intent)
+  - **Modify**: Existing resource properties will change (review property diff)
+  - **NoChange**: Resource exists and matches template (ideal state)
+  - **Ignore**: Resource exists but is not managed by this template
+  - **Deploy**: Resource will be deployed (what-if cannot determine if it changes)
+
+### Validation Tests from What-If
+- Assert expected create/modify counts match planned changes
+- Flag any unexpected Delete operations
+- Verify no NoChange resources are being unnecessarily redeployed
+- Check that sensitive properties are not changing unexpectedly
+
+## Deployment Validation Tests (Post-Deploy)
+
+Verify deployed resources match expected state:
+
+### Pester Integration Tests
+- Test file naming: `*.Tests.ps1` in a `tests/` directory
+- Test structure:
+  ```powershell
+  Describe "Storage Account" {
+      It "should exist" {
+          $sa = Get-AzStorageAccount -ResourceGroupName $rg -Name $name
+          $sa | Should -Not -BeNullOrEmpty
+      }
+      It "should enforce HTTPS" {
+          $sa.EnableHttpsTrafficOnly | Should -Be $true
+      }
+  }
+  ```
+- Group tests by resource type or functional area
+- Use `BeforeAll` blocks for resource lookup, share across tests in a `Describe` block
+
+### az CLI Validation
+- Use `az resource show` to verify resource existence and properties
+- Use `az monitor diagnostic-settings list` to verify monitoring
+- Use `az network nsg rule list` to verify network security
+- Parse JSON output with `--query` (JMESPath) for specific assertions
+
+## Anti-Patterns to Avoid
+- Don't skip what-if validation before deploying to any environment
+- Don't rely solely on ARM-TTK — it checks syntax, not architecture (use PSRule for that)
+- Don't write post-deployment tests that duplicate what-if validation (test actual behavior instead)
+- Don't hardcode resource group names or subscription IDs in test scripts — parameterize them
+- Don't test individual resource properties already covered by PSRule baselines — focus on custom business rules
+- Don't run what-if against production without verifying parameter files match the target environment

--- a/docs/azure-guide.md
+++ b/docs/azure-guide.md
@@ -1,0 +1,501 @@
+# Azure Deployment Guide
+
+How to use the Claude Code Pipeline for projects that deploy to Azure. Covers the Bicep adapter for Infrastructure as Code, the Azure SDK overlay for application code, Azure authentication, and the 7 Azure-specific skills.
+
+## Who This Is For
+
+Developers building applications or infrastructure that deploy to Azure. Your repo might contain:
+
+- **Bicep templates** (`main.bicep`, `modules/*.bicep`) for infrastructure provisioning
+- **Application code** (Python, TypeScript, .NET) that uses Azure SDK to talk to Azure services
+- **Both** — a full-stack project with app code + IaC in the same repo
+
+The pipeline handles each scenario differently:
+
+| Scenario | Adapter | Overlay | What You Get |
+|----------|---------|---------|-------------|
+| Bicep IaC only | `bicep` | `azure-sdk` (auto) | Bicep build/lint/test + all 7 Azure skills |
+| Python app + Azure SDK | `python` | `azure-sdk` (auto) | Python pipeline + Azure SDK review rules + Azure skills |
+| React app + Azure SDK | `react` | `azure-sdk` (auto) | React pipeline + Azure SDK review rules + Azure skills |
+| Bicep + Python app in same repo | `bicep` or `python` | `azure-sdk` (auto) | Choose primary stack; Azure overlay adds cross-cutting rules |
+
+## Quick Start
+
+### 1. Bootstrap
+
+```bash
+# Clone the pipeline
+git clone https://github.com/swtarmey/claude-code-pipeline.git .claude/pipeline
+
+# Bootstrap — auto-detects Bicep from .bicep files or bicepconfig.json
+bash .claude/pipeline/init.sh .
+```
+
+If your project has both Bicep and Python files, the auto-detector picks Bicep (it checks before Python). To override:
+
+```bash
+bash .claude/pipeline/init.sh . --stack=python   # Use Python adapter, Azure SDK overlay auto-detected
+bash .claude/pipeline/init.sh . --stack=bicep     # Use Bicep adapter explicitly
+```
+
+### 2. Verify Azure detection
+
+Check `.claude/pipeline.config`:
+
+```ini
+stack=bicep
+pipeline_root=/path/to/claude-code-pipeline
+overlays=azure-sdk
+initialized=2026-03-29T12:00:00Z
+```
+
+The `overlays=azure-sdk` line means the Azure SDK overlay was detected. If it's missing and you're deploying to Azure, add it manually.
+
+### 3. Authenticate
+
+```bash
+az login
+az account set --subscription "My Dev Subscription"
+```
+
+Then verify from within Claude Code:
+
+```
+/azure-login
+```
+
+This validates your auth state, shows the active subscription, and caches the result for the session.
+
+### 4. Run the pipeline
+
+```
+/orchestrate
+```
+
+The pipeline flows exactly as documented in the main README. For Bicep projects, the implementer writes `.bicep` files, the reviewer checks for Azure security/cost/reliability patterns, and build/test runs `bicep build` + PSRule/ARM-TTK.
+
+## Azure Authentication
+
+### How Auth Works in the Pipeline
+
+The pipeline **does not manage your Azure credentials**. It validates that you're authenticated and targeting the right subscription before running any Azure-dependent operation.
+
+The `azure-login` skill runs a 6-step pre-flight check:
+
+1. **az CLI installed?** — If not, shows install instructions for your platform
+2. **Authenticated?** — If not, shows login options (interactive, service principal, managed identity, GitHub Actions OIDC)
+3. **Display context** — Shows subscription, tenant, user, auth method
+4. **Correct subscription?** — Validates the active subscription if a target is known
+5. **Resource group exists?** — Checks the target RG (advisory, non-blocking)
+6. **Sufficient permissions?** — Verifies RBAC roles for the operation type
+
+### When Auth Is Checked
+
+Auth is checked **lazily** — only before the first Azure-dependent step, not at pipeline start. This means:
+
+- `bicep build` / `bicep lint` — **No auth needed** (local operations)
+- PSRule / ARM-TTK template validation — **No auth needed** (local operations)
+- Security scan (PSRule/Checkov) — **No auth needed** (local operations)
+- Cost estimate — **No auth needed** (public pricing API)
+- `az deployment group what-if` — **Auth required** (queries Azure Resource Manager)
+- `deploy-bicep` — **Auth required** (creates/modifies resources)
+- `azure-drift-check` — **Auth required** (reads deployed state)
+- Post-deploy infrastructure tests — **Auth required** (reads deployed state)
+
+If you're only doing local build/lint/review cycles, you'll never be asked to authenticate.
+
+### Auth Methods
+
+**Local development (most common):**
+```bash
+az login                                    # Opens browser for interactive login
+az account set --subscription "My Dev Sub"  # Set target subscription
+```
+
+**Service principal (CI/CD):**
+```bash
+az login --service-principal \
+  -u $AZURE_CLIENT_ID \
+  -p $AZURE_CLIENT_SECRET \
+  --tenant $AZURE_TENANT_ID
+```
+
+**Managed identity (Azure-hosted runners):**
+```bash
+az login --identity
+```
+
+**GitHub Actions (OIDC — recommended for CI):**
+```yaml
+- uses: azure/login@v2
+  with:
+    client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+
+### Required RBAC Roles
+
+| Operation | Minimum Role | Scope |
+|-----------|-------------|-------|
+| What-if / drift check | Reader | Target resource group |
+| Deploy (incremental) | Contributor | Target resource group |
+| Deploy (complete mode) | Contributor | Target resource group |
+| Role assignments in template | Owner or User Access Administrator | Target resource group |
+
+### Multiple Subscriptions
+
+If you have access to dev, staging, and prod subscriptions, the pipeline shows which one is active and asks for confirmation before any deployment. To switch:
+
+```bash
+az account set --subscription "My Staging Subscription"
+```
+
+Or run `/azure-login` to see all available subscriptions.
+
+## The Bicep Adapter
+
+### What It Does
+
+The Bicep adapter teaches the pipeline's 4 generic agents about Infrastructure as Code:
+
+| Agent | What the Bicep overlay adds |
+|-------|---------------------------|
+| **Architect** | Module decomposition patterns, scope hierarchy (subscription/RG/management group), resource dependency chains, hub-spoke networking, environment parameterization |
+| **Implementer** | Naming conventions (camelCase params, PascalCase resources), `@description`/`@secure` decorators, API version policy, module patterns, conditional deployments, Key Vault references |
+| **Reviewer** | 8-category checklist: security (RBAC, private endpoints, encryption), cost (SKU, auto-scale, tagging), reliability (availability zones, backups, locks), module boundaries, parameter validation, output contracts, dependency chains, naming |
+| **Test architect** | ARM-TTK patterns, PSRule baselines, what-if interpretation, post-deploy Pester tests |
+
+### Build Script
+
+`python3 .claude/scripts/build.py` runs:
+
+1. **`bicep lint`** (via `az bicep lint` or `bicep build` with `bicepconfig.json` rules)
+2. **`bicep build`** (compiles each `.bicep` to ARM JSON)
+
+Output follows the standard pipeline contract:
+```
+BUILD SUCCEEDED  |  2 warning(s)
+```
+or:
+```
+BUILD FAILED  |  1 error(s)  |  2 warning(s)
+
+File                      Ln  Error
+-------------------------------------------------------
+main.bicep                18  [BCP035] missing required property "location"
+```
+
+### Test Script
+
+`python3 .claude/scripts/test.py` auto-detects and runs available frameworks:
+
+| Framework | Detection | What it tests |
+|-----------|----------|--------------|
+| **PSRule for Azure** | `ps-rule.yaml` or PowerShell module | Azure Well-Architected Framework rules (security, cost, reliability) |
+| **ARM-TTK** | PowerShell module | Template syntax, parameters, resource types |
+| **What-if** | `az` CLI + `--resource-group` flag | Deployment impact (requires Azure auth) |
+
+Output follows the standard test contract:
+```
+Summary: Total: 18, Passed: 18, Failed: 0 | Coverage: 83.3%
+```
+
+### Project Structure
+
+The adapter expects a typical Bicep project layout:
+
+```
+your-project/
+|-- main.bicep                    # Entry point
+|-- bicepconfig.json              # Linter configuration
+|-- modules/
+|   |-- storage.bicep             # Reusable module
+|   |-- networking.bicep
+|   +-- keyvault.bicep
+|-- dev.bicepparam                # Dev environment parameters
+|-- staging.bicepparam            # Staging parameters
+|-- prod.bicepparam               # Production parameters
++-- tests/
+    +-- infra.Tests.ps1           # Pester integration tests (optional)
+```
+
+## The Azure SDK Overlay
+
+### What It Does
+
+The Azure SDK overlay is a **cross-cutting concern** that layers onto any adapter. When the pipeline detects Azure SDK packages in your project dependencies, it automatically activates.
+
+This means a Python + Azure project gets both:
+- Python adapter overlays (type hints, pytest patterns, Django/FastAPI conventions)
+- Azure SDK overlays (DefaultAzureCredential, retry policies, Key Vault, managed identity)
+
+### How It's Detected
+
+`init.sh` checks for Azure SDK packages in:
+
+| Stack | Detection |
+|-------|----------|
+| Python | `azure-*` in `requirements.txt` or `pyproject.toml` |
+| Node/JS | `@azure/*` in `package.json` |
+| .NET | `Azure.*` NuGet packages in `*.csproj` |
+| Bicep | Always activated (implicit) |
+
+### What It Adds
+
+**For the architect:** Azure service integration patterns (Service Bus, Cosmos DB, Blob Storage), managed identity design, Key Vault integration, multi-region patterns.
+
+**For the implementer:** `DefaultAzureCredential` as the standard auth chain, client reuse/singleton patterns, retry policy configuration, Key Vault secret retrieval, connection strings from Key Vault only, proper client disposal.
+
+**For the reviewer:** 5 additional review categories layered on top of the adapter's existing categories:
+1. Authentication — managed identity over keys, DefaultAzureCredential, no hardcoded secrets
+2. Retry & Resilience — retry policies, circuit breakers, timeouts
+3. Resource Lifecycle — client disposal, connection pooling, no leaked connections
+4. Security — Key Vault for secrets, RBAC over access keys, no secrets in logs
+5. Cost & Performance — client reuse, batch operations, tagging
+
+### Manual Activation
+
+If auto-detection missed your Azure SDK usage, add it to `pipeline.config`:
+
+```ini
+overlays=azure-sdk
+```
+
+Or re-run init with a project that has Azure packages in its dependencies.
+
+## Azure Skills Reference
+
+### `/azure-login` — Authentication Pre-Flight
+
+Validates Azure auth state, subscription context, and permissions. Run before any Azure-dependent operation, or let the orchestrator call it automatically.
+
+```
+> /azure-login
+
+AZURE CONTEXT
+  Subscription:  My Dev Subscription (xxxxxxxx-...)
+  Tenant:        Contoso (xxxxxxxx-...)
+  User:          dev@contoso.com
+  Auth method:   Interactive (az login)
+
+AZURE AUTH OK | Subscription: My Dev Subscription (xxxxxxxx-...) | User: dev@contoso.com | Method: interactive
+```
+
+### `/validate-bicep` — Lint, Build, and What-If
+
+Validates Bicep templates without deploying. The what-if step is optional and requires Azure auth.
+
+```
+> /validate-bicep
+
+BUILD SUCCEEDED  |  0 warning(s)
+
+WHAT-IF SUMMARY | Create: 2, Modify: 1, Delete: 0, NoChange: 3
+```
+
+### `/deploy-bicep` — Deploy with Confirmation Gate
+
+Deploys Bicep templates to Azure. **Always** shows a what-if preview and requires explicit confirmation.
+
+```
+> /deploy-bicep
+
+What-if results for rg-staging:
+  Create: myStorageAccount (Microsoft.Storage/storageAccounts)
+  Modify: myKeyVault (Microsoft.KeyVault/vaults)
+  NoChange: 3 resources
+
+Proceed with deployment to rg-staging? (yes/no)
+> yes
+
+DEPLOY SUCCEEDED | 1 resources created | 1 modified
+```
+
+The confirmation gate is mandatory and cannot be bypassed. The pipeline will never deploy without an explicit "yes" in the same conversation turn.
+
+### `/azure-cost-estimate` — Monthly Cost Estimation
+
+Parses Bicep templates, extracts resource types and SKUs, and queries the Azure Retail Pricing API. No Azure auth required.
+
+```
+> /azure-cost-estimate
+
+COST ESTIMATE | Total: $284.50/month
+
+Resource                   Type                                SKU          Est. Monthly
+──────────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount           Microsoft.Storage/storageAccounts   Standard_LRS $21.00
+myAppServicePlan           Microsoft.Web/serverfarms           P1v3         $138.00
+myCosmosDb                 Microsoft.DocumentDB/databaseAccts  Standard     $25.00-$500.00*
+
+* Consumption-based resources show estimate ranges.
+```
+
+### `/security-scan` — Security and Compliance Scanning
+
+Runs PSRule for Azure or Checkov against Bicep templates. No Azure auth required.
+
+```
+> /security-scan
+
+SECURITY SCAN | Total: 4 findings | Critical: 1, High: 1, Medium: 2, Low: 0
+
+Rule                          Severity  Resource            Description
+───────────────────────────────────────────────────────────────────────────
+Azure.SQL.FirewallIPRange     CRITICAL  mySqlServer         Firewall allows 0.0.0.0-255.255.255.255
+Azure.Storage.MinTLS          HIGH      myStorageAccount    TLS version below 1.2
+```
+
+### `/infra-test-runner` — Infrastructure Tests
+
+Runs ARM-TTK template validation, Pester integration tests, or post-deploy resource checks. Template validation is local; post-deploy tests require Azure auth.
+
+```
+> /infra-test-runner
+
+Summary: Total: 18, Passed: 15, Failed: 3 | Coverage: 83.3%
+
+Test                              Result   Time
+───────────────────────────────────────────────────
+Storage.MinTLS                    PASSED   0.8s
+KeyVault.SoftDelete               PASSED   0.6s
+Network.NSGRules                  FAILED   1.2s
+   Expected: DenyAllInbound rule present, Actual: no deny-all rule found
+```
+
+### `/azure-drift-check` — Configuration Drift Detection
+
+Compares deployed Azure resource state against Bicep templates. Requires Azure auth.
+
+```
+> /azure-drift-check
+
+DRIFT CHECK | Total: 5 resources | Drifted: 2, Compliant: 2, Missing: 1
+
+Resource              Property               Expected    Actual      Status
+──────────────────────────────────────────────────────────────────────────────
+myStorageAccount      minimumTlsVersion      TLS1_2      TLS1_0      DRIFTED
+myKeyVault            enableSoftDelete       true        false       DRIFTED
+myAppServicePlan      —                      Standard_S1 —           MISSING
+```
+
+## Workflows
+
+### Workflow 1: Building a New Bicep Module
+
+You're adding a new storage module to your IaC project.
+
+```
+> Add a storage account module with blob containers, private endpoint, and diagnostic settings
+
+Pipeline runs:
+  1a. Architect analyzes: module boundaries, dependency on networking + Key Vault modules
+  1b. Plan: 4 Haiku tasks (module, params, outputs, param file) + 1 Sonnet (networking integration)
+  1.5. Opens draft PR
+  2.  Implements each task with bicep build + PSRule validation
+  2.1. Reviews: checks @secure on connection strings, private endpoint config, tagging
+  3.  Commits each task
+  3.5. You test: /validate-bicep, /security-scan, /azure-cost-estimate
+  4.  Finalizes PR
+```
+
+### Workflow 2: Adding Azure SDK Integration to a Python App
+
+You're adding Cosmos DB integration to an existing Python API.
+
+```
+> Add Cosmos DB client for user profile storage using DefaultAzureCredential
+
+Pipeline runs with Python adapter + Azure SDK overlay:
+  1a. Architect considers: DefaultAzureCredential chain, retry policies, connection pooling
+  1b. Plan: CosmosDB client wrapper (Sonnet), CRUD operations (Haiku x3), tests (Haiku x2)
+  2.  Implements with Python + Azure SDK rules enforced
+  2.1. Reviews: checks client reuse, retry config, no hardcoded keys, proper disposal
+```
+
+### Workflow 3: Pre-Deployment Validation
+
+Before deploying to staging, run the validation skills standalone:
+
+```
+/security-scan              # Check for misconfigurations
+/azure-cost-estimate        # Verify cost is within budget
+/validate-bicep             # Lint + build + what-if preview
+/azure-drift-check          # Check if staging has drifted from templates
+/deploy-bicep               # Deploy (with confirmation gate)
+/infra-test-runner           # Post-deploy validation
+```
+
+### Workflow 4: Investigating Production Drift
+
+Something changed in production outside of your templates:
+
+```
+> /azure-login                 # Verify you're on the prod subscription
+> /azure-drift-check           # Compare deployed state vs templates
+
+DRIFT CHECK | Total: 12 resources | Drifted: 3, Compliant: 8, Missing: 1
+
+# Fix the drift by updating templates to match desired state, then:
+> /orchestrate                 # Pipeline plans + implements the template updates
+> /validate-bicep              # Verify the fix
+> /deploy-bicep                # Deploy the corrected templates
+```
+
+## Tips
+
+### Keeping Bicep and App Code in Sync
+
+If your repo has both Bicep templates and application code:
+
+1. Bootstrap with the adapter matching your **primary development activity**
+2. The Azure SDK overlay activates automatically for both stacks
+3. Use `/orchestrate` for your primary stack's changes
+4. Use the Azure skills (`/validate-bicep`, `/deploy-bicep`, etc.) directly for IaC changes
+
+### Environment-Specific Deployments
+
+Use parameter files to target different environments:
+
+```bash
+# Dev (default — safe to experiment)
+/deploy-bicep   # Uses dev.bicepparam by default
+
+# Staging (requires confirmation)
+# Tell the pipeline: "deploy to staging using staging.bicepparam"
+
+# Production (requires explicit subscription switch + double confirmation)
+az account set --subscription "Production"
+/azure-login    # Re-validates auth on new subscription
+/deploy-bicep   # Shows what-if, requires confirmation
+```
+
+### Cost Control
+
+Run `/azure-cost-estimate` before deploying to catch:
+- Over-provisioned SKUs (Premium when Standard suffices)
+- Resources that should use reserved pricing
+- Missing cost allocation tags
+- Accidental duplicate resources
+
+### Security Hardening
+
+Run `/security-scan` as part of your review process to catch:
+- Public endpoints without private endpoints
+- Missing encryption at rest or in transit
+- Overly permissive firewall rules
+- Missing diagnostic settings
+- Hardcoded secrets or connection strings
+
+## Requirements
+
+In addition to the [base pipeline requirements](../README.md#requirements):
+
+- **Azure CLI** (`az`) — for deployments, what-if, drift checks
+- **Bicep CLI** (`bicep`) — standalone or via `az bicep` (included with az CLI)
+- **PowerShell 7+** (`pwsh`) — for ARM-TTK and PSRule (optional, for testing)
+- **PSRule for Azure** — `Install-Module PSRule.Rules.Azure` (optional, for security scanning)
+- **ARM-TTK** — `Install-Module arm-ttk` (optional, for template validation)
+
+None of the optional tools are required for basic `bicep build`/`bicep lint` — they extend the testing and scanning capabilities.

--- a/init.sh
+++ b/init.sh
@@ -4,7 +4,7 @@
 # Bootstrap script: links the pipeline into a target project's .claude/ directory
 #
 # Usage:
-#   bash init.sh /path/to/project [--stack=swift-ios|react|python] [--force]
+#   bash init.sh /path/to/project [--stack=swift-ios|react|python|bicep] [--force]
 #
 
 set -euo pipefail
@@ -28,7 +28,7 @@ Arguments:
   project-dir          Path to the target project root
 
 Options:
-  --stack=<name>       Force a specific adapter (swift-ios, react, python)
+  --stack=<name>       Force a specific adapter (swift-ios, react, python, bicep)
                        Auto-detected from project files if omitted
   --force              Overwrite existing symlinks and config
   --help               Show this help message
@@ -88,6 +88,21 @@ detect_stack() {
         return
     fi
 
+    # Check for Bicep (before Python — a Bicep project may have requirements.txt for tooling)
+    # Check root, infra/, infrastructure/, deploy/ for .bicep files
+    for bicep_dir in "$dir" "$dir/infra" "$dir/infrastructure" "$dir/deploy" "$dir/modules"; do
+        for f in "$bicep_dir"/*.bicep; do
+            if [ -e "$f" ]; then
+                echo "bicep"
+                return
+            fi
+        done
+    done
+    if [ -f "$dir/bicepconfig.json" ]; then
+        echo "bicep"
+        return
+    fi
+
     # Check for React (package.json with react dependency)
     if [ -f "$dir/package.json" ]; then
         if grep -q '"react"' "$dir/package.json" 2>/dev/null; then
@@ -113,10 +128,56 @@ detect_stack() {
     echo ""
 }
 
+detect_overlays() {
+    local dir="$1"
+    local stack="$2"
+    local overlays=""
+
+    # Bicep adapter always implies Azure SDK overlay
+    if [ "$stack" = "bicep" ]; then
+        overlays="azure-sdk"
+        echo "$overlays"
+        return
+    fi
+
+    # Check Python dependencies for Azure SDK
+    if [ -f "$dir/requirements.txt" ]; then
+        if grep -qE '^azure-' "$dir/requirements.txt" 2>/dev/null; then
+            overlays="azure-sdk"
+        fi
+    fi
+    if [ -z "$overlays" ] && [ -f "$dir/pyproject.toml" ]; then
+        if grep -q 'azure-' "$dir/pyproject.toml" 2>/dev/null; then
+            overlays="azure-sdk"
+        fi
+    fi
+
+    # Check Node/JS dependencies for Azure SDK
+    if [ -z "$overlays" ] && [ -f "$dir/package.json" ]; then
+        if grep -q '"@azure/' "$dir/package.json" 2>/dev/null; then
+            overlays="azure-sdk"
+        fi
+    fi
+
+    # Check .NET dependencies for Azure SDK
+    if [ -z "$overlays" ]; then
+        for csproj in "$dir"/*.csproj; do
+            if [ -e "$csproj" ]; then
+                if grep -qE 'Include="Azure\.' "$csproj" 2>/dev/null; then
+                    overlays="azure-sdk"
+                    break
+                fi
+            fi
+        done
+    fi
+
+    echo "$overlays"
+}
+
 if [ -z "$STACK" ]; then
     STACK=$(detect_stack "$PROJECT_DIR")
     if [ -z "$STACK" ]; then
-        error "Could not auto-detect tech stack. Use --stack=<name> to specify.\nAvailable: swift-ios, react, python"
+        error "Could not auto-detect tech stack. Use --stack=<name> to specify.\nAvailable: swift-ios, react, python, bicep"
     fi
     info "Auto-detected stack: $STACK"
 else
@@ -126,7 +187,12 @@ fi
 ADAPTER_DIR="$PIPELINE_ROOT/adapters/$STACK"
 [ -d "$ADAPTER_DIR" ] || error "Adapter not found: $ADAPTER_DIR"
 
-# --- Step 3: Write pipeline.config ---
+# --- Step 3: Detect overlays and write pipeline.config ---
+OVERLAYS=$(detect_overlays "$PROJECT_DIR" "$STACK")
+if [ -n "$OVERLAYS" ]; then
+    info "Detected overlay(s): $OVERLAYS"
+fi
+
 CONFIG_FILE="$CLAUDE_DIR/pipeline.config"
 if [ -f "$CONFIG_FILE" ] && [ "$FORCE" = false ]; then
     info "pipeline.config already exists. Use --force to overwrite."
@@ -140,6 +206,9 @@ stack=$STACK
 
 # Absolute path to the pipeline repo
 pipeline_root=$PIPELINE_ROOT
+
+# Cross-cutting overlays (comma-separated, empty if none)
+overlays=$OVERLAYS
 
 # Date this config was generated
 initialized=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -190,6 +259,14 @@ create_symlink "$PIPELINE_ROOT/skills" "$CLAUDE_DIR/skills" "skills"
 
 # Scripts (adapter-specific)
 create_symlink "$ADAPTER_DIR/scripts" "$CLAUDE_DIR/scripts" "scripts"
+
+# Overlays (cross-cutting, only when detected)
+if [ -n "$OVERLAYS" ]; then
+    OVERLAYS_DIR="$PIPELINE_ROOT/overlays"
+    if [ -d "$OVERLAYS_DIR" ]; then
+        create_symlink "$OVERLAYS_DIR" "$CLAUDE_DIR/overlays" "overlays"
+    fi
+fi
 
 # --- Step 5: Merge hooks into settings.json ---
 ADAPTER_HOOKS="$ADAPTER_DIR/hooks.json"
@@ -265,9 +342,15 @@ echo "  Symlinks:"
 echo "    .claude/agents  -> pipeline/agents"
 echo "    .claude/skills  -> pipeline/skills"
 echo "    .claude/scripts -> pipeline/adapters/$STACK/scripts"
+if [ -n "$OVERLAYS" ]; then
+echo "    .claude/overlays -> pipeline/overlays"
+fi
 echo ""
 echo "  Config:     .claude/pipeline.config"
 echo "  Hooks:      .claude/settings.json"
+if [ -n "$OVERLAYS" ]; then
+echo "  Overlays:   $OVERLAYS"
+fi
 echo ""
 echo "  Next steps:"
 echo "    1. Edit .claude/CLAUDE.md with your project description"

--- a/overlays/azure-sdk/architect-overlay.md
+++ b/overlays/azure-sdk/architect-overlay.md
@@ -1,0 +1,76 @@
+# Azure SDK Architect Context
+
+## Project Context
+
+This project integrates with Azure services via the Azure SDK. When planning, account for:
+- Azure service dependencies and their availability/latency characteristics
+- Authentication chain design — managed identity is the default, fallback strategies must be explicit
+- Network topology constraints — private endpoints, VNet integration, DNS resolution
+- The 4-file rule: tasks touching more than 3 files must be split into smaller tasks
+
+## Azure Service Integration Patterns
+
+When planning tasks that involve Azure services, account for their specific integration complexity:
+
+### Service Bus
+- **Single queue/topic sender or receiver** (Haiku): Sending or receiving messages from a known queue/topic with a configured client
+- **Session-based messaging** (Sonnet): Ordered message processing, session state management, session lock renewal
+- **Dead-letter queue processing and poison message handling** (Sonnet): DLQ monitoring, retry policies, alerting on DLQ depth
+- **Cross-service message choreography** (Opus): Saga patterns, compensation logic, multi-topic event flows
+
+### Event Grid
+- **Single event subscription handler** (Haiku): Webhook endpoint receiving a known event type
+- **Custom event schema design** (Sonnet): Event type taxonomy, schema versioning, filtering rules
+- **Multi-source event routing** (Sonnet/Opus): System topics + custom topics, dead-letter destinations, event delivery guarantees
+
+### Cosmos DB
+- **Single container CRUD operations** (Haiku): Point reads, upserts, simple queries against a known container
+- **Partition key strategy and data modeling** (Sonnet): Access patterns, partition key selection, denormalization decisions
+- **Cross-partition queries and change feed processing** (Sonnet): Fan-out queries, change feed processors, materialized views
+- **Multi-region write conflict resolution** (Opus): Conflict resolution policies, consistency level selection, failover handling
+
+### Blob Storage
+- **Single blob upload/download** (Haiku): Uploading or downloading a known blob with a configured client
+- **Lifecycle management and tiering** (Sonnet): Hot/cool/archive policies, access patterns, cost optimization
+- **Event-driven blob processing pipelines** (Sonnet): Blob triggers, Event Grid integration, large file chunked uploads
+
+### App Configuration
+- **Reading feature flags or configuration values** (Haiku): Single key-value retrieval with a configured client
+- **Feature flag design and configuration schema** (Sonnet): Feature flag taxonomy, label strategy, configuration refresh patterns
+- **Dynamic configuration with Sentinel keys** (Sonnet): Configuration refresh triggers, cache invalidation, multi-environment label strategy
+
+## Managed Identity Design
+
+- **System-assigned identity** (Haiku): Enable on a single resource, assign a role — use when the resource has a 1:1 relationship with its identity
+- **User-assigned identity** (Sonnet): Create a shared identity, assign to multiple resources — use when multiple resources need the same permissions or when identity must survive resource recreation
+- **Role assignment patterns** (Sonnet): Principle of least privilege, scope role assignments to specific resources (not resource groups), use built-in roles over custom where possible
+- **Cross-subscription identity** (Opus): Federated identity, cross-tenant access, workload identity federation for CI/CD
+
+## Key Vault Integration
+
+- **Secret retrieval** (Haiku): Using `SecretClient` to read a known secret with caching
+- **Key/certificate management** (Sonnet): Key rotation strategy, certificate auto-renewal, versioning
+- **Reference patterns** (Sonnet): App Configuration Key Vault references, App Service Key Vault references, resolving at startup vs on-demand
+- **Access policies vs RBAC** (Sonnet): Prefer RBAC model over access policies, scope permissions per secret/key/certificate
+
+## Network Architecture
+
+- **Private endpoint for a single service** (Haiku): Creating a private endpoint connection and DNS record for one Azure service
+- **VNet integration design** (Sonnet): Subnet planning, service endpoints vs private endpoints, NSG rules for Azure service traffic
+- **DNS resolution for private endpoints** (Sonnet): Private DNS zones, DNS forwarding, hybrid DNS with on-premises
+- **Multi-region networking** (Opus): VNet peering, hub-spoke topology, Traffic Manager/Front Door routing, cross-region private endpoint access
+
+## Multi-Region Patterns
+
+- **Active-passive failover** (Sonnet): Primary region with standby, data replication, manual or automated failover
+- **Active-active** (Opus): Traffic Manager/Front Door routing, data consistency across regions, conflict resolution
+- **Geo-replication** (Sonnet): Cosmos DB multi-region writes, Storage GRS/GZRS, SQL geo-replication
+- **Traffic Manager vs Front Door** (Sonnet): DNS-based vs proxy-based routing, Layer 4 vs Layer 7, caching and WAF considerations
+
+## Azure SDK Decomposition Notes
+
+- Single-service integrations are natural Haiku boundaries — define the client configuration (Sonnet if non-trivial), then implement each operation as a separate Haiku task
+- Authentication design is always Sonnet (choosing the credential chain, role assignments, Key Vault access); using `DefaultAzureCredential` in a client is Haiku
+- Cross-service orchestration (e.g., Service Bus trigger that writes to Cosmos DB and publishes to Event Grid) is Sonnet — each individual service call is Haiku but the coordination logic requires judgment
+- Multi-region architecture is always Opus; single-region deployment of an already-designed pattern is Sonnet
+- Retry and resilience policy design is Sonnet; applying a configured retry policy to a client is Haiku

--- a/overlays/azure-sdk/implementer-overlay-essential.md
+++ b/overlays/azure-sdk/implementer-overlay-essential.md
@@ -1,0 +1,14 @@
+# Azure SDK Essential Rules
+
+Critical rules for Haiku execution. Violations will fail code review.
+
+- Always use `DefaultAzureCredential` — never hardcode keys or connection strings
+- Reuse SDK clients (singleton/scoped) — never create per-request
+- Configure retry policies with exponential backoff on all clients
+- Retrieve secrets from Key Vault only — never from config files in production
+- Use managed identity over connection strings wherever supported
+- Dispose/close SDK clients properly (context managers, using blocks, finally)
+- Tag all resources: environment, owner, costCenter, project
+- Use RBAC role assignments over access keys or shared access signatures
+- Propagate correlation IDs on all cross-service operations
+- Never log secrets, connection strings, or request bodies with PII

--- a/overlays/azure-sdk/implementer-overlay.md
+++ b/overlays/azure-sdk/implementer-overlay.md
@@ -1,0 +1,93 @@
+# Azure SDK Implementer Rules
+
+## Code Quality Rules (Rule 4)
+
+Within the boundaries of what the brief asks for, write clean Azure SDK integration code:
+
+### Authentication
+- Always use `DefaultAzureCredential` as the credential chain — it handles managed identity, Azure CLI, environment variables, and more
+- Never hardcode API keys, connection strings, or shared access signatures
+- Never pass credentials as constructor arguments when `DefaultAzureCredential` is available
+- Use `ManagedIdentityCredential` directly only when you need to specify a user-assigned identity client ID
+- Cache credential instances — do not create a new credential per request
+
+### Client Management
+- Reuse SDK clients: create once at startup (singleton or scoped lifetime), not per-request
+- Configure retry policies with exponential backoff on all clients:
+  - Python: `retry_total=3, retry_backoff_factor=0.8, retry_backoff_max=60`
+  - JS/TS: `retryOptions: { maxRetries: 3, retryDelayInMs: 800, maxRetryDelayInMs: 60000 }`
+  - .NET: `new RetryOptions(maxRetries: 3, delay: TimeSpan.FromSeconds(0.8))`
+- Set reasonable timeouts on all network operations — never use unbounded timeouts
+- Use connection pooling where the SDK supports it (HTTP pipeline is shared across clients of the same type)
+
+### Key Vault Integration
+- Use `SecretClient` for secret retrieval — never use the REST API directly
+- Cache secrets with a TTL (5-15 minutes depending on rotation frequency)
+- Never log secret values, connection strings, or access keys — not even at DEBUG level
+- Use Key Vault references in App Configuration instead of duplicating secrets
+- Handle `ResourceNotFoundException` gracefully when a secret does not exist or has been soft-deleted
+
+### Connection Strings
+- Always retrieve connection strings from Key Vault or App Configuration — never from config files or environment variables in production
+- In local development, use `DefaultAzureCredential` to authenticate to Key Vault for secrets
+- Never commit connection strings to source control — use `.env.example` with placeholder values
+- Prefer managed identity (passwordless connections) over connection strings wherever the service supports it
+
+### Resource Lifecycle
+- Properly dispose of SDK clients when they are no longer needed:
+  - Python: Use `async with` or `with` context managers for async/sync clients; call `.close()` in `finally` if not using context managers
+  - JS/TS: Call `.close()` in `finally` blocks or use try-finally patterns
+  - .NET: Use `using` blocks or `await using` for async disposal; implement `IDisposable`/`IAsyncDisposable` on wrapper classes
+- Close `ServiceBusReceiver`, `ServiceBusSender`, and `ServiceBusClient` in the correct order (receiver first, then sender, then client)
+- Return Cosmos DB client connections to the pool — do not hold references beyond the operation scope
+
+### Error Handling
+- Handle Azure SDK specific exceptions by type, not by catching generic `Exception`:
+  - Python: `ResourceNotFoundError`, `ClientAuthenticationError`, `ServiceRequestError`, `HttpResponseError`
+  - JS/TS: `RestError` with `statusCode` checks, `@azure/abort-controller` for cancellation
+  - .NET: `RequestFailedException` with `Status` property, `Azure.Identity.AuthenticationFailedException`
+- Retry transient errors (HTTP 429, 500, 503) — the SDK retry policy handles most, but verify configuration
+- Do not retry authentication failures (401/403) — these indicate misconfiguration, not transient issues
+- Log the `x-ms-request-id` header on failures for Azure support correlation
+
+### Logging & Observability
+- Use Azure Monitor / Application Insights SDK for telemetry — do not roll custom logging infrastructure
+- Add correlation IDs to all cross-service operations — propagate via `traceparent` header or SDK built-in distributed tracing
+- Use structured logging with consistent field names: `operationName`, `resourceName`, `durationMs`, `statusCode`
+- Enable SDK-level logging for debugging (Python: `logging.getLogger('azure')`, .NET: `AzureEventSourceListener`)
+- Never log request/response bodies that may contain PII or secrets
+
+### Language-Specific SDK Patterns
+
+#### Python (`azure-*` packages)
+- Use `azure-identity` for `DefaultAzureCredential`
+- Prefer async clients (`aio` submodule) for async applications: `from azure.servicebus.aio import ServiceBusClient`
+- Use `azure-core` pipeline policies for cross-cutting concerns (logging, retry, custom headers)
+- Pin Azure SDK package versions in `requirements.txt` or `pyproject.toml`
+
+#### JavaScript/TypeScript (`@azure/*` packages)
+- Use `@azure/identity` for `DefaultAzureCredential`
+- All SDK methods return `Promise` — always `await` or handle the promise
+- Use `@azure/abort-controller` for operation cancellation and timeouts
+- Configure the SDK client with `{ retryOptions, userAgentOptions }` in the constructor
+
+#### .NET (`Azure.*` packages)
+- Use `Azure.Identity` for `DefaultAzureCredential`
+- Register SDK clients via `Microsoft.Extensions.Azure` for dependency injection: `builder.Services.AddAzureClients()`
+- Use `Azure.Core` pipeline policies for cross-cutting concerns
+- Configure retry with `AzureClientOptions.Retry` property
+
+### Resource Tagging
+- Tag all Azure resources created programmatically with: `environment`, `owner`, `costCenter`, `project`
+- Propagate tags from the deployment context — do not hardcode tag values
+- Use consistent tag key casing (lowercase with hyphens or camelCase — match the project convention)
+
+## Project Conventions
+
+Key conventions for Azure SDK integration (the context brief overrides these if different):
+- One service client wrapper per Azure service (e.g., `BlobStorageService`, `ServiceBusPublisher`)
+- Configuration classes for each service client (connection details, retry policies, timeouts)
+- Secrets and connection strings loaded from Key Vault at startup, cached in memory
+- All Azure operations wrapped with correlation ID propagation
+- Error handling follows the SDK exception hierarchy — no generic catches
+- Managed identity preferred over connection strings in all environments except local development

--- a/overlays/azure-sdk/reviewer-overlay.md
+++ b/overlays/azure-sdk/reviewer-overlay.md
@@ -1,0 +1,74 @@
+# Azure SDK Code Review Rules
+
+**Your Domain Expertise:**
+- Senior Azure cloud engineer with deep expertise in Azure SDK integration across Python, JavaScript/TypeScript, and .NET
+- Master of Azure Identity, Key Vault, Service Bus, Cosmos DB, Blob Storage, and App Configuration SDKs
+- Expert in Azure Well-Architected Framework applied to application code (security, reliability, cost, performance)
+- Specialist in managed identity, RBAC, private endpoints, and zero-trust networking patterns
+- Authority on distributed tracing, Azure Monitor, Application Insights, and observability best practices
+- Expert in resilience patterns: retry policies, circuit breakers, bulkheads, and graceful degradation
+
+**Stack-Specific Review Categories:**
+
+1. **Authentication** - Aggressively identify:
+   - Hardcoded API keys, connection strings, shared access signatures, or account keys
+   - Missing `DefaultAzureCredential` — custom credential implementations without justification
+   - Connection strings used where managed identity is available (Storage, Service Bus, Cosmos DB, Key Vault)
+   - Credential instances created per-request instead of cached/reused
+   - Missing token caching — `DefaultAzureCredential` handles this, but custom flows may not
+   - Service principals with secrets instead of certificate-based or federated credentials
+   - Overly broad role assignments (Contributor/Owner when a data-plane role like Storage Blob Data Reader suffices)
+   - Missing RBAC scope — role assigned at subscription or resource group when resource-level scope is possible
+
+2. **Retry & Resilience** - Tear apart:
+   - Missing retry policies on SDK clients — the defaults may not match the workload requirements
+   - Linear retry instead of exponential backoff with jitter
+   - Missing timeouts on network operations — unbounded waits block threads and exhaust connection pools
+   - No circuit breaker pattern on calls to external Azure services that may be degraded
+   - Missing bulkhead isolation — one failing service dependency bringing down the entire application
+   - Retrying non-transient errors (401 authentication failures, 404 not found, 409 conflicts)
+   - Missing graceful degradation — application crashes instead of serving partial results when a dependency is unavailable
+   - No dead-letter or fallback strategy for failed message processing
+
+3. **Resource Lifecycle** - Ruthlessly expose:
+   - SDK clients created per-request instead of singleton/scoped lifetime
+   - Missing `close()`, `dispose()`, or context manager usage on SDK clients
+   - `ServiceBusReceiver` or `ServiceBusSender` not closed before `ServiceBusClient`
+   - HTTP connections leaked by not reusing the SDK's built-in connection pool
+   - Cosmos DB clients holding connections beyond operation scope
+   - Async clients not properly awaited on cleanup (`await client.close()`)
+   - Missing `finally` blocks for client cleanup in error paths
+   - File handles or streams from Blob Storage downloads not closed after consumption
+
+4. **Security** - Hunt down:
+   - Secrets retrieved from environment variables or config files instead of Key Vault
+   - Secret values logged at any level (DEBUG, INFO, WARNING, ERROR)
+   - Request/response bodies logged without PII redaction
+   - Missing private endpoint usage for production Azure service access
+   - Storage accounts or Cosmos DB accessible over public internet without justification
+   - Minimum TLS version not enforced on service connections
+   - SAS tokens with excessive permissions or no expiry
+   - Access keys used instead of RBAC for data-plane operations
+   - Missing encryption configuration for data at rest or in transit
+   - Secrets committed to source control (even in test/example files)
+
+5. **Cost & Performance** - Demand better:
+   - SDK clients created per-request — each new client establishes TCP connections, DNS lookups, and TLS handshakes
+   - Missing batch operations where the SDK supports them (Service Bus batch send, Cosmos DB bulk executor, Blob Storage batch delete)
+   - Over-provisioned SKUs selected in code (Premium Service Bus for low-throughput scenarios)
+   - Missing caching for frequently accessed secrets, configuration values, or reference data
+   - Point reads not used in Cosmos DB when partition key and ID are known (using queries instead)
+   - Cross-partition queries where partition-aware queries would suffice
+   - Missing resource tagging for cost tracking (environment, costCenter, owner, project)
+   - Large blob downloads loaded entirely into memory instead of streaming
+   - Missing connection reuse — multiple clients to the same service not sharing the HTTP pipeline
+
+**Coding Standards to Enforce:**
+- `DefaultAzureCredential` as the standard authentication mechanism
+- SDK clients as singletons or scoped instances, never per-request
+- Retry policies with exponential backoff configured on all clients
+- All secrets from Key Vault, all configuration from App Configuration
+- Proper client disposal via language-idiomatic patterns (context managers, using blocks, finally)
+- Correlation IDs propagated across all cross-service operations
+- Structured logging with Azure Monitor/Application Insights — no secrets in logs
+- Resource tagging on all programmatically created resources

--- a/skills/azure-cost-estimate/SKILL.md
+++ b/skills/azure-cost-estimate/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: azure-cost-estimate
+description: >
+  Estimate monthly Azure costs from Bicep templates. Parses resource types and SKUs
+  to produce a cost breakdown. Use before deploying to understand cost impact.
+---
+
+# Azure Cost Estimate
+
+Parses Bicep templates to extract resource types, SKUs, and regions, then queries the Azure Retail Pricing API to produce an estimated monthly cost breakdown.
+
+## How It Works
+
+1. Read Bicep files and compile to ARM JSON if needed (`bicep build`).
+2. Extract resource types, SKU/tier information, and target regions from the compiled templates.
+3. Query the Azure Retail Pricing API for each resource type + SKU + region combination.
+4. Aggregate and present the cost breakdown.
+
+## How to Run
+
+1. Read the target Bicep files to identify all resource definitions.
+2. Compile to ARM JSON if SKU details are parameterized:
+   ```bash
+   az bicep build --file <path/to/main.bicep> --stdout
+   ```
+3. Query pricing for each resource:
+   ```
+   https://prices.azure.com/api/retail/prices?$filter=serviceName eq '<service>' and skuName eq '<sku>' and armRegionName eq '<region>'
+   ```
+4. Compile results into the output contract format.
+
+## Output Contract
+
+```
+COST ESTIMATE | Total: $X.XX/month
+
+Resource                   Type                                SKU          Region        Est. Monthly
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount           Microsoft.Storage/storageAccounts   Standard_LRS eastus        $21.00
+myAppService               Microsoft.Web/servingSites          P1v3         eastus        $138.00
+myCosmosDb                 Microsoft.DocumentDB/databaseAccts  Standard     eastus        $25.00-$500.00*
+
+* Consumption-based resources show estimate ranges based on typical usage tiers.
+```
+
+## Limitations
+
+- **Estimates only** — actual costs depend on usage, data transfer, and transactions.
+- Consumption-based resources (Functions, Cosmos DB, Event Hubs) show ranges based on typical usage tiers, not exact costs.
+- Marketplace and third-party resource costs are not included.
+- Prices are retail (pay-as-you-go); enterprise agreements, reservations, and savings plans may differ significantly.
+- The Azure Retail Pricing API is public and does not require authentication.
+- Currency defaults to USD. Regional pricing variations are accounted for.

--- a/skills/azure-drift-check/SKILL.md
+++ b/skills/azure-drift-check/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: azure-drift-check
+description: >
+  Compare deployed Azure resource state against Bicep template definitions.
+  Detects configuration drift from manual portal changes or external modifications.
+  Use for compliance checks or before deployments to understand current state.
+---
+
+# Azure Drift Check
+
+Compares deployed Azure resource state against Bicep template definitions to detect configuration drift caused by manual portal changes, external scripts, or other out-of-band modifications.
+
+## Pre-Flight: Azure Authentication
+
+This skill requires an authenticated Azure session with at least **Reader** access to the target resource group.
+
+1. If `AZURE_AUTH_STATUS` is cached and `OK`, proceed.
+2. Otherwise, run the `azure-login` skill. If auth fails, **stop** and show remediation guidance.
+
+## How It Works
+
+1. Run `az deployment group what-if` against the live environment to compare template definitions with actual deployed state.
+2. Optionally use Azure Resource Graph queries to inspect specific resource properties for more granular comparison.
+3. Report drifted, compliant, and missing resources.
+
+## How to Run
+
+**What-if comparison (primary method):**
+```bash
+az deployment group what-if \
+  --resource-group <resource-group> \
+  --template-file <path/to/main.bicep> \
+  --parameters <path/to/parameters.json> \
+  --result-format ResourceIdOnly
+```
+
+**Resource Graph queries (granular inspection):**
+```bash
+az graph query -q "
+  Resources
+  | where resourceGroup == '<resource-group>'
+  | project name, type, properties
+"
+```
+
+## Output Contract
+
+```
+DRIFT CHECK | Total: N resources | Drifted: N, Compliant: N, Missing: N
+
+Resource                   Property                    Expected              Actual                 Status
+────────────────────────────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount           minimumTlsVersion           TLS1_2                TLS1_0                 DRIFTED
+myStorageAccount           enableHttpsTrafficOnly      true                  true                   COMPLIANT
+myKeyVault                 enableSoftDelete            true                  false                  DRIFTED
+myAppServicePlan           —                           Standard_S1           —                      MISSING
+```
+
+- **DRIFTED** — deployed property differs from template definition.
+- **COMPLIANT** — deployed property matches template definition.
+- **MISSING** — resource defined in template but not found in the environment.
+- Exit code 0 = no drift detected, 1 = drift or missing resources found.
+
+## When to Use
+
+- Periodic compliance checks to ensure environments match their template definitions.
+- Before deployments to understand what the current state looks like.
+- After incident investigation to detect unauthorized changes.
+- Governance audits to verify infrastructure policy adherence.
+
+## Important Notes
+
+- What-if may show false positives for computed or read-only properties (e.g., `provisioningState`, `createdTime`). Filter these from drift reports.
+- Resource Graph queries provide point-in-time snapshots and may have a slight propagation delay (typically under 60 seconds).
+- Requires an active `az login` session with read access to the target resource group.
+- For large environments, scope the check to specific resource types to reduce noise.

--- a/skills/azure-login/SKILL.md
+++ b/skills/azure-login/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: azure-login
+description: >
+  Pre-flight Azure authentication and context validation. Verifies az CLI auth,
+  shows active subscription/tenant, validates target resource group access.
+  Run before any Azure-dependent skill (deploy-bicep, validate-bicep what-if,
+  azure-drift-check, infra-test-runner). Also provides guided login for
+  unauthenticated sessions.
+---
+
+# Azure Login & Context Validation
+
+Pre-flight check that validates Azure authentication state, subscription context, and
+resource group permissions before any Azure-dependent operation. This skill verifies
+context — it does not manage credentials.
+
+## When to Use
+
+- **Automatically**: The orchestrator calls this before Azure-dependent pipeline steps when `stack=bicep` or `overlays=azure-sdk`.
+- **Manually**: Run `/azure-login` to verify your Azure context or switch subscriptions.
+- **Before deployment**: `deploy-bicep` and `validate-bicep` (what-if) invoke this as a pre-flight gate.
+
+## Pre-Flight Check Sequence
+
+Run these checks in order. Stop at the first failure and provide guided remediation.
+
+### Step 1: Verify az CLI Installed
+
+```bash
+az version --output json
+```
+
+If `az` is not found:
+```
+AZURE AUTH FAILED | az CLI not installed
+
+Install the Azure CLI:
+  macOS:   brew install azure-cli
+  Linux:   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  Windows: winget install Microsoft.AzureCLI
+  Docs:    https://learn.microsoft.com/cli/azure/install-azure-cli
+```
+
+### Step 2: Verify Authentication
+
+```bash
+az account show --output json
+```
+
+If not authenticated (exit code != 0):
+```
+AZURE AUTH FAILED | Not logged in
+
+Choose your login method:
+
+  Interactive (recommended for local dev):
+    az login
+
+  Service principal (CI/CD):
+    az login --service-principal -u <app-id> -p <secret-or-cert> --tenant <tenant-id>
+
+  Managed identity (Azure-hosted):
+    az login --identity
+
+  Environment variables (headless):
+    export AZURE_CLIENT_ID=<app-id>
+    export AZURE_TENANT_ID=<tenant-id>
+    export AZURE_CLIENT_SECRET=<secret>
+    az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+
+  GitHub Actions (OIDC):
+    uses: azure/login@v2
+    with:
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+
+**Important**: Do NOT run `az login` on behalf of the user. Print the guidance and ask them to authenticate. The user should type `! az login` in the Claude Code prompt to run it in their session.
+
+### Step 3: Display Active Context
+
+If authenticated, parse `az account show` output and display:
+
+```
+AZURE CONTEXT
+  Subscription:  My Dev Subscription (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  Tenant:        My Org (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  User:          dev@myorg.com
+  Cloud:         AzureCloud
+  Auth method:   Interactive (az login)
+```
+
+Detect auth method from the `user.type` field:
+- `user` → Interactive (`az login`)
+- `servicePrincipal` → Service principal
+- `managedIdentity` → Managed identity
+
+### Step 4: Validate Subscription (if target specified)
+
+If a target subscription is known (from parameter files, pipeline.config, or user input):
+
+```bash
+az account show --subscription <subscription-id-or-name> --output json
+```
+
+If the subscription does not exist or user lacks access:
+```
+AZURE AUTH FAILED | Cannot access subscription '<name>'
+
+Available subscriptions:
+  - My Dev Subscription    (xxxxxxxx-...) [default]
+  - My Staging Sub         (xxxxxxxx-...)
+
+To switch subscription:
+  az account set --subscription "<name-or-id>"
+```
+
+### Step 5: Validate Resource Group (if target specified)
+
+If a target resource group is known:
+
+```bash
+az group show --name <resource-group> --output json
+```
+
+If the resource group does not exist:
+```
+AZURE AUTH WARNING | Resource group '<name>' does not exist
+
+The deployment will create it if the template includes a resource group resource
+at subscription scope. Otherwise, create it first:
+  az group create --name <name> --location <location>
+```
+
+### Step 6: Validate Permissions (if deploying)
+
+For deployment operations, verify the user has write access:
+
+```bash
+az role assignment list --assignee <user-or-sp-id> --scope /subscriptions/<sub-id>/resourceGroups/<rg> --output json
+```
+
+Check that the user has at least one of: `Contributor`, `Owner`, or a custom role with `Microsoft.Resources/deployments/write`.
+
+If insufficient permissions:
+```
+AZURE AUTH FAILED | Insufficient permissions on resource group '<name>'
+
+Current roles: Reader
+Required: Contributor or Owner (for deployments)
+
+To grant access (requires Owner or User Access Administrator):
+  az role assignment create --assignee <user> --role Contributor --scope /subscriptions/<sub-id>/resourceGroups/<rg>
+```
+
+## Output Contract
+
+**On success:**
+```
+AZURE AUTH OK | Subscription: <name> (<id>) | User: <upn-or-sp> | Method: <interactive|service-principal|managed-identity>
+```
+
+**On failure:**
+```
+AZURE AUTH FAILED | <reason>
+```
+
+Followed by remediation guidance specific to the failure.
+
+**On warning (non-blocking):**
+```
+AZURE AUTH WARNING | <message>
+```
+
+Warnings (missing RG, unknown permissions) are advisory — they do not block the pipeline. Failures (no az CLI, not logged in, wrong subscription) are blocking.
+
+## Context Caching
+
+After a successful pre-flight check, cache the result in-session:
+- `AZURE_AUTH_STATUS = OK`
+- `AZURE_SUBSCRIPTION_ID = <id>`
+- `AZURE_SUBSCRIPTION_NAME = <name>`
+- `AZURE_TENANT_ID = <id>`
+- `AZURE_USER = <upn-or-sp>`
+- `AZURE_AUTH_METHOD = <method>`
+
+Subsequent Azure-dependent skills in the same pipeline run can skip re-validation by checking `AZURE_AUTH_STATUS`. Re-validate if the target subscription or resource group changes.
+
+## Scenarios
+
+### Local Developer (most common)
+
+1. Developer runs `az login` once (opens browser, authenticates)
+2. Pipeline calls `/azure-login` → detects interactive session, shows context
+3. Developer confirms subscription is correct
+4. Pipeline proceeds with deploy/what-if/drift-check
+
+### CI/CD Pipeline
+
+1. CI sets `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` (or OIDC)
+2. CI runs `az login --service-principal` before pipeline
+3. Pipeline calls `/azure-login` → detects service principal, shows context
+4. No user confirmation needed (automated)
+
+### Multiple Subscriptions
+
+1. Developer has access to dev, staging, prod subscriptions
+2. Pipeline calls `/azure-login` → shows current subscription
+3. If wrong: `az account set --subscription "My Dev Subscription"`
+4. Pipeline re-validates and proceeds
+
+### Expired Token
+
+1. Developer's `az login` token has expired (common after overnight)
+2. Pipeline calls `/azure-login` → `az account show` fails
+3. Skill shows "Not logged in" guidance with `az login` command
+4. Developer re-authenticates, pipeline retries

--- a/skills/deploy-bicep/SKILL.md
+++ b/skills/deploy-bicep/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: deploy-bicep
+description: >
+  Deploy Bicep templates to Azure with MANDATORY user confirmation.
+  Shows what-if preview first, waits for explicit approval, then deploys.
+  Use when you need to deploy infrastructure changes to an Azure environment.
+---
+
+# Deploy Bicep
+
+Deploys Bicep templates to Azure. **Always** shows a what-if preview and requires explicit user confirmation before any deployment executes.
+
+## **MANDATORY CONFIRMATION GATE**
+
+**Before ANY deployment, you MUST:**
+1. Run `az deployment group what-if` and show the full output to the user.
+2. Ask the user: **"Proceed with deployment to `<resource-group>`? (yes/no)"**
+3. Wait for an explicit **"yes"** before proceeding.
+
+**NEVER deploy without explicit "yes" from the user. NEVER assume consent. NEVER skip the what-if preview.**
+
+## Pre-Flight: Azure Authentication
+
+Before running any deployment commands, verify Azure auth:
+
+1. If `AZURE_AUTH_STATUS` is cached and `OK` from a prior `azure-login` check in this session, proceed.
+2. Otherwise, run the `azure-login` skill to validate auth, subscription context, and resource group permissions.
+3. If auth fails, **stop** — do not proceed with deployment. Show the remediation guidance from `azure-login`.
+4. Verify the active subscription matches the intended deployment target. Display the subscription name and ask the user to confirm if it was not previously validated in this session.
+
+## How to Deploy
+
+### Step 1: What-If Preview
+
+```bash
+az deployment group what-if \
+  --resource-group <resource-group> \
+  --template-file <path/to/main.bicep> \
+  --parameters <path/to/parameters.json>
+```
+
+Show the results to the user with a clear summary of what will be created, modified, or deleted.
+
+### Step 2: Ask for Confirmation
+
+Present the what-if summary and ask: **"Proceed with deployment to `<resource-group>`? (yes/no)"**
+
+### Step 3: Deploy (Only After "yes")
+
+```bash
+az deployment group create \
+  --resource-group <resource-group> \
+  --template-file <path/to/main.bicep> \
+  --parameters <path/to/parameters.json> \
+  --name <deployment-name>
+```
+
+## Required Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--resource-group` | Target Azure resource group |
+| `--template-file` | Path to the main `.bicep` file |
+| `--parameters` | Parameters file or inline key=value pairs |
+
+## Output Contract
+
+**On success:**
+```
+DEPLOY SUCCEEDED | N resources created | N modified
+
+Resource                          Type                                    Operation
+──────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount                  Microsoft.Storage/storageAccounts       Create
+myKeyVault                        Microsoft.KeyVault/vaults               NoChange
+```
+
+**On failure:**
+```
+DEPLOY FAILED | <error summary>
+```
+
+## Post-Deploy
+
+After a successful deployment, capture deployment outputs (resource IDs, endpoints, connection strings) for use by dependent skills or subsequent pipeline steps:
+
+```bash
+az deployment group show \
+  --resource-group <resource-group> \
+  --name <deployment-name> \
+  --query properties.outputs
+```
+
+## Safety
+
+- **Never** deploy to production without explicit user confirmation in the **same** conversation turn.
+- Always prefer `--mode Incremental` (the default) over `--mode Complete` unless the user explicitly requests complete mode.
+- Complete mode deletes resources not in the template — require double confirmation for complete mode.
+- **Hooks:** The adapter's hooks block raw `az deployment` commands via Bash. This skill is the approved way to perform deployments. The `az` commands shown above are reference — execute them via subprocess or through the skill's workflow, not as raw Bash tool calls.

--- a/skills/infra-test-runner/SKILL.md
+++ b/skills/infra-test-runner/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: infra-test-runner
+description: >
+  Run infrastructure validation tests — ARM-TTK template tests, Pester integration tests,
+  or deployed resource state validation. Outputs in standard test contract format.
+  Use after deployment to verify resources match expected state.
+---
+
+# Infrastructure Test Runner
+
+Runs infrastructure validation tests against Bicep/ARM templates and deployed Azure resources. Outputs results in the standard test contract format for compatibility with the pipeline.
+
+## When to Use
+
+- After deployment to verify resources match expected state
+- During CI for template validation before deployment
+- For compliance checks against organizational policies
+- To validate resource configuration after manual changes
+
+## Pre-Flight: Azure Authentication
+
+Post-deployment tests (resource validation, configuration validation against live resources) require an authenticated Azure session with at least **Reader** access.
+
+1. If `AZURE_AUTH_STATUS` is cached and `OK`, proceed.
+2. Otherwise, run the `azure-login` skill. If auth fails, run only local template validation tests (ARM-TTK, PSRule against templates) and skip post-deployment checks.
+
+Pre-deployment template tests (ARM-TTK, PSRule against `.bicep` files) do **not** require Azure auth.
+
+## Test Types
+
+| Type | Tool | Phase | Description |
+|------|------|-------|-------------|
+| Template validation | ARM-TTK | Pre-deploy | Validates ARM/Bicep templates against best practices |
+| Resource validation | Pester + az CLI | Post-deploy | Verifies deployed resource properties match expectations |
+| Configuration validation | PSRule | Pre/Post | Validates against Azure Well-Architected Framework |
+
+## How to Run
+
+Auto-detect available test frameworks and run the appropriate tests:
+
+**ARM-TTK (template tests):**
+```bash
+pwsh -Command "Import-Module arm-ttk; Test-AzTemplate -TemplatePath <path>"
+```
+
+**Pester (integration tests):**
+```bash
+pwsh -Command "Invoke-Pester -Path ./tests/infra/ -OutputFormat NUnitXml -OutputFile results.xml"
+```
+
+**az CLI (resource state validation):**
+```bash
+az resource show --ids <resource-id> --query "properties"
+```
+
+## Output Contract
+
+Follows the standard test output format:
+
+```
+Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%
+
+Coverage:  TemplateTests: 85.0%  |  ResourceTests: 72.0%
+
+Test                              Result   Time
+───────────────────────────────────────────────────
+Storage.MinTLS                    PASSED   0.8s
+KeyVault.SoftDelete               PASSED   0.6s
+Network.NSGRules                  FAILED   1.2s
+   L Expected: DenyAllInbound rule present, Actual: no deny-all rule found
+```
+
+- `Summary:` line always appears first — include it verbatim when reporting results.
+- Failure rows show the assertion message (truncated to 160 chars).
+- Exit code 0 = all passed, 1 = failures.
+
+## Coverage
+
+For infrastructure-as-code, coverage is calculated as the percentage of deployed resource types that have at least one validation test. This differs from code coverage — it measures breadth of infrastructure validation, not line coverage.
+
+Example: if a template deploys 10 resource types and 7 have tests, coverage = 70.0%.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -24,7 +24,7 @@ Before starting, read these files (skip if already in context from this session)
 
 Before any agent launches, determine the active tech-stack adapter:
 
-1. Read `.claude/pipeline.config` to get the `stack` and `pipeline_root` values
+1. Read `.claude/pipeline.config` to get the `stack`, `pipeline_root`, and `overlays` values
 2. Read `<pipeline_root>/adapters/<stack>/adapter.md` — this is the **adapter config**
 3. For each agent you launch, read the relevant overlay file from `<pipeline_root>/adapters/<stack>/`:
    - `architect-overlay.md` — injected into architect-agent prompts
@@ -40,6 +40,67 @@ The adapter config also declares:
 - **Build command**: The command agents should use to build (e.g., `python3 .claude/scripts/build.py`)
 - **Test command**: The command agents should use to test (e.g., `python3 .claude/scripts/test.py`)
 - **Blocked commands**: Raw commands that hooks prevent (for awareness)
+
+## Step 0.1: Load Cross-Cutting Overlays
+
+After loading the adapter, check `pipeline.config` for the `overlays` key:
+
+1. Read the `overlays` value (comma-separated). If empty or missing, skip this step.
+2. For each overlay name (e.g., `azure-sdk`):
+   - Read `<pipeline_root>/overlays/<overlay_name>/architect-overlay.md`
+   - Read `<pipeline_root>/overlays/<overlay_name>/implementer-overlay.md`
+   - Read `<pipeline_root>/overlays/<overlay_name>/implementer-overlay-essential.md`
+   - Read `<pipeline_root>/overlays/<overlay_name>/reviewer-overlay.md`
+
+3. When composing agent prompts, **append** the overlay content AFTER the adapter overlay
+   at the same `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker. Use this format:
+
+   ```
+   <adapter overlay content>
+
+   ---
+   ## Cross-Cutting: Azure SDK Context
+   <overlay content>
+   ```
+
+4. For Haiku tasks in Step 2, append the overlay's `implementer-overlay-essential.md`
+   after the adapter's essential variant. The combined essential content should remain concise
+   to preserve signal-to-noise ratio for Haiku.
+
+5. The overlay's reviewer content is appended after the adapter's reviewer overlay in Step 2.1,
+   giving the code reviewer awareness of both stack-specific and Azure SDK patterns.
+
+## Step 0.2: Azure Authentication Pre-Flight
+
+**When to run:** If `stack=bicep` OR `overlays` contains `azure-sdk`, AND the pipeline will
+perform Azure-dependent operations (what-if, deploy, drift-check, infra-test).
+
+**Skip if:** The pipeline only involves local operations (bicep build/lint, PSRule, security scan,
+cost estimate). Build and review steps do NOT require Azure auth.
+
+**How to run:** Invoke the `azure-login` skill. It will:
+
+1. Verify `az` CLI is installed
+2. Verify the user is authenticated (`az account show`)
+3. Display the active subscription, tenant, user, and auth method
+4. Cache the result as `AZURE_AUTH_STATUS` for the session
+
+**On failure:** The `azure-login` skill prints remediation guidance. The pipeline should:
+- **Pause** and present the guidance to the user
+- **Ask** the user to authenticate (e.g., `! az login` in the Claude Code prompt)
+- **Retry** the pre-flight check after the user confirms they have logged in
+- **Do NOT** proceed with Azure-dependent steps if auth fails
+
+**On success:** Record the auth context:
+- `AZURE_AUTH_STATUS = OK`
+- `AZURE_SUBSCRIPTION_ID`, `AZURE_SUBSCRIPTION_NAME`, `AZURE_TENANT_ID`
+- `AZURE_USER`, `AZURE_AUTH_METHOD`
+
+Subsequent Azure-dependent skills check `AZURE_AUTH_STATUS` and skip re-validation if already OK.
+If the target subscription or resource group changes mid-pipeline, re-validate.
+
+**Timing:** This check runs lazily — only before the first Azure-dependent step, not at pipeline
+start. This avoids blocking developers who are only doing local build/lint/review cycles.
 
 ## Step 0.5: Initialize Token Tracking
 

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: security-scan
+description: >
+  Run security and compliance scans against Bicep/ARM templates using PSRule for Azure
+  or Checkov. Reports misconfigurations, policy violations, and security findings.
+  Use before deployment or during code review.
+---
+
+# Security Scan
+
+Runs security and compliance scans against Bicep and ARM templates, reporting misconfigurations, policy violations, and security findings using the Azure Well-Architected Framework and CIS benchmarks.
+
+## Tools
+
+- **PSRule for Azure** (preferred) — validates against Azure Well-Architected Framework rules. Requires `ps-rule.yaml` config for Bicep file expansion.
+- **Checkov** (fallback) — validates against CIS Azure benchmarks. Runs without config.
+- Both can be run together for comprehensive coverage.
+
+The scanner auto-detects which tools are available and uses the best option.
+
+## How to Run
+
+1. Detect available scanners:
+   ```bash
+   # Check for PSRule
+   pwsh -Command "Get-Module -ListAvailable PSRule.Rules.Azure" 2>/dev/null
+
+   # Check for Checkov
+   checkov --version 2>/dev/null
+   ```
+
+2. Run the available scanner against all `.bicep` files:
+
+   **PSRule:**
+   ```bash
+   pwsh -Command "Assert-PSRule -Module PSRule.Rules.Azure -InputPath . -Format File"
+   ```
+
+   **Checkov:**
+   ```bash
+   checkov --directory . --framework bicep --output cli
+   ```
+
+3. Collect and format findings into the output contract.
+
+## Output Contract
+
+```
+SECURITY SCAN | Total: N findings | Critical: N, High: N, Medium: N, Low: N
+
+Rule                          Severity  Resource                  Description                              Recommendation
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Azure.Storage.MinTLS          HIGH      myStorageAccount          TLS version below 1.2                    Set minimumTlsVersion to 'TLS1_2'
+Azure.KeyVault.SoftDelete     MEDIUM    myKeyVault                Soft delete not enabled                  Enable soft delete with 90-day retention
+```
+
+- Findings are sorted by severity (Critical > High > Medium > Low).
+- Each finding includes a concrete remediation recommendation.
+- Exit code 0 = no critical/high findings, 1 = critical or high findings present.
+
+## Integration
+
+- Findings can feed into the code-reviewer agent context for IaC reviews.
+- Critical findings should block deployment via the deploy-bicep skill.
+- Results can be posted as PR comments for visibility.
+
+## Important Notes
+
+- PSRule requires a `ps-rule.yaml` configuration file for Bicep file expansion. Without it, only pre-compiled ARM JSON is scanned.
+- Checkov runs without configuration and supports Bicep natively.
+- Some rules may produce false positives for resources that rely on Azure Policy for enforcement. Suppress known false positives via rule configuration, not by ignoring findings.

--- a/skills/validate-bicep/SKILL.md
+++ b/skills/validate-bicep/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: validate-bicep
+description: >
+  Validate Bicep templates via lint, build, and optional what-if dry run.
+  Use when you need to check Bicep templates for errors, lint violations,
+  or preview deployment changes. Standalone skill — can be run independently.
+---
+
+# Validate Bicep
+
+Validates Bicep templates through linting, compilation, and an optional what-if dry run against a target Azure environment. Reports errors, warnings, and projected resource changes.
+
+## When to Use
+
+- Before deploying infrastructure changes
+- After modifying any `.bicep` template
+- As a CI validation gate
+- To preview what a deployment would change without applying it
+
+## How to Run
+
+### Step 1: Lint + Build
+
+```bash
+python3 .claude/scripts/build.py --scheme all
+```
+
+This runs the Bicep linter and compiles all templates to ARM JSON. Any syntax errors, lint violations, or compilation failures are reported.
+
+### Step 1.5: Azure Auth (only if running what-if)
+
+If proceeding to the what-if step, validate Azure authentication first:
+
+1. If `AZURE_AUTH_STATUS` is cached and `OK`, proceed.
+2. Otherwise, run the `azure-login` skill. If auth fails, skip what-if and report results from lint+build only.
+
+### Step 2: What-If Dry Run (Optional)
+
+```bash
+az deployment group what-if \
+  --resource-group <resource-group> \
+  --template-file <path/to/main.bicep> \
+  --parameters <path/to/parameters.json>
+```
+
+This previews the resource changes that would occur if the template were deployed.
+
+## Output Contract
+
+**Lint + Build phase** follows the standard BUILD output contract:
+
+On success:
+```
+BUILD SUCCEEDED  |  3 warning(s)
+```
+
+On failure:
+```
+BUILD FAILED  |  2 error(s)  |  3 warning(s)
+
+File                          Ln  Error
+-----------------------------------------------------------
+modules/storage.bicep         12  BCP035: expected type 'string'
+main.bicep                    45  no-unused-params: unused parameter 'env'
+```
+
+**What-if phase** outputs a resource change summary:
+```
+WHAT-IF SUMMARY | Create: N, Modify: N, Delete: N, NoChange: N
+```
+
+## Important Notes
+
+- The what-if step requires an active `az login` session and a target resource group.
+- What-if does not make any changes — it is a read-only preview.
+- Lint + build can run without Azure credentials; what-if cannot.
+- Exit code 0 = all checks passed, 1 = errors found.
+- **Hooks:** The adapter's hooks block raw `az deployment` commands via Bash. The what-if commands shown above are for reference — when used from within the pipeline, they should be run via `python3 .claude/scripts/test.py --scheme what-if` or through this skill, not as raw Bash commands.

--- a/tests/fixtures/azure-auth-failed.txt
+++ b/tests/fixtures/azure-auth-failed.txt
@@ -1,0 +1,18 @@
+Checking az CLI...
+az CLI version: 2.64.0
+
+Checking authentication...
+Not authenticated.
+
+AZURE AUTH FAILED | Not logged in
+
+Choose your login method:
+
+  Interactive (recommended for local dev):
+    az login
+
+  Service principal (CI/CD):
+    az login --service-principal -u <app-id> -p <secret-or-cert> --tenant <tenant-id>
+
+  Managed identity (Azure-hosted):
+    az login --identity

--- a/tests/fixtures/azure-auth-ok.txt
+++ b/tests/fixtures/azure-auth-ok.txt
@@ -1,0 +1,14 @@
+Checking az CLI...
+az CLI version: 2.64.0
+
+Checking authentication...
+Authenticated.
+
+AZURE CONTEXT
+  Subscription:  My Dev Subscription (a1b2c3d4-e5f6-7890-abcd-ef1234567890)
+  Tenant:        Contoso (11111111-2222-3333-4444-555555555555)
+  User:          dev@contoso.com
+  Cloud:         AzureCloud
+  Auth method:   Interactive (az login)
+
+AZURE AUTH OK | Subscription: My Dev Subscription (a1b2c3d4-e5f6-7890-abcd-ef1234567890) | User: dev@contoso.com | Method: interactive

--- a/tests/fixtures/bicep-build-failure.txt
+++ b/tests/fixtures/bicep-build-failure.txt
@@ -1,0 +1,24 @@
+Building in: /home/user/infra
+Bicep files: 3
+Config:      bicepconfig.json found
+
+--- Running: bicep lint ---
+Running: bicep lint main.bicep
+Running: bicep lint modules/storage.bicep
+Running: bicep lint modules/compute.bicep
+
+--- Running: bicep build ---
+Running: bicep build main.bicep
+Running: bicep build modules/storage.bicep
+Running: bicep build modules/compute.bicep
+
+File                  Ln  Error
+-------------------------------------------------------
+main.bicep            18  [BCP035] The specified "resource" declaration is missing the required property "location"
+modules/compute.bicep 7   [BCP036] The property "sku" expected a value of type "string" but got "int"
+
+File                      Ln  Warning
+-------------------------------------------------------
+modules/storage.bicep     12  [no-unused-params] Parameter 'legacySku' is declared but never used
+
+BUILD FAILED  |  2 error(s)  |  1 warning(s)

--- a/tests/fixtures/bicep-build-success.txt
+++ b/tests/fixtures/bicep-build-success.txt
@@ -1,0 +1,23 @@
+Building in: /home/user/infra
+Bicep files: 4
+Config:      bicepconfig.json found
+Modules:     modules/ directory found
+
+--- Running: bicep lint ---
+Running: bicep lint main.bicep
+Running: bicep lint modules/storage.bicep
+Running: bicep lint modules/networking.bicep
+Running: bicep lint modules/keyvault.bicep
+
+--- Running: bicep build ---
+Running: bicep build main.bicep
+Running: bicep build modules/storage.bicep
+Running: bicep build modules/networking.bicep
+Running: bicep build modules/keyvault.bicep
+
+File                      Ln  Warning
+-------------------------------------------------------
+modules/storage.bicep     12  [no-unused-params] Parameter 'legacySku' is declared but never used
+modules/networking.bicep  45  [prefer-interpolation] Use string interpolation instead of the concat function
+
+BUILD SUCCEEDED  |  2 warning(s)

--- a/tests/fixtures/bicep-test-failure.txt
+++ b/tests/fixtures/bicep-test-failure.txt
@@ -1,0 +1,21 @@
+Project dir: /home/user/infra
+Bicep files: 4
+Test files:  2
+PSRule:      available
+ARM-TTK:     not found
+az CLI:      available
+Pester:      available
+Resources:   6 unique types
+
+--- Running: psrule ---
+Running: Invoke-PSRule -InputPath . -Module PSRule.Rules.Azure -Baseline Azure.Default -OutputFormat Json
+
+Coverage:  Resources: 6 types  |  PSRule: active
+
+Summary: Total: 18, Passed: 15, Failed: 3 | Coverage: 83.3%
+
+Test                                           Reason
+---------------------------------------------------------------------------------------------
+Azure.Storage.MinTLS:myStorageAccount          TLS version is below minimum required (1.2)
+Azure.KeyVault.SoftDelete:myKeyVault           Soft delete is not enabled
+Azure.NSG.Associated:webNsg                    NSG is not associated with a subnet or NIC

--- a/tests/fixtures/bicep-test-success.txt
+++ b/tests/fixtures/bicep-test-success.txt
@@ -1,0 +1,17 @@
+Project dir: /home/user/infra
+Bicep files: 4
+Test files:  2
+PSRule:      available
+ARM-TTK:     not found
+az CLI:      available
+Pester:      available
+Resources:   6 unique types
+
+--- Running: psrule ---
+Running: Invoke-PSRule -InputPath . -Module PSRule.Rules.Azure -Baseline Azure.Default -OutputFormat Json
+
+Coverage:  Resources: 6 types  |  PSRule: active
+
+Summary: Total: 18, Passed: 18, Failed: 0 | Coverage: 83.3%
+
+All tests passed.

--- a/tests/fixtures/cost-estimate.txt
+++ b/tests/fixtures/cost-estimate.txt
@@ -1,0 +1,16 @@
+Parsing Bicep templates...
+Compiling main.bicep to ARM JSON...
+Extracting resources and SKUs...
+Querying Azure Retail Pricing API...
+
+COST ESTIMATE | Total: $284.50/month
+
+Resource                   Type                                SKU          Region        Est. Monthly
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount           Microsoft.Storage/storageAccounts   Standard_LRS eastus        $21.00
+myAppServicePlan           Microsoft.Web/serverfarms           P1v3         eastus        $138.00
+myKeyVault                 Microsoft.KeyVault/vaults           Standard     eastus        $0.50
+myCosmosDb                 Microsoft.DocumentDB/databaseAccts  Standard     eastus        $25.00-$500.00*
+myLogAnalytics             Microsoft.OperationalInsights/ws    PerGB2018    eastus        $100.00
+
+* Consumption-based resources show estimate ranges based on typical usage tiers.

--- a/tests/fixtures/deploy-success.txt
+++ b/tests/fixtures/deploy-success.txt
@@ -1,0 +1,21 @@
+Running what-if preview...
+Template: main.bicep
+Resource Group: rg-staging
+Parameters: staging.bicepparam
+
+What-if results:
+  Create: 2
+  Modify: 1
+  NoChange: 3
+
+User confirmed: yes
+
+Deploying to rg-staging...
+
+DEPLOY SUCCEEDED | 2 resources created | 1 modified
+
+Resource                          Type                                    Operation
+──────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount                  Microsoft.Storage/storageAccounts       Create
+myAppServicePlan                  Microsoft.Web/serverfarms               Create
+myKeyVault                        Microsoft.KeyVault/vaults               Modify

--- a/tests/fixtures/drift-check-drifted.txt
+++ b/tests/fixtures/drift-check-drifted.txt
@@ -1,0 +1,13 @@
+Running drift check against resource group 'rg-production'...
+Template: main.bicep
+Running: az deployment group what-if
+
+DRIFT CHECK | Total: 5 resources | Drifted: 2, Compliant: 2, Missing: 1
+
+Resource                   Property                    Expected              Actual                 Status
+────────────────────────────────────────────────────────────────────────────────────────────────────────────
+myStorageAccount           minimumTlsVersion           TLS1_2                TLS1_0                 DRIFTED
+myStorageAccount           enableHttpsTrafficOnly      true                  true                   COMPLIANT
+myKeyVault                 enableSoftDelete            true                  false                  DRIFTED
+myKeyVault                 enablePurgeProtection       true                  true                   COMPLIANT
+myAppServicePlan           —                           Standard_S1           —                      MISSING

--- a/tests/fixtures/security-scan-findings.txt
+++ b/tests/fixtures/security-scan-findings.txt
@@ -1,0 +1,12 @@
+Detecting available scanners...
+PSRule for Azure: available
+Running PSRule security scan...
+
+SECURITY SCAN | Total: 4 findings | Critical: 1, High: 1, Medium: 2, Low: 0
+
+Rule                          Severity  Resource                  Description                              Recommendation
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Azure.Storage.MinTLS          HIGH      myStorageAccount          TLS version below 1.2                    Set minimumTlsVersion to 'TLS1_2'
+Azure.KeyVault.SoftDelete     MEDIUM    myKeyVault                Soft delete not enabled                  Enable soft delete with 90-day retention
+Azure.SQL.FirewallIPRange     CRITICAL  mySqlServer               Firewall allows 0.0.0.0-255.255.255.255  Restrict firewall rules to specific IPs
+Azure.NSG.Associated          MEDIUM    webNsg                    NSG not associated with subnet           Associate NSG with target subnet

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -402,3 +402,142 @@ def parse_defect_reports(comments: list[dict]) -> list[dict]:
         d["id"] = i
 
     return defects
+
+
+# ---------------------------------------------------------------------------
+# Azure / Bicep skill output parsers
+# ---------------------------------------------------------------------------
+
+def parse_cost_estimate_output(output: str) -> dict | None:
+    """Parse azure-cost-estimate skill output.
+
+    Expected format:
+        COST ESTIMATE | Total: $X.XX/month
+    """
+    match = re.search(
+        r"COST ESTIMATE\s*\|\s*Total:\s*\$([0-9,.]+)/month",
+        output,
+    )
+    if not match:
+        return None
+
+    total_str = match.group(1).replace(",", "")
+    try:
+        total = float(total_str)
+    except ValueError:
+        return None
+
+    return {"status": "estimated", "total_monthly": total}
+
+
+def parse_security_scan_output(output: str) -> dict | None:
+    """Parse security-scan skill output.
+
+    Expected format:
+        SECURITY SCAN | Total: N findings | Critical: N, High: N, Medium: N, Low: N
+    """
+    match = re.search(
+        r"SECURITY SCAN\s*\|\s*Total:\s*(\d+)\s+findings?\s*\|\s*"
+        r"Critical:\s*(\d+),\s*High:\s*(\d+),\s*Medium:\s*(\d+),\s*Low:\s*(\d+)",
+        output,
+    )
+    if not match:
+        return None
+
+    return {
+        "status": "scanned",
+        "total": int(match.group(1)),
+        "critical": int(match.group(2)),
+        "high": int(match.group(3)),
+        "medium": int(match.group(4)),
+        "low": int(match.group(5)),
+    }
+
+
+def parse_drift_check_output(output: str) -> dict | None:
+    """Parse azure-drift-check skill output.
+
+    Expected format:
+        DRIFT CHECK | Total: N resources | Drifted: N, Compliant: N, Missing: N
+    """
+    match = re.search(
+        r"DRIFT CHECK\s*\|\s*Total:\s*(\d+)\s+resources?\s*\|\s*"
+        r"Drifted:\s*(\d+),\s*Compliant:\s*(\d+),\s*Missing:\s*(\d+)",
+        output,
+    )
+    if not match:
+        return None
+
+    return {
+        "status": "checked",
+        "total": int(match.group(1)),
+        "drifted": int(match.group(2)),
+        "compliant": int(match.group(3)),
+        "missing": int(match.group(4)),
+    }
+
+
+def parse_deploy_bicep_output(output: str) -> dict | None:
+    """Parse deploy-bicep skill output.
+
+    Expected formats:
+        DEPLOY SUCCEEDED | N resources created | N modified
+        DEPLOY FAILED | <error summary>
+    """
+    success_match = re.search(
+        r"DEPLOY SUCCEEDED\s*\|\s*(\d+)\s+resources?\s+created\s*\|\s*(\d+)\s+modified",
+        output,
+    )
+    if success_match:
+        return {
+            "status": "succeeded",
+            "created": int(success_match.group(1)),
+            "modified": int(success_match.group(2)),
+        }
+
+    fail_match = re.search(r"DEPLOY FAILED\s*\|\s*(.+)", output)
+    if fail_match:
+        return {
+            "status": "failed",
+            "error": fail_match.group(1).strip(),
+        }
+
+    return None
+
+
+def parse_azure_auth_output(output: str) -> dict | None:
+    """Parse azure-login skill output.
+
+    Expected formats:
+        AZURE AUTH OK | Subscription: <name> (<id>) | User: <upn> | Method: <method>
+        AZURE AUTH FAILED | <reason>
+        AZURE AUTH WARNING | <message>
+    """
+    ok_match = re.search(
+        r"AZURE AUTH OK\s*\|\s*Subscription:\s*(.+?)\s*\(([^)]+)\)\s*\|\s*User:\s*(\S+)\s*\|\s*Method:\s*(.+)",
+        output,
+    )
+    if ok_match:
+        return {
+            "status": "ok",
+            "subscription_name": ok_match.group(1).strip(),
+            "subscription_id": ok_match.group(2).strip(),
+            "user": ok_match.group(3).strip(),
+            "method": ok_match.group(4).strip(),
+        }
+
+    fail_match = re.search(r"AZURE AUTH FAILED\s*\|\s*(.+)", output)
+    if fail_match:
+        return {
+            "status": "failed",
+            "reason": fail_match.group(1).strip(),
+        }
+
+    warn_match = re.search(r"AZURE AUTH WARNING\s*\|\s*(.+)", output)
+    if warn_match:
+        return {
+            "status": "warning",
+            "message": warn_match.group(1).strip(),
+        }
+
+    return None

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -21,12 +21,17 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from parsers import (
+    parse_azure_auth_output,
     parse_build_output,
+    parse_cost_estimate_output,
     parse_defect_report,
     parse_defect_reports,
+    parse_deploy_bicep_output,
+    parse_drift_check_output,
     parse_implementer_result,
     parse_open_pr_result,
     parse_reviewer_result,
+    parse_security_scan_output,
     parse_test_output,
     parse_token_analysis_result,
     parse_token_report,
@@ -115,6 +120,38 @@ class TestBuildOutput(unittest.TestCase):
         result = parse_build_output(fixture)
         self.assertEqual(result["status"], "failed")
         self.assertTrue(result["errors"] > 0)
+
+
+class TestBicepBuildOutput(unittest.TestCase):
+    def test_bicep_build_success(self) -> None:
+        fixture = (FIXTURES_DIR / "bicep-build-success.txt").read_text()
+        result = parse_build_output(fixture)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["warnings"], 2)
+
+    def test_bicep_build_failure(self) -> None:
+        fixture = (FIXTURES_DIR / "bicep-build-failure.txt").read_text()
+        result = parse_build_output(fixture)
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["errors"], 2)
+        self.assertEqual(result["warnings"], 1)
+
+
+class TestBicepTestOutput(unittest.TestCase):
+    def test_bicep_test_success(self) -> None:
+        fixture = (FIXTURES_DIR / "bicep-test-success.txt").read_text()
+        result = parse_test_output(fixture)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(result["total"], 18)
+        self.assertGreaterEqual(result["coverage"], 0.0)
+
+    def test_bicep_test_failure(self) -> None:
+        fixture = (FIXTURES_DIR / "bicep-test-failure.txt").read_text()
+        result = parse_test_output(fixture)
+        self.assertNotIn("error", result)
+        self.assertEqual(result["failed"], 3)
+        self.assertEqual(result["total"], 18)
 
 
 class TestTestOutput(unittest.TestCase):
@@ -306,6 +343,103 @@ class TestDefectReportsBatch(unittest.TestCase):
     def test_empty_comments_list(self) -> None:
         defects = parse_defect_reports([])
         self.assertEqual(len(defects), 0)
+
+
+class TestCostEstimateOutput(unittest.TestCase):
+    def test_cost_estimate_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "cost-estimate.txt").read_text()
+        result = parse_cost_estimate_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "estimated")
+        self.assertAlmostEqual(result["total_monthly"], 284.50)
+
+    def test_cost_estimate_no_match(self) -> None:
+        result = parse_cost_estimate_output("No cost data here")
+        self.assertIsNone(result)
+
+
+class TestSecurityScanOutput(unittest.TestCase):
+    def test_security_scan_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "security-scan-findings.txt").read_text()
+        result = parse_security_scan_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "scanned")
+        self.assertEqual(result["total"], 4)
+        self.assertEqual(result["critical"], 1)
+        self.assertEqual(result["high"], 1)
+        self.assertEqual(result["medium"], 2)
+        self.assertEqual(result["low"], 0)
+
+    def test_security_scan_no_match(self) -> None:
+        result = parse_security_scan_output("No scan results")
+        self.assertIsNone(result)
+
+
+class TestDriftCheckOutput(unittest.TestCase):
+    def test_drift_check_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "drift-check-drifted.txt").read_text()
+        result = parse_drift_check_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "checked")
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["drifted"], 2)
+        self.assertEqual(result["compliant"], 2)
+        self.assertEqual(result["missing"], 1)
+
+    def test_drift_check_no_match(self) -> None:
+        result = parse_drift_check_output("No drift data")
+        self.assertIsNone(result)
+
+
+class TestDeployBicepOutput(unittest.TestCase):
+    def test_deploy_success_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "deploy-success.txt").read_text()
+        result = parse_deploy_bicep_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "succeeded")
+        self.assertEqual(result["created"], 2)
+        self.assertEqual(result["modified"], 1)
+
+    def test_deploy_failure_parsing(self) -> None:
+        output = "DEPLOY FAILED | Resource group 'rg-staging' not found"
+        result = parse_deploy_bicep_output(output)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("not found", result["error"])
+
+    def test_deploy_no_match(self) -> None:
+        result = parse_deploy_bicep_output("No deploy output")
+        self.assertIsNone(result)
+
+
+class TestAzureAuthOutput(unittest.TestCase):
+    def test_auth_ok_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "azure-auth-ok.txt").read_text()
+        result = parse_azure_auth_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["subscription_name"], "My Dev Subscription")
+        self.assertEqual(result["subscription_id"], "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        self.assertEqual(result["user"], "dev@contoso.com")
+        self.assertEqual(result["method"], "interactive")
+
+    def test_auth_failed_parsing(self) -> None:
+        fixture = (FIXTURES_DIR / "azure-auth-failed.txt").read_text()
+        result = parse_azure_auth_output(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("Not logged in", result["reason"])
+
+    def test_auth_warning_parsing(self) -> None:
+        output = "AZURE AUTH WARNING | Resource group 'rg-dev' does not exist"
+        result = parse_azure_auth_output(output)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "warning")
+        self.assertIn("does not exist", result["message"])
+
+    def test_auth_no_match(self) -> None:
+        result = parse_azure_auth_output("No auth output here")
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 PIPELINE_ROOT = Path(__file__).resolve().parent.parent
 
-ADAPTERS = ["python", "react", "swift-ios"]
+ADAPTERS = ["python", "react", "swift-ios", "bicep"]
 
 REQUIRED_ADAPTER_FILES = [
     "adapter.md",
@@ -54,9 +54,27 @@ REQUIRED_SKILLS = [
     "summarize-implementation/SKILL.md",
     "token-analysis/SKILL.md",
     "fix-defects/SKILL.md",
+    "validate-bicep/SKILL.md",
+    "deploy-bicep/SKILL.md",
+    "azure-cost-estimate/SKILL.md",
+    "security-scan/SKILL.md",
+    "infra-test-runner/SKILL.md",
+    "azure-drift-check/SKILL.md",
+    "azure-login/SKILL.md",
 ]
 
 ESSENTIAL_OVERLAY_MAX_CHARS = 1000
+
+OVERLAYS = ["azure-sdk"]
+
+# Overlays intentionally omit test-overlay.md: testing patterns for Azure SDK
+# are language-specific and covered by each adapter's own test overlay.
+REQUIRED_OVERLAY_FILES = [
+    "architect-overlay.md",
+    "implementer-overlay.md",
+    "implementer-overlay-essential.md",
+    "reviewer-overlay.md",
+]
 
 # Markers that must exist in agent files for overlay injection
 AGENT_MARKERS = {
@@ -541,6 +559,77 @@ def check_fix_defects_skill(result: ValidationResult) -> None:
         result.fail("fix-defects missing PR comment reply mechanism")
 
 
+def check_overlay_completeness(result: ValidationResult) -> None:
+    """Check each overlay has all required files."""
+    for overlay in OVERLAYS:
+        overlay_dir = PIPELINE_ROOT / "overlays" / overlay
+        if not overlay_dir.is_dir():
+            result.fail(f"Missing overlay directory: overlays/{overlay}/")
+            continue
+
+        for req_file in REQUIRED_OVERLAY_FILES:
+            path = overlay_dir / req_file
+            if path.exists():
+                result.ok(f"Overlay {overlay}: {req_file} exists")
+            else:
+                result.fail(f"Overlay {overlay}: missing {req_file}")
+
+
+def check_overlay_essential_size(result: ValidationResult) -> None:
+    """Overlay essential overlays must be compact (under threshold)."""
+    for overlay in OVERLAYS:
+        path = PIPELINE_ROOT / "overlays" / overlay / "implementer-overlay-essential.md"
+        if not path.exists():
+            continue  # already caught by completeness check
+
+        size = len(path.read_text())
+        if size <= ESSENTIAL_OVERLAY_MAX_CHARS:
+            result.ok(f"Overlay {overlay}: essential overlay is {size} chars (under {ESSENTIAL_OVERLAY_MAX_CHARS})")
+        else:
+            result.fail(
+                f"Overlay {overlay}: essential overlay is {size} chars "
+                f"(exceeds {ESSENTIAL_OVERLAY_MAX_CHARS} limit)"
+            )
+
+
+def check_orchestrate_overlay_loading(result: ValidationResult) -> None:
+    """Orchestrate must document cross-cutting overlay loading."""
+    orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
+    if not orchestrate_path.exists():
+        return
+
+    content = orchestrate_path.read_text()
+
+    if "overlays" in content.lower():
+        result.ok("Orchestrate documents overlay loading")
+    else:
+        result.fail("Orchestrate missing overlay loading documentation")
+
+    if "Cross-Cutting" in content:
+        result.ok("Orchestrate documents cross-cutting overlay composition")
+    else:
+        result.fail("Orchestrate missing cross-cutting overlay composition documentation")
+
+
+def check_init_bicep_detection(result: ValidationResult) -> None:
+    """init.sh must contain Bicep stack detection."""
+    init_path = PIPELINE_ROOT / "init.sh"
+    if not init_path.exists():
+        return
+
+    content = init_path.read_text()
+
+    if "bicep" in content.lower():
+        result.ok("init.sh references bicep stack")
+    else:
+        result.fail("init.sh missing bicep stack detection")
+
+    if "detect_overlays" in content or "overlays" in content:
+        result.ok("init.sh supports overlay detection")
+    else:
+        result.fail("init.sh missing overlay detection support")
+
+
 def run_all_checks(verbose: bool = False) -> ValidationResult:
     result = ValidationResult()
 
@@ -562,6 +651,10 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Skill frontmatter", check_skill_frontmatter),
         ("Cross-references", check_cross_references),
         ("Fix-defects skill", check_fix_defects_skill),
+        ("Overlay completeness", check_overlay_completeness),
+        ("Overlay essential size", check_overlay_essential_size),
+        ("Orchestrate overlay loading", check_orchestrate_overlay_loading),
+        ("init.sh bicep detection", check_init_bicep_detection),
     ]
 
     for name, check_fn in checks:


### PR DESCRIPTION
## Summary

- **Bicep adapter** (9 files) — full adapter for Azure Infrastructure as Code with build/lint/test scripts, 8-category code review, hooks, and overlays for all 4 agents
- **Azure SDK overlay system** — new cross-cutting overlay concept that layers Azure SDK best practices (DefaultAzureCredential, retry, Key Vault, managed identity) onto any existing adapter (python, react, swift-ios, bicep). Auto-detected from project dependencies.
- **7 new skills** — `azure-login` (auth pre-flight), `validate-bicep`, `deploy-bicep` (with mandatory confirmation gate), `azure-cost-estimate`, `security-scan`, `infra-test-runner`, `azure-drift-check`
- **Auth infrastructure** — lazy pre-flight auth validation before Azure-dependent steps, subscription context verification, RBAC permission checks, guided remediation for all auth methods (interactive, service principal, managed identity, GitHub Actions OIDC)
- **init.sh** — Bicep stack detection (root + infra/deploy/modules dirs), Azure SDK overlay detection from deps, `overlays` config key, conditional overlay symlink
- **Orchestrator** — Step 0.1 (overlay loading/composition), Step 0.2 (lazy Azure auth pre-flight)
- **Test infrastructure** — 203 structural checks (was 163), 51 contract tests (was 34), 10 new fixtures, 5 new parsers

## Test plan

- [x] `python3 tests/validate_structure.py` — 203/203 passed
- [x] `python3 tests/test_contracts.py` — 51/51 passed
- [ ] `bash init.sh /tmp/test-bicep --stack=bicep` — verify symlinks, config with overlays key, hooks
- [ ] `bash init.sh /tmp/test-python-azure --stack=python` on a project with `azure-*` in requirements.txt — verify overlay auto-detection
- [ ] Smoke test: bootstrap a Bicep project and run `/orchestrate` on a simple template change
- [ ] Verify `deploy-bicep` confirmation gate blocks without explicit "yes"
- [ ] Verify `azure-login` provides clear guidance when `az` is not authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)