### PR TITLE
feat(adapter): add Flutter/Dart adapter

### DIFF
--- a/adapters/flutter/adapter.md
+++ b/adapters/flutter/adapter.md
@@ -1,0 +1,49 @@
+# Flutter / Dart Adapter
+
+## Stack Metadata
+
+- **Stack name:** `flutter`
+- **Display name:** Flutter / Dart
+- **Languages:** Dart
+- **Build system:** Flutter SDK (`flutter analyze`, `dart format`)
+- **Test framework:** `flutter test` (unit, widget, integration, golden)
+- **Coverage tool:** `flutter test --coverage` (lcov)
+- **Code generation:** `build_runner` + `freezed` + `json_serializable`
+
+## Build & Test Commands
+
+- **Build:** `python3 .claude/scripts/flutter/build.py [--project-dir .] [--no-format-check]`
+- **Test:** `python3 .claude/scripts/flutter/test.py [--project-dir .] [--no-coverage] [--exclude-from-coverage '<pattern>']`
+
+## Blocked Commands
+
+These commands are blocked by hooks and must use the pipeline skills instead:
+- `flutter test` / `flutter analyze` / `dart analyze` -> use `build-runner` / `test-runner` skill
+- `flutter build` / `flutter run` -> use `build-runner` skill
+- `dart run build_runner` -> use `build-runner` skill
+
+## Overlay Files
+
+| Overlay | Agent | Purpose |
+|---------|-------|---------|
+| `architect-overlay.md` | architect-agent | MVVM architecture, widget decomposition, state management patterns |
+| `implementer-overlay.md` | implementer-agent | Dart style, Flutter composition, performance, accessibility |
+| `reviewer-overlay.md` | code-reviewer-agent | Flutter/Dart-specific review checklist |
+| `test-overlay.md` | test-architect-agent | flutter test, widget tests, golden tests, integration tests |
+
+## Project Detection
+
+This adapter activates when the project root contains:
+- `pubspec.yaml` with `flutter:` section
+
+## Common Conventions
+
+- **Architecture:** MVVM — View (widgets) + ViewModel (ChangeNotifier) + Repository + Service layers
+- **State management:** ChangeNotifier + provider (Google-recommended); Riverpod or BLoC for complex cases
+- **Navigation:** go_router with declarative routing and deep link support
+- **Data models:** Immutable classes via freezed; JSON via json_serializable
+- **Styling:** Material 3 (default), Cupertino for iOS-native fidelity, adaptive constructors for cross-platform
+- **Dart style:** Effective Dart — lowerCamelCase, `///` doc comments, `async`/`await`, `final` fields
+- **L10n:** flutter_localizations + gen-l10n with ARB files — no hard-coded user-facing strings
+- **Error handling:** Result pattern at service boundaries; FlutterError.onError + PlatformDispatcher for global handling
+- **Accessibility:** 4.5:1 contrast, 48x48 tap targets, Semantics widget for custom interactive elements

--- a/adapters/flutter/architect-overlay.md
+++ b/adapters/flutter/architect-overlay.md
@@ -1,0 +1,68 @@
+# Flutter / Dart — Architect Overlay
+
+<!-- Injected into architect-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Architecture: MVVM with Repository Pattern (Google-Recommended)
+
+**UI Layer:** Views (StatelessWidget/StatefulWidget displaying state) + ViewModels (ChangeNotifier transforming repository data into UI state, exposing Commands for user interactions). Each View pairs with exactly one ViewModel (1:1).
+
+**Data Layer:** Repositories (single source of truth per data type, owns business logic, caching, retry, outputs domain models) + Services (one per data source — REST, local storage, platform API — holds no state, returns Futures/Streams).
+
+**Optional Domain Layer:** Use-Cases/Interactors when merging data from multiple repositories or encapsulating complex business logic that spans repositories.
+
+**Data flow is unidirectional:** Data flows up (Service → Repository → ViewModel → View). User interactions flow down (View → ViewModel → Repository). ViewModels never access Services directly. No repository-to-repository awareness.
+
+## Complexity Patterns for Task Decomposition
+
+### Widget & UI Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| StatelessWidget, single-screen view | Haiku | Mechanical composition, fully specified |
+| StatefulWidget with ephemeral state (form, animation) | Haiku | Localized setState, clear scope |
+| Adaptive/platform-aware widget (Material + Cupertino) | Haiku-Sonnet | Platform branching logic |
+| Custom multi-child layout / RenderObject | Sonnet-Opus | Framework-level rendering knowledge |
+| Complex animation choreography (staggered, hero, custom) | Sonnet | Timing, controller lifecycle, composition |
+
+### ViewModel & State Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| ViewModel + repository wiring (CRUD) | Haiku | Follows established MVVM, contract clear |
+| ViewModel with multiple repository dependencies | Haiku-Sonnet | Data merging, state coordination |
+| State management architecture (provider setup, DI tree) | Sonnet | Design decisions on scope and granularity |
+| Complex reactive flows (Stream composition, real-time) | Sonnet | Concurrency, backpressure, error propagation |
+
+### Data Layer Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Service wrapping REST API (single endpoint) | Haiku | Mechanical: request/response/error |
+| Repository with caching + retry logic | Haiku-Sonnet | Policy decisions, invalidation strategy |
+| Local persistence (Hive, sqflite, shared_preferences) | Haiku-Sonnet | Schema design, migration |
+| Code generation setup (freezed, json_serializable) | Haiku | Config-driven, follows established patterns |
+
+### Platform & Integration Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Platform channel design (Pigeon/MethodChannel) | Sonnet | Cross-boundary contract, error handling |
+| Navigation/routing architecture (go_router) | Sonnet | Deep links, guards, redirect logic |
+| Internationalization architecture (ARB, gen-l10n) | Haiku-Sonnet | Setup is mechanical, pluralization rules need judgment |
+| App-wide error handling strategy | Sonnet | FlutterError + PlatformDispatcher + Result pattern |
+| Multi-isolate computation strategy | Sonnet | Concurrency design, message passing |
+| Cross-cutting theming (Material 3, dynamic color) | Haiku-Sonnet | Token application is Haiku, theme architecture is Sonnet |
+
+### Testing Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Unit test for service/repository/ViewModel | Haiku | Method-level, clear inputs/outputs |
+| Widget test for single widget | Haiku | pump/find/expect pattern |
+| Golden test setup and maintenance | Haiku-Sonnet | Setup is Sonnet, individual goldens are Haiku |
+| Integration test for user journey | Sonnet | Multi-screen flow, async, platform interaction |
+
+## Decomposition Notes
+
+- **Widgets are Haiku boundaries.** Each widget is a self-contained unit when its props/state contract is defined.
+- **ViewModels are Haiku boundaries** when the repository interface is already defined. If the ViewModel design requires choosing which repositories to depend on, that's Sonnet.
+- **Services are Haiku** when the API contract (endpoint, request/response shapes) is specified in the brief.
+- **Architecture decisions are Sonnet:** Which state management approach, how to structure the DI tree, navigation guard strategy, error handling philosophy.
+- **Platform channel design is Sonnet:** Requires contract design across Dart ↔ native boundary. Implementation of the Dart side is Haiku once the contract exists.
+- **Prefer feature-first decomposition** — group by feature (lib/ui/feature_name/, lib/data/repositories/, lib/data/services/) not by layer.
+- **Generated code is not a task.** Never create tasks for `*.g.dart` or `*.freezed.dart` files — these are produced by `build_runner`.

