### PR TITLE
fix(pipeline): address token cost findings from issue #6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Layer 2 (dry-run mode for prompt composition validation) is planned but not yet 
 
 ### Pipeline Flow
 
-User request → **1a: Analyze & Clarify** (Sonnet) → **1b: Plan** (Opus) → **1.5: Open Draft PR** → **2: Implement** (Haiku per task) → **2.1: Review** (Sonnet) → **2.2: Fix** (Sonnet) → **3: Commit & Push** → **3.5: Manual Test Loop** → **4: Finalize PR** → **5: Token Analysis** (mandatory)
+User request → **1a: Analyze & Clarify** (Sonnet) → **1b: Plan** (Sonnet default, Opus for novel architecture) → **1.5: Open Draft PR** → **2: Implement** (Haiku per task) → **2.1: Review** (Sonnet) → **2.2: Fix** (Sonnet) → **3: Commit & Push** → **3.5: Manual Test Loop** → **4: Finalize PR** → **5: Token Analysis** (mandatory)
 
 ### Three Layers
 
@@ -85,17 +85,22 @@ Conditional pipeline behavior (e.g., Azure authentication pre-flight) is driven 
 ### Model Assignment Strategy
 
 - **Haiku** (~70%): Single-file, fully-specified mechanical tasks via implementer-agent and test-architect-agent
-- **Sonnet** (~20%): Judgment tasks — code review, design decisions, fixes, analysis (step 1a)
-- **Opus** (~10%): Architecture and planning (step 1b)
+- **Sonnet** (~25%): Judgment tasks — code review, design decisions, fixes, analysis (step 1a), and planning for routine features (step 1b default)
+- **Opus** (~5%): Planning for novel architecture, cross-cutting changes, or security-critical design (step 1b escalation only)
 
-The planner's job is to decompose work so Haiku can execute it. Irreducibly complex tasks (algorithms, security, concurrency) escalate to Sonnet/Opus.
+The planner's job is to decompose work so Haiku can execute it. Irreducibly complex tasks (algorithms, security, concurrency) escalate to Sonnet/Opus. Step 1b defaults to Sonnet — Opus is reserved for cases where the 1a-spec indicates novel architecture or cross-cutting complexity.
 
 ### Token Optimization
 
 The orchestrator uses several strategies to reduce token consumption:
+- **Sonnet-default planning**: Step 1b defaults to Sonnet instead of Opus, reducing planning cost by ~5x for routine features. Opus is reserved for novel architecture or cross-cutting complexity.
+- **Brief-size gate**: The planner enforces token limits on context briefs (Haiku: 3K, Sonnet: 6K, Opus: 8K). Oversized briefs must be trimmed or split before implementation.
+- **Wave batch cap**: Waves are capped at 4 tasks. The orchestrator splits larger waves into batches of ≤4, reducing blast radius and keeping agent calls under ~50K tokens.
+- **Plan output budget**: Context briefs are capped at 400 tokens each; total plan output targets ≤4,000 tokens for ≤15-task features.
 - **Scoped ORCHESTRATOR.md extracts**: Each agent receives only the sections it needs (1a gets fragile areas + architecture, 1b gets conventions + data flow, 3.5 gets fragile areas only), not the full file.
 - **Essential overlay variants**: Haiku implementers receive a compact rules-only overlay (~500-800 chars) instead of the full overlay (~3,500 chars). The reviewer has the full overlay and catches violations.
 - **Reviewer reuse**: Within a wave, one code-reviewer agent handles all reviews via SendMessage, avoiding re-ingestion of the agent definition and overlay per review (cap: 8 reviews per agent).
