### PR TITLE
Separate feature vs implementation Q&A in planning phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Layer 2 (dry-run mode for prompt composition validation) is planned but not yet 
 
 ### Pipeline Flow
 
-User request → **1a: Analyze & Clarify** (Sonnet) → **1b: Plan** (Sonnet default, Opus for novel architecture) → **1.5: Open Draft PR** → **2: Implement** (Haiku per task) → **2.1: Review** (Sonnet) → **2.2: Fix** (Sonnet) → **3: Commit & Push** → **3.5: Manual Test Loop** → **4: Finalize PR** → **5: Token Analysis** (mandatory)
+User request → **1a: Feature Clarification** (Sonnet, feature-only Q&A) → **1b: Implementation Clarification & Plan** (Sonnet default, Opus for novel architecture — implementation-specific Q&A then decomposition) → **1.5: Open Draft PR** → **2: Implement** (Haiku per task) → **2.1: Review** (Sonnet) → **2.2: Fix** (Sonnet) → **3: Commit & Push** → **3.5: Manual Test Loop** → **4: Finalize PR** → **5: Token Analysis** (mandatory)
 
 ### Three Layers
 

--- a/agents/architect-agent.md
+++ b/agents/architect-agent.md
@@ -11,7 +11,7 @@ memory: project
 You are the architect for this project. Your job is to take feature requests and architectural changes and produce **implementation plans so precise that most tasks can be executed by Haiku**.
 
 When launched by the orchestration pipeline, the prompt specifies which skill file to read:
-- **1a (Analysis):** `.claude/skills/architect-analyzer/SKILL.md` — do NOT enter plan mode (you need to write files)
+- **1a (Analysis):** `.claude/skills/architect-analyzer/SKILL.md` — do NOT enter plan mode (plan mode is read-only, but you must write the enriched spec file)
 - **1b (Planning):** `.claude/skills/architect-planner/SKILL.md` — enter plan mode (read-only is correct)
 
 When running standalone (no MODE header in prompt), read `.claude/skills/architect-planner/SKILL.md` and enter plan mode.
@@ -42,11 +42,12 @@ Before planning, gather the information you need:
 2. Read the user's request and identify what's actually being asked.
 3. Consult CLAUDE.md and your agent memory for supplementary patterns.
 4. Examine relevant existing code to understand integration points.
-5. **Ask clarifying questions** if requirements are ambiguous (Mode 1a). In Mode 1b, the enriched spec is authoritative — do not re-ask.
+5. **Ask feature clarifying questions** if requirements are ambiguous (Mode 1a — feature-only, no technical questions). In Mode 1b, scope/behavior/DoD are settled by the enriched spec — but you SHOULD ask implementation-specific questions (technical approach, patterns, integration strategy) after analyzing the codebase.
 
-### 2. Make Architectural Decisions
+### 2. Make Architectural Decisions (1b mode only)
 
-This is where your Opus-level reasoning earns its cost. You decide:
+In 1a mode, skip this — architectural decisions are deferred to 1b. In 1b mode,
+this is where your reasoning earns its cost. You decide:
 - **What** gets built (which files, types, protocols, services)
 - **How** components interact (data flow, dependencies, error propagation)
 - **Where** it fits in the existing architecture (which layers, which patterns to follow)

--- a/skills/architect-analyzer/SKILL.md
+++ b/skills/architect-analyzer/SKILL.md
@@ -1,59 +1,69 @@
 ---
 name: architect-analyzer
 description: >
-  Analyzes implementation requests before planning. Decomposes along natural seams,
-  identifies fragile areas and architecture decisions, generates clarifying questions,
-  and produces an enriched spec (.claude/tmp/1a-spec.md) for the planner skill.
-  Used as Step 1a of the orchestration pipeline.
+  Analyzes feature requests before planning. Clarifies the *what* — scope, behavior,
+  acceptance criteria — without prescribing the *how*. Produces an enriched spec
+  (.claude/tmp/1a-spec.md) for the planner skill. Used as Step 1a of the pipeline.
 agent: architect-agent
 ---
 