--- a/adapters/flutter/hooks.json
+++ b/adapters/flutter/hooks.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in flutter) echo \"$CMD\" | head -1 | grep -qE '^[[:space:]]*flutter (test|analyze|build|run)' && echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the build-runner or test-runner skill instead. Subagents: python3 .claude/scripts/flutter/build.py or python3 .claude/scripts/flutter/test.py.\"}' || echo '{}' ;; dart) echo \"$CMD\" | head -1 | grep -qE '^[[:space:]]*dart (analyze|run build_runner)' && echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the build-runner skill instead. Subagents: python3 .claude/scripts/flutter/build.py.\"}' || echo '{}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for forbidden build/test commands..."
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in grep|rg) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Grep tool instead of grep/rg via Bash. Grep supports regex, glob filters, context lines, and multiple output modes.\"}' ;; cat|head|tail) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Read tool instead of cat/head/tail via Bash. Read supports offset and limit parameters for partial file reading.\"}' ;; find) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Glob tool instead of find via Bash. Glob supports patterns like **/*.dart for recursive file discovery.\"}' ;; sed|awk) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Edit tool instead of sed/awk via Bash. Edit performs exact string replacements in files.\"}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for dedicated tool alternatives..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/flutter/implementer-overlay-essential.md
+++ b/adapters/flutter/implementer-overlay-essential.md
@@ -1,0 +1,14 @@
+# Flutter / Dart — Essential Rules (Haiku)
+
+- MVVM: Views display state, ViewModels transform data via ChangeNotifier, Repositories own business logic, Services wrap data sources
+- Extract widgets as classes, not helper functions — `const` constructors everywhere
+- `setState` only for ephemeral widget-local state — never high in the tree
+- `ListView.builder` for collections — never concrete child lists for dynamic data
+- Dispose all controllers, streams, timers, subscriptions in `dispose()`
+- Check `mounted` before `setState` after async operations
+- No hard-coded user-facing strings — use `AppLocalizations`
+- Specific `on ExceptionType` clauses — never bare `catch`
+- `final` fields, constructor DI via `provider`, private dependency fields
+- `async`/`await` over raw futures, `rethrow` to preserve stack traces
+- `compute()` or `Isolate.spawn()` for heavy work — never block the UI thread
+- Relative imports within package, `dart:` → `package:` → relative ordering

--- a/adapters/flutter/implementer-overlay.md
+++ b/adapters/flutter/implementer-overlay.md
@@ -1,0 +1,85 @@
+# Flutter / Dart — Implementer Overlay
+
+<!-- Injected into implementer-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Architecture (MVVM)
+
+- Views display state from their ViewModel — minimal logic (simple conditionals for visibility, animation, layout, routing).
+- ViewModels transform repository data into UI state. Expose `Command` objects for user interactions. Store injected dependencies as **private fields**.
+- Repositories are the single source of truth per data type. Output domain models, not raw API responses. Handle caching, retry, error transformation.
+- Services wrap a single data source (REST endpoint, local storage, platform API). Hold no state. Return `Future` or `Stream`.
+- Constructor injection via `provider`. Use `context.read<T>()` to retrieve without rebuilds. No globally accessible singletons or service locators.
+- Data flows one direction: Service → Repository → ViewModel → View. User events flow: View → ViewModel → Repository.
+
+## Widget Composition
+
+- **Extract widgets as classes, not helper functions.** Widget classes participate in framework rebuild optimization (same-instance detection skips subtree traversal). Functions do not.
+- Mark widgets `const` wherever possible. Enable `prefer_const_constructors` lint.
+- One widget, one responsibility. Localize `setState()` to the smallest subtree that actually changes.
+- Split build methods >100 lines into smaller widget classes.
+- Pass static subtrees as `child` parameter to `AnimatedBuilder` — not inside the builder callback.
+- Use `RepaintBoundary` to isolate frequently-redrawn subtrees from their surroundings.
+
+## State Management
+
+- `setState` only for ephemeral, widget-local state (form focus, animation, toggle).
+- `ChangeNotifier` + `provider` for app-level state — the Google-recommended approach.
+- ViewModels extend `ChangeNotifier`. Each View has exactly one ViewModel.
+- Never store computed values — derive them in getters.
+
+## Performance
+
+- No expensive or repetitive work in `build()`. It is called frequently.
+- `ListView.builder` / `GridView.builder` for collections — never concrete child lists (`Column(children: [...])`) for dynamic/large data.
+- `compute()` or `Isolate.spawn()` for heavy computation (large JSON parsing, image processing). Never block the UI thread.
+- Avoid `Opacity` widget in animations — use `AnimatedOpacity` or `FadeInImage`.
+- Don't override `operator ==` on widgets — causes O(N^2) behavior and prevents compiler optimizations.
+- Frame budget: 16ms at 60Hz (8ms build + 8ms render). 120Hz devices need <8ms total.
+
+## Dart Style (Effective Dart)
+
+- `lowerCamelCase` for variables, functions, parameters, named constants. `UpperCamelCase` for types, extensions, enums, typedefs. `lowercase_with_underscores` for packages, files, import prefixes.
+- Capitalize acronyms >2 letters as words (`HttpRequest`, not `HTTPRequest`).
+- `///` doc comments on all public APIs. No `//` block comments for documentation.
+- Collection literals (`[]`, `{}`) over constructors. `isEmpty`/`isNotEmpty` over `.length == 0`.
+- `async`/`await` over raw `Future` chains. `rethrow` to preserve stack traces.
+- `final` for fields that don't change. `const` for compile-time constants.
+- Initializing formals (`this.parameter`) in constructors.
+- `=>` for single-expression members. No `new` keyword.
+- `for` loops over `forEach()` with closures. `.toList()` over `List.from()` unless changing type.
+- Relative imports within a package. Imports: `dart:` → `package:` → relative, each group alphabetically sorted.
+
+## Null Safety
+
+- Don't explicitly initialize nullable variables to `null` — they're implicitly null.
+- Type promotion via null checks (`if (value != null)`) to access non-null members.
+- Avoid `late` when you need to check initialization state — use nullable type + null check.
+- Don't compare non-nullable booleans to `true`/`false` literals.
+
+## Error Handling
+
+- Result pattern (sealed `Result<T>` with `Ok`/`Error` variants) at service boundaries. Forces exhaustive handling via pattern matching.
+- `FlutterError.onError` for framework errors. `PlatformDispatcher.instance.onError` for uncaught async errors. Initialize both in `main()` before `runApp()`.
+- Specific `on ExceptionType` clauses — never bare `catch`. Never silently discard errors.
+- Check `mounted` before calling `setState` after any async operation.
+- Throw `Error` subclasses only for programmatic bugs — never catch them.
+
+## Resource Management
+
+- Dispose **all** controllers and subscriptions in `dispose()`: `AnimationController`, `TextEditingController`, `ScrollController`, `FocusNode`, `StreamSubscription`, `Timer`.
+- Cancel async operations in `dispose()` to prevent `setState` after unmount.
+- Remove listeners explicitly on objects passed in from outside, even if you call `dispose()`.
+
+## Internationalization
+
+- **No hard-coded user-facing strings.** All text through `AppLocalizations` via `flutter_localizations` + `gen-l10n`.
+- ARB files in `lib/l10n/` with `@` metadata descriptions for every translatable string.
+- ICU message format for plurals and gendered text. Typed placeholders, not string concatenation.
+
+## Accessibility
+
+- Minimum contrast ratio: 4.5:1 between controls/text and background.
+- Minimum tap target size: 48x48 pixels.
+- `Semantics` widget with `SemanticsRole` for custom interactive widgets.
+- Test with TalkBack (Android) and VoiceOver (iOS).
+- Standard Flutter widgets handle accessibility automatically — prefer them over custom implementations.