+- **Cost-weighted distribution tracking**: Token analysis reports model distribution by dollar cost, not call count, preventing misleading metrics (e.g., "69% Haiku calls" masking 12% cost share).
 - **TOKEN_REPORT**: All agents append a `---TOKEN_REPORT---` block to their output reporting files read from disk, tool calls, and self-assessed token consumption. This captures the ~43% of token usage invisible to the orchestrator's prompt-level tracking.
 
 ### Output Protocols

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -179,6 +179,11 @@ Wave 2 (parallel): [Task D - Haiku, needs A+C] [Task E - Haiku, needs B]
 Wave 3 (sequential): [Task F - Haiku, integration test, needs D+E]
 ```
 
+**Wave sizing:** Keep each wave to a maximum of **4 tasks**. If more than 4 independent tasks
+exist at the same dependency level, split them into separate waves (e.g., Wave 1a and Wave 1b).
+This keeps individual agent calls under ~50K input tokens and reduces blast radius — a failure
+in one batch doesn't require re-running the other batch.
+
 ## Output Format
 
 The plan MUST be output as a structured document following this exact format:
@@ -266,6 +271,23 @@ The plan MUST be output as a structured document following this exact format:
 
 Before finalizing the plan, verify each task against these criteria:
 
+**Brief size gate** — estimate the token count of each context brief (1 token ≈ 4 characters).
+Flag any brief that would exceed these thresholds:
+
+| Model | Max brief tokens | Action if exceeded |
+|-------|------------------|--------------------|
+| Haiku | 3,000 | Decompose further or trim unnecessary context |
+| Sonnet | 6,000 | Trim — remove file dumps, inline only the signatures/types needed |
+| Opus | 8,000 | Acceptable only if the task is genuinely irreducible |
+
+Common causes of oversized briefs:
+- Pasting full file contents instead of the relevant interface/types
+- Including background context the implementer doesn't need to act on
+- Duplicating information already in the adapter overlay
+
+If a brief exceeds its threshold, do NOT proceed — either split the task or reduce the brief
+to only what the implementer needs to produce code.
+
 **Haiku readiness checklist** — read `.claude/agents/implementer-contract.md` for the canonical
 6-point contract. Every Haiku task must pass ALL items in that contract.
 
@@ -280,6 +302,13 @@ Before finalizing the plan, verify each task against these criteria:
 - [ ] OR concurrent/async correctness that requires holistic reasoning
 - [ ] OR security/financial-critical logic where subtle errors have severe consequences
 - [ ] The cost of an Opus task is justified by the cost of getting it wrong
+
+**Wave-ordering validation** — verify these sequencing rules before finalizing:
+- [ ] A test task for component X is in the **same wave or a later wave** than the
+  implementation task for X. Placing a test before its component causes guaranteed retry waste.
+- [ ] Tasks that produce interfaces consumed by other tasks are in an earlier wave than
+  their consumers.
+- [ ] Integration test tasks are in the final wave, after all component tasks complete.
 
 ## Common Mistakes to Avoid
 
@@ -316,6 +345,23 @@ Sometimes the planner can't fully specify a task because it depends on runtime d
 **Haiku limits:** Keep output <150 lines. Make ALL conventions explicit. If >3 edge cases, split or escalate.
 
 **Pricing:** Haiku $1/$5, Sonnet $3/$15, Opus $15/$75 per M tokens (in/out). A plan with 20 Haiku tasks ~ 4 Sonnet tasks ~ 1.3 Opus tasks.
+
+## Output Budget
+
+The plan's total output is expensive — at Opus rates, every 1,000 output tokens costs $0.075.
+Apply these limits to keep planning costs proportional to implementation costs:
+
+- **Context briefs**: max 400 tokens each. Lead with the objective and output spec; omit
+  background the implementer doesn't need. If a brief requires more than 400 tokens, the task
+  may need further decomposition.
+- **Overview section**: max 200 tokens. State what is being built and the key constraint — no
+  background essays.
+- **Risk notes**: max 100 tokens. Only include genuine risks, not boilerplate.
+- **Total plan output**: target under 4,000 tokens for features with ≤15 tasks. For larger
+  plans, scale linearly (~250 tokens per additional task).
+
+These limits apply to the plan output text only — inline code snippets in context briefs
+(type definitions, signatures) do not count against the token budget.
 
 ## Plan Persistence
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -218,7 +218,7 @@ Step 1a: ANALYZE & CLARIFY (architect-agent, Sonnet, interactive)
     |  Pre-flight check -> seam analysis -> clarifying questions (iterative)
     |  Writes: .claude/tmp/1a-spec.md (enriched spec + recovery artifact)
     v
-Step 1b: PLAN (architect-agent, Opus, fresh agent)
+Step 1b: PLAN (architect-agent, Sonnet default / Opus for novel architecture, fresh agent)
     |  Reads: 1a-spec.md + full ORCHESTRATOR.md (clean context, ~15K tokens)
     |  Produces: ordered task list with context briefs
     |  Present to user for confirmation
@@ -321,9 +321,22 @@ Prompt: |
 
 Launch a **fresh** architect-agent in 1b mode. Do NOT use SendMessage from the 1a agent — start a new agent so 1b has a clean context window (~15K tokens of focused signal vs. the full 1a Q&A history).
 
+**Model selection:** Default to **Sonnet** for Step 1b. Only escalate to **Opus** when the
+1a-spec indicates at least one of:
+- Novel architecture with no existing patterns in the codebase to follow
+- Cross-cutting changes affecting 3+ services/modules with shared state
+- Concurrent/async coordination requiring holistic correctness reasoning
+- Security-critical design where subtle errors have severe consequences
+
+Most feature work — CRUD endpoints, UI components, config changes, test additions,
+mechanical refactors — does not need Opus-level planning. The planner skill's decomposition
+logic works equally well on Sonnet for well-understood problem types. When in doubt, start
+with Sonnet; if the plan quality is poor (vague briefs, missed dependencies), the user can
+request a re-plan with Opus.
+
 ```
 Agent: architect-agent
-Model: opus
+Model: <sonnet (default) or opus (if escalation criteria above are met)>
 Prompt: |
   MODE: 1b — Plan Generation
 