-# Request Analyzer
+# Feature Spec Analyzer
 
-Your goal is to remove all ambiguity from the request before any planning occurs.
-You are a senior architect interrogating a feature brief before committing team
-resources to it. You do NOT plan tasks or decompose into implementation units here.
+Your goal is to fully understand **what** the user wants before any planning occurs.
+You are a product-minded architect interrogating a feature brief to ensure the request
+is unambiguous, complete, and actionable. You do NOT plan tasks, decompose into
+implementation units, or make technical/architecture decisions here — that is the
+planner's job in Step 1b.
 
-## Step 1: Seam Analysis
+**Your questions must be about the feature, not the implementation.**
+Ask "what should happen when X?" — never "should we use pattern Y or Z?"
 
-Read the user's request and the ORCHESTRATOR.md provided in your prompt. Decompose
-the request along natural seams:
+## Step 1: Feature Decomposition
 
-- **Platform boundaries** — does this touch multiple platforms or targets?
-- **Layer boundaries** — UI / ViewModel / Service / Model / Tests / Config?
-- **Cross-cutting concerns** — persistence, networking, real-time sync, notifications, analytics?
-- **New vs. modify** — new files, or changes to existing ones?
+Read the user's request and the ORCHESTRATOR.md provided in your prompt. Break the
+feature down along its natural product seams:
+
+- **User-facing surfaces** — which screens, endpoints, or interfaces are affected?
+- **Behavioral boundaries** — distinct user flows, states, or interaction modes?
+- **Data boundaries** — what new or changed data does this feature involve?
+- **Cross-cutting concerns** — does the feature imply changes to auth, notifications, analytics, etc.?
+- **New vs. modify** — is this entirely new functionality, or extending existing behavior?
 
 For each seam, identify the specific files and services from ORCHESTRATOR.md that would be affected.
 
 ## Step 2: Fragile Area Scan
 
-Cross-reference your seam analysis against ORCHESTRATOR.md's "Known Fragile Areas". For each
-fragile area this request touches, note the specific concern.
+Cross-reference your feature decomposition against ORCHESTRATOR.md's "Known Fragile Areas".
+For each fragile area this request touches, note the specific concern.
 
-## Step 3: Architecture Decision Identification
-
-Identify design choices the plan would need to make that have downstream impact. These are
-decisions the user should weigh in on, not the planner. Examples: "Should this be a new
-service or extend the existing one?", "Should this state live in the existing store or separately?"
-
-## Step 4: Scope Validation
+## Step 3: Scope Validation
 
 If the request appears to touch more than 12 files or 3+ fragile areas, flag this explicitly.
 Recommend the user scope it down or split it into multiple orchestration runs. A plan that's
 too broad will collapse mid-implementation.
 
-## Step 5: Clarifying Questions
+## Step 4: Clarifying Questions
 
-Generate grouped clarifying questions. Only ask what genuinely changes the plan. Group as:
+Generate grouped clarifying questions. **All questions must be about the feature requirements,
+not about technical approach or implementation strategy.** Only ask what genuinely changes the
+deliverable. Group as:
 
-**Scope** — what's in, what's explicitly out?
-**Behavior & Constraints** — edge cases, error states, platform-specific behaviors?
-**Architecture Decisions** — choices identified in Step 3?
-**Definition of Done** — what does "complete" look like? Any coverage or performance targets beyond defaults?
+**Scope** — what's in, what's explicitly out? Are there related behaviors the user intentionally wants to defer?
+**User Experience & Behavior** — how should the feature behave in edge cases, error states, empty states, and platform-specific scenarios? What does the user see/experience at each step?
+**Data & Business Rules** — what are the validation rules, constraints, formats, or business logic that govern this feature? What are the boundaries and limits?
+**Definition of Done** — what does "complete" look like? Any acceptance criteria, coverage targets, or performance expectations beyond defaults?
 
 Present the analysis summary first (seams, files, fragile areas), then the questions.
 Be concise — no filler.