--- a/adapters/flutter/manifest.json
+++ b/adapters/flutter/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "flutter",
+  "display_name": "Flutter / Dart",
+  "capabilities": [],
+  "implies_overlays": [],
+  "detection": [
+    { "type": "file_contains", "path": "pubspec.yaml", "pattern": "flutter:" }
+  ],
+  "stack_paths": {
+    "directories": ["lib", "test", "integration_test"],
+    "fallback_globs": ["**/*.dart", "pubspec.yaml", "analysis_options.yaml", "l10n.yaml", "lib/l10n/*.arb"]
+  }
+}

--- a/adapters/flutter/reviewer-overlay.md
+++ b/adapters/flutter/reviewer-overlay.md
@@ -1,0 +1,79 @@
+# Flutter / Dart — Code Reviewer Overlay
+
+<!-- Injected into code-reviewer-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Domain Expertise
+
+You are a senior Flutter engineer with deep expertise in Dart, the Flutter framework, Google's official app architecture guide (MVVM + Repository pattern), Material Design 3, Human Interface Guidelines, platform channels, state management, performance optimization, accessibility, and internationalization. You review code for correctness, architecture adherence, performance, and platform best practices.
+
+## Review Categories
+
+### 1. Architecture Violations
+- View bypassing ViewModel to access Repository or Service directly
+- ViewModel accessing Service directly (must go through Repository)
+- Repository-to-repository coupling (combine in ViewModel or Use-Case)
+- Public dependency fields on ViewModels (must be private)
+- Storing computed values instead of deriving them in getters
+- Circular dependencies between architecture layers
+- Business logic in View layer (beyond simple conditionals for visibility/layout/routing)
+- Missing unidirectional data flow — data should flow up, events flow down
+
+### 2. Widget Composition & Rebuilds
+- God widgets (>200 lines) that should be decomposed
+- Helper functions returning widgets instead of widget classes (prevents rebuild optimization)
+- Missing `const` constructors on stateless widgets and widget parameters
+- `setState()` called high in widget tree, rebuilding large subtrees unnecessarily
+- Missing `RepaintBoundary` on frequently-redrawn isolated subtrees
+- `AnimatedBuilder` with static child inside builder callback instead of `child` parameter
+- Widget splitting that breaks encapsulation (child widgets reaching into parent state)
+
+### 3. Performance
+- Expensive or repetitive work inside `build()` method
+- Concrete child lists (`Column(children: [...])`, `ListView(children: [...])`) for large or dynamic collections — must use `.builder` constructors
+- `Opacity` widget in animations instead of `AnimatedOpacity` or `FadeInImage`
+- Blocking the main isolate with heavy computation (JSON parsing, image processing, crypto)
+- `operator ==` overridden on Widget subclasses (O(N^2), prevents compiler optimization)
+- Missing `const` on widget subtrees that could be compile-time constant
+- `StringBuffer` not used for string concatenation in loops
+
+### 4. State & Lifecycle
+- `setState` called after `dispose()` — missing `mounted` check after async operations
+- Undisposed controllers: `AnimationController`, `TextEditingController`, `ScrollController`, `FocusNode`
+- Uncancelled `StreamSubscription`, `Timer`, or async operations in `dispose()`
+- Listeners not removed on externally-provided objects
+- `late` variables used to check initialization state (should be nullable + null check)
+- State stored in ViewModel that should be ephemeral widget-local state (or vice versa)
+
+### 5. Platform & Adaptive
+- Hard-coded Material or Cupertino widgets where adaptive constructors exist (`Switch.adaptive()`, `Slider.adaptive()`, etc.)
+- Platform channel (`MethodChannel`/`EventChannel`) invoked off the platform's main thread
+- Missing `PlatformException` handling on platform channel calls
+- Raw `MethodChannel` where Pigeon would provide type safety
+- Missing deep link configuration for navigation routes that should be deep-linkable
+
+### 6. Accessibility
+- Tap targets smaller than 48x48 pixels
+- Contrast ratio below 4.5:1 between interactive controls/text and background
+- Missing `Semantics` widget on custom interactive elements
+- Color as the only indicator of state (must work in colorblind/grayscale mode)
+- Auto-context switching while user is typing
+
+### 7. Internationalization
+- Hard-coded user-facing strings in widget trees (must use `AppLocalizations`)
+- String concatenation for translatable text (must use placeholders in ARB)
+- Missing `@` metadata descriptions in ARB files for translator context
+- Number/date/currency displayed without locale-aware formatting
+
+### 8. Dart Best Practices
+- Bare `catch` clauses without `on ExceptionType`
+- Silently discarded caught errors
+- `forEach()` with function literals instead of `for` loops
+- `List.from()` where `.toList()` suffices
+- Missing `///` doc comments on public API
+- Positional boolean parameters (should be named)
+- `new` keyword usage
+- Non-final fields that should be `final`
+- Mutable data models where immutable (freezed) is expected
+- Missing `rethrow` — caught exception re-thrown with `throw` loses stack trace
+- `var` where `final` is appropriate (value never reassigned)
+- Package imports where relative imports should be used (within same package)