@@ -364,7 +377,7 @@ answers, the agent completes the plan.
 
 Present the plan summary to the user and wait for confirmation before proceeding.
 
-**Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If architecture decision questions occur, record the SendMessage round as step `1b:decision`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: `opus`.
+**Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If architecture decision questions occur, record the SendMessage round as step `1b:decision`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: as selected above (`sonnet` or `opus`).
 
 **Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.
 
@@ -388,7 +401,13 @@ All subsequent commits and pushes target this branch.
 For each wave in the plan, launch implementer agents. **Tasks within a wave run in parallel.**
 Tasks across waves are sequential (wave N+1 waits for wave N to complete).
 
-For each task in the current wave:
+**Batch cap:** If a wave contains more than 4 tasks assigned to the same model, split them
+into multiple agent calls of at most 4 tasks each. This reduces blast radius (a failure at
+task 3 doesn't require re-running tasks 5-8) and keeps individual agent calls under ~50K
+input tokens. The planner should ideally keep waves to ≤4 tasks, but if it produces larger
+waves, the orchestrator enforces the cap here.
+
+For each task (or batch of up to 4 tasks) in the current wave:
 
 1. Read the task's `Stack:` field from the plan to determine `<task_stack>`.
    If the plan omits the stack field, resolve it from the task's file paths using the

--- a/skills/token-analysis/SKILL.md
+++ b/skills/token-analysis/SKILL.md
@@ -36,12 +36,18 @@ Identify the top 3 most expensive steps by total cost.
 
 ### 2. Model Distribution Analysis
 
-Compare actual model usage (by token spend, not call count) against the 70/20/10 target:
-- **Haiku** should be ~70% of total token spend
+Compare actual model usage **by estimated dollar cost** (not call count or raw token count)
+against the 70/20/10 target:
+- **Haiku** should be ~70% of total dollar spend
 - **Sonnet** should be ~20%
 - **Opus** should be ~10%
 
-Flag if any model deviates more than 15 percentage points from its target.
+Compute each model's share as: `model_cost / total_cost × 100`. Report BOTH cost-weighted
+percentages AND call-count percentages — but flag deviations based on the cost metric only.
+Call-count percentages can create a false sense of efficiency (e.g., "69% Haiku calls" while
+Haiku accounts for only 12% of spend).
+
+Flag if any model deviates more than 15 percentage points from its target on the cost metric.
 
 ### 3. Prompt Efficiency Analysis
 
@@ -164,11 +170,11 @@ Use this structure for the issue body:
 
 ## Model Distribution
 
-| Model | Target % | Actual % | Delta | Calls | Cost |
-|-------|----------|----------|-------|-------|------|
-| Haiku | 70% | X% | +/-X% | X | $X.XX |
-| Sonnet | 20% | X% | +/-X% | X | $X.XX |
-| Opus | 10% | X% | +/-X% | X | $X.XX |
+| Model | Target % (cost) | Actual % (cost) | Delta | Calls (%) | Est. Cost |
+|-------|----------------|-----------------|-------|-----------|-----------|
+| Haiku | 70% | X% | +/-Xpp | X (X%) | $X.XX |
+| Sonnet | 20% | X% | +/-Xpp | X (X%) | $X.XX |
+| Opus | 10% | X% | +/-Xpp | X (X%) | $X.XX |
 
 ## Findings
 


### PR DESCRIPTION
## Summary

Addresses all 5 findings from the token cost analysis in #6, where Opus planning consumed 53% of total pipeline spend (target: 10%):

- **F1 — Opus dominance**: Step 1b now defaults to Sonnet; Opus reserved for novel architecture, cross-cutting changes, or security-critical design. Estimated ~5x reduction in planning cost for routine features.
- **F2 — Misleading metrics**: Token analysis now reports model distribution by dollar cost (not call count), preventing stats like "69% Haiku calls" from masking 12% cost share.
- **F3 — Oversized briefs**: Added brief-size gate in the planner (Haiku: 3K, Sonnet: 6K, Opus: 8K tokens). Briefs exceeding thresholds must be trimmed or split before proceeding.
- **F4 — Batch blowup**: Waves capped at 4 tasks; orchestrator splits larger waves into ≤4 batches, keeping agent calls under ~50K tokens and reducing retry blast radius.
- **F5 — Wave misordering**: Added wave-ordering validation ensuring test tasks are in the same or later wave than their component implementation tasks.

Also adds a plan output budget (400 tokens/brief, 4K total for ≤15-task features) to keep planning output proportional to implementation cost.

Closes #6

## Test plan

- [x] `python3 tests/validate_structure.py` — 263/263 checks pass
- [x] `python3 tests/test_contracts.py` — 51/51 tests pass
- [ ] Run pipeline on a routine feature to verify Sonnet 1b produces viable plans
- [ ] Run pipeline on a cross-cutting change to verify Opus escalation triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)