### PR TITLE
fix: optimize pipeline workflow for token cost and wall-clock time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,13 @@ The planner's job is to decompose work so Haiku can execute it. Irreducibly comp
 ### Token Optimization
 
 The orchestrator uses several strategies to reduce token consumption:
-- **Scoped ORCHESTRATOR.md extracts**: Each agent receives only the sections it needs (1a gets fragile areas + architecture, 1b gets conventions + data flow, 3.5 gets fragile areas only), not the full file.
+- **Scoped ORCHESTRATOR.md extracts**: Each agent receives only the sections it needs (1a gets fragile areas + architecture, 1b gets only sections NOT already in 1a-spec, 3.5 gets fragile areas only), not the full file. The 1b Extract excludes Architecture and Key Services/Modules since those are already embedded in the 1a-spec.
 - **Essential overlay variants**: Haiku implementers receive a compact rules-only overlay (~500-800 chars) instead of the full overlay (~3,500 chars). The reviewer has the full overlay and catches violations.
-- **Reviewer reuse**: Within a wave, one code-reviewer agent handles all reviews via SendMessage, avoiding re-ingestion of the agent definition and overlay per review (cap: 8 reviews per agent).
+- **Reviewer reuse**: Within a wave, one code-reviewer agent handles all reviews via SendMessage, avoiding re-ingestion of the agent definition and overlay per review (cap: 8 reviews per agent). Bug-fix reviews in Step 3.5 use the same reuse pattern.
+- **Streaming reviews**: Reviews start as soon as each implementer completes, not after the full wave finishes. This overlaps review work with still-running implementer tasks.
+- **Parallel bug fixes**: Independent bugs (non-overlapping file sets) found during manual testing can be fixed in parallel using worktree isolation.
+- **Local overlay comment stripping**: HTML comment blocks are stripped from `.claude/local/` files before injection, so template placeholders don't waste tokens.
+- **Background token analysis**: Step 5 (token analysis) runs in the background concurrently with Step 4 (PR finalization), reducing wall-clock time.
 - **TOKEN_REPORT**: All agents append a `---TOKEN_REPORT---` block to their output reporting files read from disk, tool calls, and self-assessed token consumption. This captures the ~43% of token usage invisible to the orchestrator's prompt-level tracking.
 
 ### Output Protocols

--- a/README.md
+++ b/README.md
@@ -266,9 +266,13 @@ A typical feature plan targets **>=70% Haiku tasks**, making the mixed strategy 
 
 The pipeline also reduces per-step token consumption through several strategies:
 
-- **Scoped ORCHESTRATOR.md extracts**: Instead of pasting the full architecture file into every agent, the orchestrator extracts only the sections each agent needs (e.g., blast-radius analysis only gets Directory Structure, Fragile Areas, and Key Services)
+- **Scoped ORCHESTRATOR.md extracts**: Instead of pasting the full architecture file into every agent, the orchestrator extracts only the sections each agent needs. The 1b Extract excludes sections already present in the 1a-spec (Architecture, Key Services) to avoid duplication on the most expensive model.
 - **Essential overlay variants**: Haiku implementers receive a compact rules-only overlay (~500-800 chars) instead of the full overlay with examples (~3,500 chars). The reviewer has the full overlay and catches violations.
-- **Reviewer reuse via SendMessage**: Within a wave, one code-reviewer agent handles all reviews via SendMessage, avoiding re-ingestion of the agent definition and overlay per review (cap: 8 reviews per agent)
+- **Reviewer reuse via SendMessage**: Within a wave, one code-reviewer agent handles all reviews via SendMessage, avoiding re-ingestion of the agent definition and overlay per review (cap: 8 reviews per agent). Bug-fix reviews in Step 3.5 use the same reuse pattern.
+- **Streaming wave reviews**: Reviews begin as each implementer completes, not after the full wave finishes. This overlaps review work with still-running tasks, reducing wall-clock time.
+- **Parallel bug fixes**: Independent bugs (non-overlapping file sets) found during manual testing can be fixed in parallel using worktree isolation, same as Step 2 implementation.
+- **Local overlay comment stripping**: HTML comment blocks are stripped from `.claude/local/` files before injection, so template placeholders don't waste tokens.
+- **Background token analysis**: Step 5 runs concurrently with Step 4 (PR finalization) since it only needs the TOKEN_LEDGER, which is complete after Step 3.5.
 - **TOKEN_REPORT protocol**: All agents append a `---TOKEN_REPORT---` block to their output, self-reporting files read from disk, tool calls, and token consumption. This captures the ~43% of token usage invisible to the orchestrator's prompt-level tracking.
 - **Mandatory Step 5 analysis**: After every pipeline run, the token-analysis skill examines the accumulated ledger for cost anomalies, model distribution drift, prompt bloat, and escalation patterns — filing a GitHub issue on the pipeline repo when significant findings exist
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -119,13 +119,15 @@ After loading cross-cutting overlays, check for project-specific local overlays 
    - `.claude/local/architecture-rules.md` — injected into architect agent
    - `.claude/local/review-criteria.md` — injected into reviewer agent
 