--- a/adapters/flutter/scripts/build.py
+++ b/adapters/flutter/scripts/build.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Run Flutter build (analyze + format check) and output errors in a minimal table.
+Usage: python build.py [--project-dir /path/to/project] [--no-format-check]
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+
+
+# ---------------------------------------------------------------------------
+# Flutter SDK detection
+# ---------------------------------------------------------------------------
+
+def find_flutter():
+    """Find the flutter executable."""
+    # Check if flutter is in PATH
+    for cmd in ["flutter", "fvm flutter"]:
+        try:
+            result = subprocess.run(
+                cmd.split() + ["--version"],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                return cmd.split()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+
+    # Check for FVM
+    fvm_path = os.path.join(".fvm", "flutter_sdk", "bin", "flutter")
+    if os.path.exists(fvm_path):
+        return [fvm_path]
+
+    print("ERROR: Flutter SDK not found. Ensure 'flutter' is in PATH or FVM is configured.")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Build steps
+# ---------------------------------------------------------------------------
+
+def run_analyze(project_dir, flutter_cmd):
+    """
+    Run flutter analyze.
+    Returns (stdout+stderr, returncode).
+    """
+    print("Running flutter analyze...")
+    cmd = flutter_cmd + ["analyze", "--no-pub"]
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+def run_format_check(project_dir, flutter_cmd):
+    """
+    Run dart format --set-exit-if-changed to check formatting.
+    Returns (stdout+stderr, returncode).
+    """
+    print("Running dart format check...")
+
+    # Use dart format from the Flutter SDK
+    dart_cmd = flutter_cmd[:-1] + ["dart"] if flutter_cmd[-1] == "flutter" else ["dart"]
+    cmd = dart_cmd + ["format", "--set-exit-if-changed", "--output=none", "lib/"]
+
+    # Check if lib/ exists
+    lib_dir = os.path.join(project_dir, "lib")
+    if not os.path.isdir(lib_dir):
+        return "No lib/ directory found, skipping format check.", 0
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Error parsing
+# ---------------------------------------------------------------------------
+
+def parse_analyze_output(output):
+    """
+    Parse flutter analyze output.
+    Format: severity - message - path/to/file.dart:line:col - rule_name
+    Also: path/to/file.dart:line:col - message - rule_name
+    """
+    errors = []
+    warnings = []
+    infos = []
+    seen = set()
+
+    # Standard flutter analyze format:
+    # severity • message • path:line:col • rule_name
+    # Also handles: severity - message - path:line:col - rule_name
+    pattern = re.compile(
+        r"(error|warning|info)\s*[•\-]\s*(.+?)\s*[•\-]\s*([^\s]+\.dart):(\d+):(\d+)\s*[•\-]\s*(\S+)"
+    )
+
+    for m in pattern.finditer(output):
+        severity, message, filepath, line, col, rule = m.groups()
+        parts = filepath.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+        message = message.strip()[:120]
+        key = (short_path, line, rule)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {
+            "file": short_path,
+            "line": line,
+            "col": col,
+            "msg": f"{rule}: {message}",
+        }
+        if severity == "error":
+            errors.append(entry)
+        elif severity == "warning":
+            warnings.append(entry)
+        else:
+            infos.append(entry)
+
+    # Fallback: compilation errors
+    # file.dart:10:5: Error: message
+    compile_pattern = re.compile(
+        r"([^\s]+\.dart):(\d+):(\d+):\s+(Error|Warning):\s+(.+)"
+    )
+    for m in compile_pattern.finditer(output):
+        filepath, line, col, severity, message = m.groups()
+        parts = filepath.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+        message = message.strip()[:120]
+        key = (short_path, line, message)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {"file": short_path, "line": line, "col": col, "msg": message}
+        if severity == "Error":
+            errors.append(entry)
+        else:
+            warnings.append(entry)
+
+    return errors, warnings, infos
+
+
+def parse_format_output(output):
+    """
+    Parse dart format --set-exit-if-changed output.
+    Lists files that would be changed.
+    """
+    unformatted = []
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if line.endswith(".dart") and not line.startswith("Formatted"):
+            parts = line.replace("\\", "/").split("/")
+            short_path = "/".join(parts[-3:]) if len(parts) > 3 else line
+            unformatted.append(short_path)
+    return unformatted
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_table(analyze_errors, analyze_warnings, analyze_infos,
+                format_issues, analyze_rc, format_rc, raw_output=None):
+    """Print results in the pipeline contract format."""
+    all_errors = analyze_errors + [
+        {"file": f, "line": "-", "col": "-", "msg": "Needs formatting (dart format)"}
+        for f in format_issues
+    ]
+    all_warnings = analyze_warnings
+    failed = analyze_rc != 0 or format_rc != 0
+
+    if not failed and not all_errors:
+        warning_count = len(all_warnings) + len(analyze_infos)
+        print(f"\nBUILD SUCCEEDED  |  {warning_count} warning(s)")
+        return
+
+    if failed and not all_errors:
+        warning_count = len(all_warnings) + len(analyze_infos)
+        print(f"\nBUILD FAILED  |  0 error(s)  |  {warning_count} warning(s)\n")
+        print("No parseable errors found. Showing relevant build output:\n")
+        if raw_output:
+            lines = raw_output.strip().splitlines()
+            filtered = [
+                l for l in lines
+                if l.strip()
+                and not any(skip in l for skip in [
+                    "Analyzing", "No issues found", "files analyzed",
+                ])
+            ]
+            problem_lines = [
+                l for l in filtered
+                if any(kw in l.lower() for kw in [
+                    "error", "failed", "fatal", "cannot",
+                    "not found", "invalid", "unexpected",
+                ])
+            ]
+            if problem_lines:
+                print("\n".join(problem_lines[:30]))
+            else:
+                print("\n".join(filtered[-30:]))
+        sys.exit(1)
+
+    error_count = len(all_errors)
+    warning_count = len(all_warnings) + len(analyze_infos)
+    print(f"\nBUILD FAILED  |  {error_count} error(s)  |  {warning_count} warning(s)\n")
+
+    if analyze_errors:
+        print("Analysis Errors:")
+        _print_error_rows(analyze_errors)
+        print()
+
+    if format_issues:
+        print("Formatting Issues:")
+        for f in format_issues[:20]:
+            print(f"  {f}")
+        if len(format_issues) > 20:
+            print(f"  ... and {len(format_issues) - 20} more")
+        print()
+
+
+def _print_error_rows(errors):
+    """Print a formatted error table."""
+    fw = max(len(e["file"]) for e in errors)
+    lw = max(len(str(e["line"])) for e in errors)
+
+    header = f"  {'File':<{fw}}  {'Ln':>{lw}}  {'Error'}"
+    print(header)
+    print("  " + "-" * min(len(header) + 80, 120))
+
+    for e in errors:
+        print(f"  {e['file']:<{fw}}  {str(e['line']):>{lw}}  {e['msg']}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Flutter build (analyze + format check) and output errors in a minimal table."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument("--no-format-check", action="store_true", help="Skip dart format check")
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    print(f"Building in: {project_dir}")
+
+    # Verify pubspec.yaml exists
+    if not os.path.exists(os.path.join(project_dir, "pubspec.yaml")):
+        print("ERROR: No pubspec.yaml found in:")
+        print(f"  {project_dir}")
+        sys.exit(1)
+
+    flutter_cmd = find_flutter()
+    print(f"Flutter: {' '.join(flutter_cmd)}")
+
+    # Step 1: flutter analyze
+    analyze_output, analyze_rc = run_analyze(project_dir, flutter_cmd)
+    analyze_errors, analyze_warnings, analyze_infos = parse_analyze_output(analyze_output)
+
+    if analyze_rc != 0:
+        print(f"Analysis: FAILED ({len(analyze_errors)} error(s), {len(analyze_warnings)} warning(s))")
+    else:
+        print(f"Analysis: OK ({len(analyze_warnings)} warning(s), {len(analyze_infos)} info(s))")
+
+    # Step 2: dart format check
+    format_output = ""
+    format_rc = 0
+    format_issues = []
+
+    if not args.no_format_check:
+        format_output, format_rc = run_format_check(project_dir, flutter_cmd)
+        format_issues = parse_format_output(format_output) if format_rc != 0 else []
+
+        if format_rc != 0:
+            print(f"Format check: FAILED ({len(format_issues)} file(s) need formatting)")
+        else:
+            print("Format check: OK")
+
+    # Combine outputs for fallback display
+    combined_output = (analyze_output + "\n" + format_output).strip()
+
+    print_table(
+        analyze_errors, analyze_warnings, analyze_infos,
+        format_issues, analyze_rc, format_rc,
+        raw_output=combined_output,
+    )
+
+    if analyze_rc != 0 or format_rc != 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/flutter/scripts/test.py
+++ b/adapters/flutter/scripts/test.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""
+Run Flutter tests and output a minimal results table.
+
+Usage examples:
+  # Auto-detect everything
+  python test.py --project-dir .
+
+  # Without coverage
+  python test.py --project-dir . --no-coverage
+
+  # Exclude patterns from coverage
+  python test.py --project-dir . --exclude-from-coverage '*.g.dart' '*.freezed.dart'
+
+  # Run specific test directory
+  python test.py --project-dir . --test-dir test/unit
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+import json
+import fnmatch
+
+
+# ---------------------------------------------------------------------------
+# Flutter SDK detection
+# ---------------------------------------------------------------------------
+
+def find_flutter():
+    """Find the flutter executable."""
+    for cmd in ["flutter", "fvm flutter"]:
+        try:
+            result = subprocess.run(
+                cmd.split() + ["--version"],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                return cmd.split()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+
+    fvm_path = os.path.join(".fvm", "flutter_sdk", "bin", "flutter")
+    if os.path.exists(fvm_path):
+        return [fvm_path]
+
+    print("ERROR: Flutter SDK not found. Ensure 'flutter' is in PATH or FVM is configured.")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Test execution
+# ---------------------------------------------------------------------------
+
+def run_tests(project_dir, flutter_cmd, coverage=True, test_dir=None):
+    """
+    Run flutter test and return (stdout+stderr, returncode).
+    Uses --machine for JSON output on stdout.
+    """
+    cmd = flutter_cmd + ["test", "--machine", "--no-pub"]
+
+    if coverage:
+        cmd.append("--coverage")
+
+    if test_dir:
+        cmd.append(test_dir)
+
+    print(f"Running: {' '.join(cmd)}")
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Result parsing
+# ---------------------------------------------------------------------------
+
+def parse_machine_output(stdout):
+    """
+    Parse flutter test --machine JSON output.
+    Each line is a separate JSON event.
+    Returns (total, passed, failed, skipped, failures).
+    """
+    tests = {}  # id -> test info
+    results = {}  # id -> result
+    failures = []
+
+    for line in stdout.strip().splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        event_type = event.get("type")
+
+        if event_type == "testStart":
+            test_info = event.get("test", {})
+            test_id = test_info.get("id")
+            if test_id is not None:
+                tests[test_id] = test_info
+
+        elif event_type == "testDone":
+            test_id = event.get("testID")
+            if test_id is not None:
+                results[test_id] = {
+                    "hidden": event.get("hidden", False),
+                    "skipped": event.get("skipped", False),
+                    "result": event.get("result", ""),
+                }
+
+        elif event_type == "error":
+            test_id = event.get("testID")
+            error_msg = event.get("error", "Unknown error")
+            # Clean up error message
+            error_msg = error_msg.split("\n")[0].strip()[:160]
+            if test_id is not None and test_id in tests:
+                test_info = tests[test_id]
+                suite_path = test_info.get("root_url", test_info.get("url", ""))
+                if suite_path:
+                    suite_path = _shorten_path(suite_path)
+                failures.append({
+                    "suite": suite_path or "unknown",
+                    "test": test_info.get("name", "unknown"),
+                    "msg": error_msg,
+                })
+
+    # Count results (exclude hidden/setup tests)
+    total = 0
+    passed = 0
+    failed = 0
+    skipped = 0
+
+    for test_id, result in results.items():
+        if result.get("hidden"):
+            continue
+        total += 1
+        if result.get("skipped"):
+            skipped += 1
+        elif result.get("result") == "success":
+            passed += 1
+        elif result.get("result") == "error" or result.get("result") == "failure":
+            failed += 1
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
+def parse_fallback(stderr):
+    """
+    Fallback parser when --machine output is unavailable or empty.
+    Parses text output for pass/fail counts.
+    """
+    total = 0
+    passed = 0
+    failed = 0
+    skipped = 0
+    failures = []
+
+    # Flutter test summary line: XX:XX +N -M: Some message
+    # Or: XX:XX +N: All tests passed!
+    summary_pattern = re.compile(
+        r"(\d+:\d+)\s+\+(\d+)(?:\s+~(\d+))?(?:\s+-(\d+))?:\s+(.*)"
+    )
+
+    # Find the last summary line
+    last_match = None
+    for m in summary_pattern.finditer(stderr):
+        last_match = m
+
+    if last_match:
+        passed = int(last_match.group(2))
+        skipped = int(last_match.group(3) or 0)
+        failed = int(last_match.group(4) or 0)
+        total = passed + failed + skipped
+
+    # Extract failure details
+    fail_pattern = re.compile(
+        r"^(.*\.dart)\s+.*?(?:FAILED|ERROR)\s*$", re.MULTILINE
+    )
+    for m in fail_pattern.finditer(stderr):
+        filepath = _shorten_path(m.group(1).strip())
+        failures.append({
+            "suite": filepath,
+            "test": "See output above",
+            "msg": "",
+        })
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coverage parsing
+# ---------------------------------------------------------------------------
+
+def parse_coverage(project_dir, exclude_patterns=None):
+    """
+    Parse coverage from lcov.info file produced by flutter test --coverage.
+    Returns dict with 'overall' (float %), 'per_target' (list of strings), or None.
+    """
+    lcov_path = os.path.join(project_dir, "coverage", "lcov.info")
+    if not os.path.exists(lcov_path):
+        return None
+
+    try:
+        with open(lcov_path) as f:
+            content = f.read()
+    except IOError:
+        return None
+
+    # Parse LCOV format
+    total_lines = 0
+    covered_lines = 0
+    excluded_lines = 0
+    excluded_covered = 0
+    per_file = []  # (short_path, pct, file_total)
+    current_file = None
+    file_total = 0
+    file_covered = 0
+
+    for line in content.splitlines():
+        if line.startswith("SF:"):
+            current_file = line[3:].strip()
+            file_total = 0
+            file_covered = 0
+        elif line.startswith("LF:"):
+            file_total = int(line[3:].strip())
+        elif line.startswith("LH:"):
+            file_covered = int(line[3:].strip())
+        elif line.startswith("end_of_record"):
+            if current_file and file_total > 0:
+                short = _shorten_path(current_file)
+
+                if exclude_patterns and _file_matches_patterns(current_file, exclude_patterns):
+                    excluded_lines += file_total
+                    excluded_covered += file_covered
+                else:
+                    total_lines += file_total
+                    covered_lines += file_covered
+                    pct = file_covered / file_total * 100
+                    per_file.append((short, pct, file_total))
+
+            current_file = None
+
+    if total_lines == 0:
+        return None
+
+    overall = covered_lines / total_lines * 100
+    per_target = _group_by_directory(per_file)
+
+    result = {"overall": overall, "per_target": per_target}
+    if exclude_patterns and excluded_lines > 0:
+        result["excluded_lines"] = excluded_lines
+        result["excluded_pct"] = excluded_covered / excluded_lines * 100
+    return result
+
+
+def _group_by_directory(per_file):
+    """Group per-file coverage into per-directory summaries."""
+    dir_stats = {}
+    for short_path, pct, file_total in per_file:
+        parts = short_path.split("/")
+        if len(parts) >= 2:
+            dir_key = parts[0] if parts[0] != "lib" else (parts[1] if len(parts) > 2 else "lib")
+        else:
+            dir_key = "root"
+        if dir_key not in dir_stats:
+            dir_stats[dir_key] = [0, 0]
+        dir_stats[dir_key][0] += file_total
+        dir_stats[dir_key][1] += int(file_total * pct / 100)
+
+    per_target = []
+    for dir_name, (total, covered) in sorted(dir_stats.items(), key=lambda x: x[1][0], reverse=True):
+        if total == 0:
+            continue
+        pct = covered / total * 100
+        per_target.append(f"{dir_name}: {pct:.1f}%")
+
+    return per_target
+
+
+def _file_matches_patterns(filepath, patterns):
+    """Check if a filepath matches any exclusion pattern."""
+    basename = os.path.basename(filepath)
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern):
+            return True
+        if fnmatch.fnmatch(basename, pattern):
+            return True
+        if "/" in pattern and fnmatch.fnmatch(filepath, f"*{pattern}*"):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _shorten_path(filepath):
+    """Shorten a file path for display."""
+    filepath = filepath.replace("\\", "/")
+    # Remove common prefixes and URI schemes
+    for prefix in ["file://", "package:"]:
+        if filepath.startswith(prefix):
+            filepath = filepath[len(prefix):]
+    for prefix in ["/lib/", "lib/", "./lib/", "./", "/"]:
+        idx = filepath.find(prefix)
+        if idx >= 0:
+            filepath = filepath[idx + len(prefix):]
+            break
+    parts = filepath.split("/")
+    if len(parts) > 4:
+        return "/".join(parts[-4:])
+    return filepath
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_table(results, coverage=None):
+    """Print results in the pipeline contract format."""
+    if not results or results["total"] == 0:
+        print("\nNo test results parsed. Check diagnostic info above.")
+        return
+
+    total = results["total"]
+    passed = results["passed"]
+    failed = results["failed"]
+    skipped = results["skipped"]
+    failures = results["failures"]
+
+    coverage_str = f" | Coverage: {coverage['overall']:.1f}%" if coverage else ""
+    skip_str = f", Skipped: {skipped}" if skipped else ""
+    print(f"\nSummary: Total: {total}, Passed: {passed}, Failed: {failed}{skip_str}{coverage_str}\n")
+
+    if coverage and coverage.get("per_target"):
+        print("Coverage:  " + "  |  ".join(coverage["per_target"]))
+        if coverage.get("excluded_lines"):
+            print(f"Excluded:  {coverage['excluded_lines']} lines ({coverage['excluded_pct']:.1f}% covered) -- filtered by --exclude-from-coverage")
+        print()
+
+    if not failures:
+        if failed == 0:
+            print("All tests passed.")
+        return
+
+    # Print failure table
+    sw = max(len(f["suite"]) for f in failures) if failures else 0
+    tw = max(len(f["test"]) for f in failures) if failures else 0
+    sw = max(sw, 5)
+    tw = max(tw, 4)
+
+    header = f"{'Suite':<{sw}}  {'Test':<{tw}}"
+    print(header)
+    print("-" * min(sw + tw + 4, 120))
+
+    for f in failures:
+        print(f"{f['suite']:<{sw}}  {f['test']:<{tw}}")
+        if f.get("msg"):
+            print(f"   > {f['msg']}")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Flutter tests and show minimal pass/fail table."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument("--test-dir", default=None, help="Specific test directory to run (e.g. test/unit)")
+    parser.add_argument("--no-coverage", action="store_true", help="Disable code coverage collection")
+    parser.add_argument(
+        "--exclude-from-coverage",
+        nargs="+",
+        metavar="PATTERN",
+        help="Glob patterns for files to exclude from coverage (e.g. '*.g.dart' '*.freezed.dart')",
+    )
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    collect_coverage = not args.no_coverage
+
+    print(f"Project dir: {project_dir}")
+
+    # Verify pubspec.yaml exists
+    if not os.path.exists(os.path.join(project_dir, "pubspec.yaml")):
+        print("ERROR: No pubspec.yaml found in:")
+        print(f"  {project_dir}")
+        sys.exit(1)
+
+    flutter_cmd = find_flutter()
+    print(f"Flutter: {' '.join(flutter_cmd)}")
+
+    stdout, stderr, returncode = run_tests(
+        project_dir, flutter_cmd,
+        coverage=collect_coverage,
+        test_dir=args.test_dir,
+    )
+
+    # Parse results from --machine JSON output (stdout)
+    results = parse_machine_output(stdout)
+
+    # Fallback to text parsing from stderr if machine output didn't work
+    if not results or results["total"] == 0:
+        results = parse_fallback(stderr)
+
+    # Parse coverage
+    coverage = None
+    if collect_coverage:
+        # Default exclusions for generated files
+        exclude_patterns = list(args.exclude_from_coverage or [])
+        default_excludes = ["*.g.dart", "*.freezed.dart", "*.gen.dart"]
+        for pattern in default_excludes:
+            if pattern not in exclude_patterns:
+                exclude_patterns.append(pattern)
+
+        coverage = parse_coverage(project_dir, exclude_patterns=exclude_patterns)
+
+    print_table(results, coverage=coverage)
+
+    # Diagnostic output when no results were parsed
+    if not results or results["total"] == 0:
+        print("\n--- Diagnostic Info ---")
+        if returncode != 0:
+            print(f"flutter test returned exit code {returncode}")
+        else:
+            print("Tests ran but no results were parsed.")
+
+        # Show stderr (flutter test puts human-readable output there when --machine is used)
+        lines = stderr.strip().splitlines()
+        filtered = [l for l in lines if l.strip()]
+        display = filtered if filtered else lines
+        print("\nLast 50 lines of output:")
+        print("\n".join(display[-50:]))
+
+        if returncode != 0:
+            sys.exit(1)
+        return
+
+    if results["failed"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/flutter/test-overlay.md
+++ b/adapters/flutter/test-overlay.md
@@ -1,0 +1,232 @@
+# Flutter / Dart — Test Overlay
+
+<!-- Injected into test-architect-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Test Framework: flutter test
+
+Flutter provides three test levels with increasing scope and cost. Test the architecture layers bottom-up: Services → Repositories → ViewModels → Widgets → Integration flows.
+
+## Test Structure
+
+```
+test/
+  unit/
+    data/
+      services/
+        feature_service_test.dart
+      repositories/
+        feature_repository_test.dart
+    ui/
+      feature_name/
+        feature_view_model_test.dart
+  widget/
+    ui/
+      feature_name/
+        feature_view_test.dart
+  goldens/
+    feature_widget_test.dart
+integration_test/
+  critical_flow_test.dart
+```
+
+Naming convention: `test_<feature>_<scenario>_<expected>` for test descriptions.
+
+File naming: `<source_file>_test.dart` in a parallel directory structure under `test/`.
+
+## Unit Tests
+
+Test every method on Services, Repositories, and ViewModels individually.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late FeatureRepository repository;
+  late FakeFeatureService fakeService;
+
+  setUp(() {
+    fakeService = FakeFeatureService();
+    repository = FeatureRepository(service: fakeService);
+  });
+
+  group('FeatureRepository', () {
+    test('fetches and transforms data from service', () async {
+      fakeService.stubbedResponse = RawData(id: '1', value: 42);
+
+      final result = await repository.getFeature('1');
+
+      expect(result, isA<Ok<Feature>>());
+      expect((result as Ok<Feature>).value.id, '1');
+    });
+
+    test('returns error result on service failure', () async {
+      fakeService.shouldFail = true;
+
+      final result = await repository.getFeature('1');
+
+      expect(result, isA<Error<Feature>>());
+    });
+  });
+}
+```
+
+### Mocking Strategy
+
+- Write **fakes** (manual implementations of abstract classes) that focus on inputs/outputs — not implementation details.
+- Use `mockito` + `@GenerateNiceMocks` for generated mocks when fakes would be verbose.
+- Mock at the boundary: fake Services when testing Repositories, fake Repositories when testing ViewModels.
+- Never mock the class under test.
+
+### ViewModel Testing
+
+```dart
+test('updates state when data loads', () async {
+  final viewModel = FeatureViewModel(repository: fakeRepository);
+
+  await viewModel.loadData();
+
+  expect(viewModel.items, hasLength(3));
+  expect(viewModel.isLoading, isFalse);
+});
+
+test('notifies listeners on state change', () async {
+  final viewModel = FeatureViewModel(repository: fakeRepository);
+  var notified = false;
+  viewModel.addListener(() => notified = true);
+
+  await viewModel.loadData();
+
+  expect(notified, isTrue);
+});
+```
+
+## Widget Tests
+
+Test widget rendering, user interaction, and child widget instantiation using `testWidgets()`.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('displays loading indicator while fetching', (tester) async {
+    final viewModel = FakeFeatureViewModel(isLoading: true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FeatureView(viewModel: viewModel),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('tapping item navigates to detail', (tester) async {
+    final viewModel = FakeFeatureViewModel(items: [testItem]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FeatureView(viewModel: viewModel),
+      ),
+    );
+
+    await tester.tap(find.text(testItem.title));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DetailView), findsOneWidget);
+  });
+}
+```
+
+### Key Widget Test APIs
+
+- `tester.pumpWidget(widget)` — Renders the widget.
+- `tester.pump(duration)` — Advances time by duration, triggers rebuild.
+- `tester.pumpAndSettle()` — Pumps until all animations complete.
+- `tester.tap(finder)` — Simulates tap on found widget.
+- `tester.enterText(finder, text)` — Types text into field.
+- `tester.drag(finder, offset)` — Simulates drag gesture.
+- `find.byType(Widget)` — Finds by widget type.
+- `find.text('string')` — Finds by displayed text.
+- `find.byKey(Key('id'))` — Finds by widget key.
+- Wrap in `MaterialApp` or `CupertinoApp` for theming/navigation context.
+
+## Golden Tests
+
+Verify widget rendering matches reference bitmap images.
+
+```dart
+testWidgets('feature widget matches golden', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(home: FeatureWidget(data: testData)),
+  );
+
+  await expectLater(
+    find.byType(FeatureWidget),
+    matchesGoldenFile('goldens/feature_widget.png'),
+  );
+});
+```
+
+Update golden files: `flutter test --update-goldens`
+
+Golden tests are brittle across platforms/OS versions. Run on CI with a fixed environment. Store golden files in `test/goldens/`.
+
+## Integration Tests
+
+Test critical user journeys end-to-end on real devices or emulators.
+
+```dart
+// integration_test/app_test.dart
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_app/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('complete feature flow', (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Get Started'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Welcome'), findsOneWidget);
+  });
+}
+```
+
+## Coverage
+
+```bash
+flutter test --coverage                          # Generates coverage/lcov.info
+# Convert to HTML (requires lcov):
+genhtml coverage/lcov.info -o coverage/html
+```
+
+### Coverage Exclusions
+
+Exclude from coverage calculations:
+- Generated files: `*.g.dart`, `*.freezed.dart`, `*.gen.dart`
+- L10n generated: `lib/l10n/`, `*.arb`
+- Platform-specific: `android/`, `ios/`, `linux/`, `macos/`, `windows/`, `web/`
+- Config: `pubspec.yaml`, `analysis_options.yaml`
+
+## Async Testing
+
+- Use `async` test bodies for `Future`-based code.
+- `tester.pump()` advances the event loop — use after triggering async operations in widget tests.
+- `tester.pumpAndSettle()` waits for all animations and scheduled frames.
+- `tester.runAsync(() async { ... })` for real async operations (HTTP, file I/O) in widget tests.
+- For `Stream`-based code, use `expectLater(stream, emitsInOrder([...]))`.
+
+## Anti-Patterns
+
+- **Testing implementation details:** Don't assert on internal state — test observable behavior (rendered UI, emitted values, returned results).
+- **Shared mutable state between tests:** Each test must set up its own fakes/state in `setUp()`.
+- **Testing framework code:** Don't test that `Navigator` works or that `provider` propagates — test your code's behavior.
+- **Hard-coded delays:** Never use `Future.delayed` in tests. Use `tester.pump(duration)` for animations, `tester.pumpAndSettle()` for completion.
+- **Testing generated code:** Don't write tests for `*.g.dart` or `*.freezed.dart` output.
+- **Broad golden tests:** Golden-test small, isolated widgets — not full screens that change frequently.
+- **Missing tearDown:** If a test registers global error handlers or modifies static state, restore in `tearDown()`.


### PR DESCRIPTION
## Summary

- Adds complete Flutter/Dart adapter (10 files) with Google's official MVVM + Repository architecture baked into all overlays
- Encodes Effective Dart, widget composition patterns, performance best practices, accessibility, internationalization, and platform-adaptive guidance
- Build script runs `flutter analyze` + `dart format --set-exit-if-changed`; test script parses `flutter test --machine --coverage` JSON events + lcov (auto-excludes `*.g.dart`/`*.freezed.dart`)
- Designed for multi-stack use: `--stack=flutter --stack=swift-ios --stack=android` — Flutter owns `lib/**/*.dart`, native adapters own platform directories

## Key design decisions

- **Architecture**: MVVM (View → ViewModel → Repository → Service) with unidirectional data flow, constructor DI via `provider`, immutable models via `freezed` — all per Google's official app architecture guide
- **Complexity mapping**: Widgets and ViewModels are Haiku boundaries when contracts are defined; architecture decisions (state management, DI tree, navigation guards) escalate to Sonnet; custom RenderObjects to Opus
- **Essential overlay**: 12 rules, ~650 chars — well within the 500-800 char target for Haiku tasks
- **FVM support**: Build and test scripts detect FVM-managed Flutter SDK automatically
- **No pipeline changes needed**: Discovered automatically from `manifest.json` — zero edits to `init.sh`, skills, or tests

## Test plan

- [x] `python3 tests/validate_structure.py` — 297 checks passed (adapter auto-discovered)
- [x] `python3 tests/test_contracts.py` — 51 tests passed
- [ ] Bootstrap smoke test with a real Flutter project (`bash init.sh /path/to/flutter-app --stack=flutter`)
- [ ] Verify `flutter analyze` + `dart format` output parsing with a project containing intentional errors
- [ ] Verify `flutter test --machine` JSON event parsing with passing and failing tests
- [ ] Verify lcov coverage parsing with `*.g.dart` exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)