+
+**Do NOT ask about:**
+- Technical approach or architecture patterns ("should we use X pattern?")
+- Implementation strategy ("new service vs. extending existing?")
+- Data storage or API design choices
+- Framework or library selection
+
+These are deferred to Step 1b where the planner asks implementation-specific questions
+after analyzing the codebase and enriched spec together.
 
 ## Iteration
 
@@ -84,11 +94,11 @@ When clarification is complete, write `.claude/tmp/1a-spec.md` with this exact s
 ## Fragile Areas Affected
 - [Area name]: [specific concern for this task]
 
-## Architecture Decisions
-- [Decision]: [rationale from clarification]
-
 ## Behavioral Specifications
 [All clarified behaviors, precise enough to eliminate planner ambiguity. Bullet list.]
+
+## Data & Business Rules
+- [rule/constraint clarified during Q&A]
 
 ## Definition of Done
 - [ ] [criterion]
@@ -98,11 +108,15 @@ When clarification is complete, write `.claude/tmp/1a-spec.md` with this exact s
 - [constraint]
 ```
 
+Note: Architecture and implementation decisions are intentionally absent — they are resolved
+in Step 1b after the planner analyzes the codebase alongside this spec.
+
 After writing the file, output `CLARIFICATION COMPLETE` on its own line.
 
 ## Guardrails
 
-- Ask only questions that genuinely change the plan. Do not ask for confirmation of obvious requirements.
+- Ask only questions about the feature requirements. Do not ask about technical approach, architecture patterns, or implementation strategy.
 - Do not plan tasks, assign models, or decompose into implementation units — that is the planner's job.
 - Do not read code files unless needed to verify a specific integration point for a clarifying question.
 - Keep the total clarification to 3 rounds maximum. If ambiguity remains after 3 rounds, note it in the spec's Constraints section and proceed.
+- If the user volunteers technical preferences unprompted, capture them in Constraints — but do not solicit them.

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -18,10 +18,12 @@ agent: architect-agent
 
 You receive a pre-clarified enriched spec from the analyzer (`.claude/tmp/1a-spec.md`).
 All scope, behavior, and definition-of-done ambiguity has been resolved. Your job is to
-decompose it into a cost-optimized task plan where most tasks are Haiku-executable.
+analyze the codebase, surface implementation-specific questions, and then decompose the
+feature into a cost-optimized task plan where most tasks are Haiku-executable.
 
 Do not re-ask scope, behavior, or DoD questions — the enriched spec is authoritative
-for those. You MAY surface architecture decision forks (see Step 2.5 in Planning Process).
+for those. Your questions are exclusively about **how** to implement, not **what** to
+implement (see Step 2.5 in Planning Process).
 
 ## Philosophy
 
@@ -64,8 +66,10 @@ The planner must understand what each model can and cannot do reliably to decomp
 
 ### Step 1: Verify Enriched Spec Coverage
 
-The enriched spec from 1a should already contain scope, files, fragile areas, architecture
-decisions, behavioral specs, DoD, and constraints. Verify it covers:
+The enriched spec from 1a should already contain scope, files, fragile areas, behavioral
+specs, data/business rules, DoD, and constraints. Architecture and implementation decisions
+are NOT in the spec — you will determine those during Steps 2-2.5 based on codebase analysis.
+Verify the spec covers:
 - **Deliverables**: What concrete artifacts (files, configs, tests) must be produced?
 - **Dependencies**: What existing code/systems does this interact with?
 - **Constraints**: Performance requirements, framework conventions, compatibility needs?
@@ -85,25 +89,47 @@ Before decomposing, scan for tasks that **cannot** be split without losing corre
 
 Mark these and set them aside. Everything else gets decomposed.
 
-### Step 2.5: Surface Architecture Decision Forks (User Checkpoint)
+### Step 2.5: Implementation Clarification (User Checkpoint)
 
-During analysis, you may discover implementation forks where both paths are technically
-valid and the choice meaningfully affects the plan structure. If so, **pause planning
-and present them to the user in a single batch** before continuing to decomposition.
+After completing Steps 1-2 (enriched spec verification + irreducible complexity scan), you
+have a deep understanding of both the feature requirements AND the codebase context. Now
+**pause planning and present implementation-specific questions to the user** before
+committing to a decomposition strategy.
 
-For each fork, present:
+There are always multiple technically valid ways to implement a feature. The user should
+choose — not the planner. Your questions should reflect the full analysis you've done so far.
+
+**What to ask about (implementation-specific only):**
+
+- **Architecture approach** — "Should X be a new service or extend `ExistingService`?", "New table or add columns to `existing_table`?"
+- **Pattern selection** — "The codebase uses both observer and pub/sub patterns for events — which should this feature follow?", "Repository pattern or direct data access?"
+- **Integration strategy** — "Wire through the existing middleware pipeline or create a dedicated handler?", "Sync or async processing for X?"
+- **Data modeling** — "Normalize into separate entities or denormalize for read performance?", "Store as structured JSON or typed columns?"
+- **Technical tradeoffs** — when both paths are valid, present options with cost/complexity/risk tradeoffs
+- **Reuse vs. build** — "Existing `FooHelper` covers 80% of this — extend it or build a purpose-built replacement?"
+
+For each question, present:
 - **Decision:** One sentence framing the choice
-- **Option A:** Approach + tradeoff (cost, complexity, risk)
+- **Option A:** Approach + tradeoff (cost, complexity, risk, future implications)
 - **Option B:** Approach + tradeoff
-- **Recommendation:** Your pick with reasoning
+- **Recommendation:** Your pick with reasoning (based on codebase patterns and constraints)
+
+**Format:** Group questions by theme (architecture, patterns, data, integration) for clarity.
 
 **Guardrails:**
-- Maximum ONE round of questions. Batch all forks into a single pause.
+- Maximum TWO rounds of questions. Batch related questions into a single pause per round.
+  Round 1: questions from initial analysis. Round 2 (if needed): follow-up questions that
+  arise from the user's Round 1 answers. After Round 2, proceed with best judgment.
 - Never re-ask scope, behavior, or DoD questions — those are settled by the enriched spec.
-- Only surface forks where the choice changes the plan structure (task count, model assignment, wave ordering, or risk profile), not implementation details a context brief can specify.
+- Only ask questions where the answer changes the plan structure (task count, model assignment,
+  wave ordering, file set, or risk profile). If a decision only affects implementation details
+  within a single task's context brief, just decide — don't ask.
 - If your recommendation is strong and the tradeoff is minor, just decide — don't ask.
+- If no implementation questions exist (rare — usually means the feature maps trivially to
+  existing patterns), skip directly to Step 3 and note "No implementation clarification needed —
+  feature maps directly to existing patterns."
 
-After receiving answers (or if no forks exist), proceed to Step 3.
+After receiving answers (or if no questions exist), proceed to Step 3.
 
 ### Step 3: Decompose Into Haiku-Sized Tasks
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -274,13 +274,16 @@ customized), paste the full file instead of a partial extract.
 User Request
     |
     v
-Step 1a: ANALYZE & CLARIFY (architect-agent, Sonnet, interactive)
-    |  Pre-flight check -> seam analysis -> clarifying questions (iterative)
+Step 1a: FEATURE CLARIFICATION (architect-agent, Sonnet, interactive)
+    |  Pre-flight check -> feature decomposition -> feature-only Q&A (iterative, max 3 rounds)
+    |  Questions: scope, behavior, edge cases, business rules, DoD — NO technical questions
     |  Writes: .claude/tmp/1a-spec.md (enriched spec + recovery artifact)
     v
-Step 1b: PLAN (architect-agent, Sonnet default / Opus for novel architecture, fresh agent)
+Step 1b: IMPLEMENTATION CLARIFICATION & PLAN (architect-agent, Sonnet default / Opus, fresh agent)
     |  Reads: 1a-spec.md + 1b Extract from ORCHESTRATOR.md (clean context, ~12K tokens)
-    |  Produces: ordered task list with context briefs
+    |  Phase 1: Analyze codebase + enriched spec -> implementation Q&A (max 2 rounds)
+    |  Questions: architecture approach, patterns, integration, data modeling, tradeoffs
+    |  Phase 2: Decompose into task plan with context briefs
     |  Present to user for confirmation
     v
 Step 1.5: OPEN PR (open-pr skill)
@@ -430,11 +433,17 @@ Prompt: |
 Note: The 1a-spec already contains project overview, directory structure, fragile areas, and
 current state — the 1b extract omits these to avoid duplication.
 
-**Architecture decision questions:** The 1b agent may pause once to surface implementation
-tradeoffs where both approaches are valid and the choice affects the plan structure (see
-Step 2.5 in the planner skill). If this happens, present the questions to the user and
-feed answers back via **SendMessage**. This is limited to ONE round — after receiving
-answers, the agent completes the plan.
+**Implementation clarification loop:**
+The 1b agent will first analyze the enriched spec against the codebase, then pause to surface
+implementation-specific questions (technical approach, patterns, integration strategy, data
+modeling). See Step 2.5 in the planner skill.
+
+- Present the implementation questions to the user verbatim.
+- Feed user answers back via **SendMessage** to the same agent (do NOT launch a new agent).
+- The agent may ask a second round of follow-up questions if the user's answers reveal new
+  decision points. Maximum TWO rounds total.
+- After receiving answers (or if the agent has no questions), it proceeds to decomposition
+  and plan generation.
 
 **Wait for the plan.** Review it for:
 - Does it respect the file-per-task limits from CLAUDE.md?
@@ -443,7 +452,7 @@ answers, the agent completes the plan.
 
 Present the plan summary to the user and wait for confirmation before proceeding.
 
-**Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If architecture decision questions occur, record the SendMessage round as step `1b:decision`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: as selected above (`sonnet` or `opus`).
+**Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If implementation clarification questions occur, record each SendMessage round as step `1b:impl-clarify-N`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: as selected above (`sonnet` or `opus`).
 
 **Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.
 


### PR DESCRIPTION
## Summary
- **Step 1a (Feature Clarification)**: Now asks only feature-spec questions — scope, behavior, edge cases, business rules, definition of done. Explicitly blocked from asking technical/architecture questions. Removed "Architecture Decisions" from enriched spec output.
- **Step 1b (Implementation Clarification & Plan)**: Enhanced from a single-round "architecture fork" pause to a full implementation Q&A phase (max 2 rounds). Asks about architecture approach, pattern selection, integration strategy, data modeling, and technical tradeoffs — all grounded in codebase analysis done before questioning.
- **Contradiction fix**: Planner Step 1 expected "architecture decisions" in the enriched spec, but the analyzer deliberately omits them. Updated to correctly note architecture decisions come from Steps 2-2.5.
- **Agent definition**: Scoped "Make Architectural Decisions" to 1b-only, clarified plan mode explanation.

## Files changed
- `skills/architect-analyzer/SKILL.md` — rewritten for feature-only Q&A
- `skills/architect-planner/SKILL.md` — expanded Step 2.5 implementation Q&A, fixed Step 1 verification
- `skills/orchestrate/SKILL.md` — updated flow diagram and 1b clarification loop
- `agents/architect-agent.md` — scoped architectural decisions to 1b, clarified mode instructions
- `CLAUDE.md` — updated pipeline flow description

## Test plan
- [x] `python3 tests/validate_structure.py` — 263 checks pass
- [x] `python3 tests/test_contracts.py` — 51 tests pass
- [ ] End-to-end smoke test with `/orchestrate` on a bootstrapped project

🤖 Generated with [Claude Code](https://claude.com/claude-code)