-3. Build a **LOCAL_OVERLAYS** registry:
+3. For each file, **strip HTML comment blocks** (`<!-- ... -->`) and leading/trailing whitespace
+   before storing. This removes template placeholder comments that would waste tokens.
+   Build a **LOCAL_OVERLAYS** registry from the stripped content:
    ```
    LOCAL_OVERLAYS = {
-     all: <project-overlay.md content or empty>,
-     implementer: <coding-standards.md content or empty>,
-     architect: <architecture-rules.md content or empty>,
-     reviewer: <review-criteria.md content or empty>,
+     all: <project-overlay.md stripped content or empty>,
+     implementer: <coding-standards.md stripped content or empty>,
+     architect: <architecture-rules.md stripped content or empty>,
+     reviewer: <review-criteria.md stripped content or empty>,
    }
    ```
 
@@ -162,8 +164,9 @@ After loading cross-cutting overlays, check for project-specific local overlays 
    overlay exceeds 500 characters, consider trimming — the pipeline does not enforce a size
    limit on local overlays, but bloated overlays degrade Haiku signal-to-noise ratio.
 
-7. **If all local overlay files are empty or contain only HTML comments:** Skip injection
-   entirely — do not add empty `## Project:` headers.
+7. **If all local overlay files are empty after stripping:** Skip injection entirely — do not
+   add empty `## Project:` headers. A file that contains only the template placeholder
+   comments will be empty after stripping and is treated as absent.
 
 ## Step 0.3: Azure Authentication Pre-Flight
 
@@ -247,15 +250,15 @@ produce three scoped extracts:
 - `## Current State`
 
 **1b Extract** (for architect-planner — decomposition, brief writing):
-- `## Architecture`
-- `## Key Services / Modules`
 - `## Data Flow`
 - `## Conventions` (all subsections)
 - `## Testing`
 - `## Anti-Patterns (Do NOT)`
 
-The 1b agent also receives the 1a-spec which already contains the project overview, directory
-structure, fragile areas, and current state — so those sections are not needed again.
+The 1b agent receives the 1a-spec which already contains Project Overview, Directory Structure,
+Architecture, Key Services / Modules, Known Fragile Areas, and Current State — so those sections
+are excluded from the 1b Extract to avoid duplication. Only sections NOT present in the 1a-spec
+are included.
 
 **3.5 Extract** (for blast-radius analysis — file correlation, fragile area check):
 - `## Directory Structure`
@@ -275,8 +278,8 @@ Step 1a: ANALYZE & CLARIFY (architect-agent, Sonnet, interactive)
     |  Pre-flight check -> seam analysis -> clarifying questions (iterative)
     |  Writes: .claude/tmp/1a-spec.md (enriched spec + recovery artifact)
     v
-Step 1b: PLAN (architect-agent, Opus, fresh agent)
-    |  Reads: 1a-spec.md + full ORCHESTRATOR.md (clean context, ~15K tokens)
+Step 1b: PLAN (architect-agent, Sonnet default / Opus for novel, fresh agent)
+    |  Reads: 1a-spec.md + 1b Extract from ORCHESTRATOR.md (clean context, ~12K tokens)
     |  Produces: ordered task list with context briefs
     |  Present to user for confirmation
     v
@@ -451,6 +454,12 @@ All subsequent commits and pushes target this branch.
 For each wave in the plan, launch implementer agents. **Tasks within a wave run in parallel.**
 Tasks across waves are sequential (wave N+1 waits for wave N to complete).
 
+**Streaming reviews:** Do NOT wait for all tasks in a wave to complete before starting reviews.
+As each implementer returns SUCCESS, immediately send it to the reviewer (via the wave's shared
+reviewer agent). This overlaps review work with still-running implementer tasks, reducing
+wall-clock time. The reviewer agent is launched on the first SUCCESS result; subsequent results
+use SendMessage. Failed implementers are reported to the user immediately without waiting.
+
 For each task in the current wave:
 
 1. Read the task's `Stack:` field from the plan to determine `<task_stack>`.
@@ -494,10 +503,11 @@ examples and patterns are valuable.
 **Stack scoping rationale:** The implementer only needs rules for the stack it is working in.
 Loading all stacks' overlays would dilute Haiku's signal-to-noise ratio and waste tokens.
 
-**After each implementer returns:**
+**After each implementer returns** (as soon as it completes, not after the full wave):
 
-- If `SUCCESS`: proceed to Step 2.1 (review)
-- If `FAILURE`: report the failure details to the user. Do NOT auto-retry implementation failures — these need human judgment.
+- If `SUCCESS`: immediately send to the wave's reviewer agent (Step 2.1). If this is the first
+  SUCCESS in the wave, launch the reviewer agent. Otherwise, use SendMessage.
+- If `FAILURE`: report the failure details to the user immediately. Do NOT auto-retry implementation failures — these need human judgment. Do NOT block other tasks' reviews.
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry for each implementer agent (step `2:<task_id>`, e.g., `2:1.1`). Agent: `implementer-agent`, model: as assigned by the plan.
 
@@ -631,6 +641,18 @@ After all implementation is committed and pushed, prompt the user to test the PR
 
 **For each bug reported, run this cycle:**
 
+**Parallel bug fixes:** When the user reports multiple bugs at once, group them by independence:
+- **Independent bugs** have non-overlapping file sets (no shared files to modify). These can be
+  fixed in parallel using worktree isolation (same pattern as Step 2 parallel tasks).
+- **Dependent bugs** share files or have causal relationships. These must be fixed sequentially.
+
+To parallelize: run Step 3.5.1 (ASSESS) for all bugs first. After assessment, identify which
+bugs have non-overlapping FILES TO MODIFY lists. Launch parallel implementer agents (with
+worktree isolation) for independent bugs. Review them using the shared bug-fix reviewer agent
+via SendMessage. Commit in assessment order (not completion order) for deterministic history.
+
+If the user reports bugs one at a time (interactive), process them sequentially as before.
+
 #### 3.5.1: ASSESS
 
 The orchestrator assesses each bug — do NOT delegate this to a subagent:
@@ -733,6 +755,13 @@ Prompt: |
 
 #### 3.5.3: REVIEW
 
+**Reviewer reuse:** Use the same SendMessage pattern as Step 2.1 wave reviews to avoid
+re-ingesting the agent definition and overlays for each bug-fix review. Launch ONE
+code-reviewer agent for the first bug-fix review, then reuse it via SendMessage for subsequent
+bug-fix reviews in the same manual test round.
+
+**First bug-fix review** — launch a fresh reviewer:
+
 ```
 Agent: code-reviewer-agent
 Model: sonnet
@@ -761,10 +790,30 @@ Prompt: |
   <list the files the fix agent modified>
 ```
 
+**Subsequent bug-fix reviews** — reuse the same agent via SendMessage:
+
+```
+SendMessage to: <bug-fix reviewer agent from first review>
+Message: |
+  NEW REVIEW — discard all prior review context. Review ONLY the following changes.
+
+  This is a BUG FIX review. Explicitly verify:
+  - The fix does not revert or contradict the original implementation's intent
+  - The fix does not introduce regressions in adjacent functionality
+  - The test count has not decreased from the baseline
+
+  REVIEW THESE CHANGES:
+
+  <list the files the fix agent modified>
+```
+
+**Cap at 8 reviews per agent** (same as wave reviews). If a manual test round produces more
+than 8 bug-fix reviews, launch a fresh reviewer for reviews 9+.
+
 **Token tracking:** Record `TOKEN_LEDGER` entries for each sub-step of the bug-fix cycle:
 - Blast-radius analysis (if triggered): step `3.5:assess:<bug_id>`, agent: `architect-agent`, model: `sonnet`
 - Bug fix: step `3.5:fix:<bug_id>`, agent: `implementer-agent`, model: `sonnet`, set `is_retry: true`
-- Bug fix review: step `3.5:review:<bug_id>`, agent: `code-reviewer-agent`, model: `sonnet`
+- Bug fix review: step `3.5:review:<bug_id>`, agent: `code-reviewer-agent`, model: `sonnet`. For SendMessage reviews, `input_chars` is the SendMessage content only.
 
 #### 3.5.4: COMMIT + PUSH
 
@@ -810,8 +859,13 @@ The orchestrator does NOT merge — the user decides when to merge.
 
 ### Step 5: TOKEN ANALYSIS (mandatory)
 
-After finalization, analyze the token usage accumulated throughout this pipeline run. This step
-always runs — it is not skippable.
+**Timing:** Launch token analysis **in the background** at the same time as Step 4 finalization.
+The TOKEN_LEDGER is complete after Step 3.5 — it does not depend on PR finalization. This
+overlaps analysis work with ORCHESTRATOR.md updates, PR body updates, and `gh pr ready`,
+reducing wall-clock time. If analysis files a GitHub issue, report it to the user after
+Step 4 completes (or immediately if Step 4 finishes first).
+
+This step always runs — it is not skippable.
 
 #### 5.1: Compute Summary
 

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -143,8 +143,6 @@ EXTRACT_PROFILES = {
         "Current State",
     ],
     "1b": [
-        "Architecture",
-        "Key Services / Modules",
         "Data Flow",
         "Conventions",
         "Testing",
@@ -486,6 +484,45 @@ def check_orchestrate_local_overlay_loading(result: ValidationResult) -> None:
         result.fail("Orchestrate missing project overlay composition headers")
 
 
+def check_orchestrate_workflow_optimizations(result: ValidationResult) -> None:
+    """Orchestrate must document key workflow optimizations."""
+    orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
+    if not orchestrate_path.exists():
+        return
+
+    content = orchestrate_path.read_text()
+
+    # Streaming reviews: reviews start as implementers complete, not after full wave
+    if "Streaming review" in content or "streaming review" in content.lower():
+        result.ok("Orchestrate documents streaming wave reviews")
+    else:
+        result.fail("Orchestrate missing streaming wave reviews documentation")
+
+    # Bug-fix reviewer reuse via SendMessage (same pattern as wave reviews)
+    if "bug-fix reviewer" in content.lower() or "bug-fix review" in content.lower():
+        result.ok("Orchestrate documents bug-fix reviewer reuse")
+    else:
+        result.fail("Orchestrate missing bug-fix reviewer reuse documentation")
+
+    # Parallel bug fixes for independent bugs
+    if "Parallel bug fix" in content or "parallel bug fix" in content.lower():
+        result.ok("Orchestrate documents parallel bug fixes")
+    else:
+        result.fail("Orchestrate missing parallel bug fixes documentation")
+
+    # HTML comment stripping for local overlays
+    if "strip HTML comment" in content or "strip html comment" in content.lower():
+        result.ok("Orchestrate documents HTML comment stripping for local overlays")
+    else:
+        result.fail("Orchestrate missing HTML comment stripping for local overlays")
+
+    # Token analysis runs in background during finalization
+    if "background" in content.lower() and "token analysis" in content.lower():
+        result.ok("Orchestrate documents background token analysis")
+    else:
+        result.fail("Orchestrate missing background token analysis documentation")
+
+
 def check_agent_frontmatter(result: ValidationResult) -> None:
     """Agent files must have valid YAML frontmatter with name, model, description."""
     frontmatter_re = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
@@ -799,6 +836,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("init.sh", check_init_script),
         ("Version file", check_version_file),
         ("Orchestrate local overlay loading", check_orchestrate_local_overlay_loading),
+        ("Workflow optimizations", check_orchestrate_workflow_optimizations),
         ("Agent frontmatter", check_agent_frontmatter),
         ("Skill frontmatter", check_skill_frontmatter),
         ("Cross-references", check_cross_references),


### PR DESCRIPTION
## Summary

Six optimizations targeting the two biggest cost/latency drivers in the pipeline: redundant token injection across agent calls, and sequential bottlenecks that could overlap.

### Token cost reductions

- **Strip 1b Extract overlap** — The 1b Extract previously included Architecture and Key Services/Modules, which are already embedded in the 1a-spec. Removing them saves 3-5KB per pipeline run on the most expensive model (Opus/Sonnet).
- **Reuse reviewer in 3.5 bug-fix reviews** — Previously launched a fresh `code-reviewer-agent` per bug fix (re-ingesting ~15-25KB of agent def + overlays each time). Now uses SendMessage reuse pattern, same as wave reviews in Step 2.1. Cap: 8 reviews per agent.
- **Strip HTML comments from local overlays** — Template placeholder comments (`<!-- ... -->`) are stripped before injection, so uncustomized `.claude/local/` files waste zero tokens instead of injecting comment blocks into every agent call.

### Wall-clock time reductions

- **Streaming wave reviews** — Reviews start as each implementer completes, not after the full wave finishes. Overlaps review work with still-running tasks.
- **Parallel bug fixes** — Independent bugs (non-overlapping file sets) found during manual testing can be fixed in parallel using worktree isolation. Dependent bugs remain sequential.
- **Background token analysis** — Step 5 (token analysis) runs concurrently with Step 4 (PR finalization) since TOKEN_LEDGER is complete after Step 3.5.

### Files changed

| File | Change |
|------|--------|
| `skills/orchestrate/SKILL.md` | Core optimizations: 1b Extract trimming, streaming reviews, parallel bug fixes, reviewer reuse in 3.5, comment stripping, background analysis |
| `tests/validate_structure.py` | +5 checks for new optimization patterns, removed 2 stale 1b Extract headers from extract profiles |
| `CLAUDE.md` | Updated Token Optimization section with new strategies |
| `README.md` | Updated Token Optimization section with new strategies |

## Test plan

- [x] `python3 tests/validate_structure.py` — 277 checks pass
- [x] `python3 tests/test_contracts.py` — 51 contract tests pass
- [x] `python3 tests/smoke/run_smoke.py` — 31 smoke checks pass
- [ ] Run a full pipeline with the optimizations and compare TOKEN_LEDGER to a baseline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)