### PR TITLE
feat(adapter): add Android/Kotlin adapter

### DIFF
--- a/adapters/android/adapter.md
+++ b/adapters/android/adapter.md
@@ -1,0 +1,50 @@
+# Android / Kotlin Adapter
+
+## Stack Metadata
+
+- **Stack name:** `android`
+- **Display name:** Android / Kotlin
+- **Languages:** Kotlin (primary), Java (legacy)
+- **Build system:** Gradle (Kotlin DSL preferred) + Android Gradle Plugin (AGP)
+- **Test framework:** JUnit 4 + Robolectric (local), Espresso / Compose Testing (instrumented)
+- **Coverage tool:** JaCoCo
+- **Dependency injection:** Hilt
+
+## Build & Test Commands
+
+- **Build:** `python3 .claude/scripts/android/build.py [--project-dir .] [--module app] [--variant debug]`
+- **Test:** `python3 .claude/scripts/android/test.py [--project-dir .] [--module app] [--variant debug] [--no-coverage]`
+
+## Blocked Commands
+
+These commands are blocked by hooks and must use the pipeline skills instead:
+- `./gradlew test` / `./gradlew connectedAndroidTest` -> use `test-runner` skill
+- `./gradlew build` / `./gradlew assemble` / `./gradlew lint` -> use `build-runner` skill
+- `gradle` / `gradlew` direct invocations -> use `build-runner` / `test-runner` skill
+
+## Overlay Files
+
+| Overlay | Agent | Purpose |
+|---------|-------|---------|
+| `architect-overlay.md` | architect-agent | Android architecture layers, Jetpack patterns, complexity mapping |
+| `implementer-overlay.md` | implementer-agent | Kotlin style, coroutines, Compose, lifecycle, security |
+| `reviewer-overlay.md` | code-reviewer-agent | Android/Kotlin-specific review checklist |
+| `test-overlay.md` | test-architect-agent | JUnit, Robolectric, Espresso, Compose testing, Turbine |
+
+## Project Detection
+
+This adapter activates when the project root contains:
+- `build.gradle.kts` or `build.gradle` (top-level or in `app/`)
+
+## Common Conventions
+
+- **Architecture:** MVVM — UI Layer (Compose/Views + ViewModel) + Domain Layer (optional Use Cases) + Data Layer (Repository + DataSource)
+- **State management:** ViewModel + StateFlow (modern) or LiveData (legacy), sealed classes for UI state
+- **DI:** Hilt with constructor injection, `@HiltViewModel`, scoped bindings
+- **UI:** Jetpack Compose (recommended for new projects), Material Design 3
+- **Navigation:** Navigation Compose with type-safe routes
+- **Async:** Kotlin Coroutines with structured concurrency — viewModelScope, lifecycleScope, injected dispatchers
+- **Persistence:** Room (database), DataStore (preferences), EncryptedSharedPreferences (secrets)
+- **Kotlin style:** lowerCamelCase functions/properties, UpperCamelCase classes, SCREAMING_SNAKE_CASE constants, `val` over `var`, immutable collections
+- **Error handling:** Sealed Result types, specific exception catching, never catch CancellationException
+- **Background work:** WorkManager for persistent tasks, coroutines for in-process async

--- a/adapters/android/architect-overlay.md
+++ b/adapters/android/architect-overlay.md
@@ -1,0 +1,85 @@
+# Android / Kotlin — Architect Overlay
+
+<!-- Injected into architect-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Architecture: Google's Recommended Android App Architecture
+
+**UI Layer:** UI elements (Compose or Views) + State holders (ViewModels). ViewModel survives configuration changes, exposes immutable UI state via `StateFlow`. UI state defined as immutable `data class`. Unidirectional data flow: state flows down, events flow up.
+
+**Domain Layer (optional):** Use Cases encapsulate reusable/complex business logic between UI and Data layers. Named `[Verb][Noun]UseCase` with `operator fun invoke()`. Must be main-safe. No own lifecycle — scoped to consumer.
+
+**Data Layer:** Repositories as single source of truth per data type. Named `[Type]Repository`. Data Sources named `[Type][Source]DataSource`. Repositories expose domain models, not raw API/DB responses. Handle caching, retry, conflict resolution. Never access data sources directly from UI.
+
+**Data flow is unidirectional:** Data flows up (DataSource → Repository → UseCase → ViewModel → UI). Events flow down (UI → ViewModel → UseCase → Repository). All exposed data is immutable.
+
+## Complexity Patterns for Task Decomposition
+
+### UI Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Stateless Compose screen (displays ViewModel state) | Haiku | Mechanical composition, fully specified |
+| Compose screen with user interaction (forms, gestures) | Haiku | Clear event/state contract |
+| Adaptive layout (window size classes, navigation suite) | Haiku-Sonnet | Platform branching, responsive design |
+| Custom Compose layout / Modifier chain | Sonnet | Layout protocol knowledge |
+| Complex animation (shared element, motion layout) | Sonnet | Timing, state coordination |
+| Compose + View interop (legacy migration) | Sonnet | Two-system coordination |
+
+### ViewModel & State Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| ViewModel exposing single StateFlow | Haiku | Standard pattern, clear contract |
+| ViewModel with multiple repository dependencies | Haiku-Sonnet | Flow combining, error coordination |
+| Sealed UI state with Loading/Success/Error | Haiku | Mechanical pattern, exhaustive when |
+| Complex state machine (multi-step flow) | Sonnet | State transitions, edge cases |
+| SavedStateHandle integration for process death | Haiku-Sonnet | Serialization strategy |
+
+### Data Layer Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Repository wrapping single data source | Haiku | Mechanical: fetch/cache/return |
+| Repository with offline-first strategy | Sonnet | Cache invalidation, sync conflicts |
+| Room entity + DAO (single table) | Haiku | Schema is mechanical |
+| Room migration / multi-table relationships | Sonnet | Migration strategy, query design |
+| DataStore setup (Preferences or Proto) | Haiku | Config-driven, follows pattern |
+| Network layer setup (Retrofit + OkHttp) | Haiku-Sonnet | Interceptors, error mapping |
+
+### Platform & Integration Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Hilt module + bindings for a feature | Haiku | Annotation-driven, follows patterns |
+| Hilt multi-module DI architecture | Sonnet | Scoping, component hierarchy |
+| Navigation graph (Compose Navigation) | Haiku-Sonnet | Route design, deep links, guards |
+| Runtime permissions flow | Haiku-Sonnet | UX design, denial handling |
+| WorkManager task (one-shot or periodic) | Haiku-Sonnet | Constraints, retry, chaining |
+| Platform channel (Flutter ↔ Android) | Sonnet | Cross-boundary contract |
+| Foreground service / notification channels | Sonnet | Lifecycle, system interaction |
+| Content provider (shared data) | Sonnet | Security, URI design |
+| Baseline profile generation | Haiku-Sonnet | Setup is Haiku, critical paths are Sonnet |
+
+### Build & Config Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Build variant / product flavor setup | Sonnet | Build system design decisions |
+| Version catalog (libs.versions.toml) | Haiku | Mechanical file editing |
+| ProGuard/R8 keep rules | Sonnet | Reflection analysis, library interaction |
+| Convention plugin | Sonnet | Build system abstraction |
+
+### Testing Patterns
+| Pattern | Model | Rationale |
+|---|---|---|
+| Unit test for ViewModel/Repository/UseCase | Haiku | Method-level, clear inputs/outputs |
+| Compose UI test (single composable) | Haiku | Semantics-based assertions |
+| Robolectric test for Android framework code | Haiku-Sonnet | Framework simulation |
+| Espresso / instrumented test | Sonnet | Device interaction, async waits |
+| End-to-end flow test | Sonnet | Multi-screen, real navigation |
+
+## Decomposition Notes
+
+- **Composables/Screens are Haiku boundaries.** Each screen is self-contained when its ViewModel interface is defined.
+- **ViewModels are Haiku boundaries** when repository interfaces exist. ViewModel design (which repos, which flows to combine) is Sonnet.
+- **Use Cases are Haiku** when the business rule is specified. Deciding whether to introduce a Use Case is Sonnet.
+- **Room entities + DAOs are Haiku** for single-table CRUD. Multi-table joins and migration strategy are Sonnet.
+- **Hilt modules are Haiku** when bindings are specified. DI architecture design is Sonnet.
+- **Architecture decisions are Sonnet:** Offline-first strategy, state management approach, navigation architecture, DI scoping.
+- **Generated code is not a task.** Never create tasks for Hilt-generated components, Room schema JSON, or Dagger files.
+- **Prefer feature-first project structure:** `feature/[name]/ui/`, `feature/[name]/data/`, `feature/[name]/domain/`.

--- a/adapters/android/hooks.json
+++ b/adapters/android/hooks.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in ./gradlew|gradlew|gradle) echo \"$CMD\" | head -1 | grep -qE '(test|Test|assemble|build|lint|connectedAndroidTest)' && echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the build-runner or test-runner skill instead. Subagents: python3 .claude/scripts/android/build.py or python3 .claude/scripts/android/test.py.\"}' || echo '{}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for forbidden build/test commands..."
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); FIRST=$(echo \"$CMD\" | head -1 | sed 's/^[[:space:]]*//' | awk '{print $1}'); case \"$FIRST\" in grep|rg) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Grep tool instead of grep/rg via Bash. Grep supports regex, glob filters, context lines, and multiple output modes.\"}' ;; cat|head|tail) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Read tool instead of cat/head/tail via Bash. Read supports offset and limit parameters for partial file reading.\"}' ;; find) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Glob tool instead of find via Bash. Glob supports patterns like **/*.kt for recursive file discovery.\"}' ;; sed|awk) echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: Use the Edit tool instead of sed/awk via Bash. Edit performs exact string replacements in files.\"}' ;; *) echo '{}' ;; esac",
+            "timeout": 5,
+            "statusMessage": "Checking for dedicated tool alternatives..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/android/implementer-overlay-essential.md
+++ b/adapters/android/implementer-overlay-essential.md
@@ -1,0 +1,14 @@
+# Android / Kotlin — Essential Rules (Haiku)
+
+- MVVM: UI displays ViewModel state via StateFlow, Repositories own data logic
+- Backing property: private MutableStateFlow, public StateFlow — never expose mutable
+- Sealed classes for UI state (Loading/Success/Error) — exhaustive `when`
+- Inject dispatchers — never hardcode. All suspend functions main-safe
+- Never catch CancellationException. Catch specific types only
+- `val` over `var`, immutable collections, data class for state
+- Hilt DI: `@HiltViewModel`, `@Inject constructor`, `@Binds` for interfaces
+- ViewModel must never hold Activity/Context/View — memory leak
+- No hardcoded strings/colors/dimensions — use resources and theme tokens
+- `android:exported=false` on internal components, parameterized SQL
+- `remember`/`rememberSaveable` for Compose state, `key` in LazyColumn
+- Avoid `!!` — use `?.`, `?:`, `requireNotNull()`

--- a/adapters/android/implementer-overlay.md
+++ b/adapters/android/implementer-overlay.md
@@ -1,0 +1,100 @@
+# Android / Kotlin — Implementer Overlay
+
+<!-- Injected into implementer-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Architecture (MVVM + Repository)
+
+- UI elements (Compose or Views) display state from ViewModel — minimal logic (formatting, visibility, navigation triggers).
+- ViewModel exposes immutable `StateFlow<UiState>` via backing property pattern (`private val _uiState` / `val uiState`). Never expose `MutableStateFlow` or `MutableLiveData`.
+- Define UI state as immutable `data class FeatureUiState(...)`. Use sealed classes/interfaces for `Loading`/`Success`/`Error` variants.
+- Repositories are the single source of truth per data type. Output domain models, handle caching, retry, conflict resolution.
+- Data sources (network, local DB, preferences) hold no business logic. One per external source.
+- Constructor injection via Hilt. `@HiltViewModel` + `@Inject constructor` for ViewModels. `@Binds` for interfaces, `@Provides` for third-party objects.
+- All suspend functions must be **main-safe** — move heavy work off main thread with `withContext(dispatcher)`.
+
+## Kotlin Style
+
+- `lowerCamelCase` for functions, properties, parameters, local variables. `UpperCamelCase` for classes, interfaces, objects, type aliases. `SCREAMING_SNAKE_CASE` for constants (`const val`, top-level `val` with no custom getter).
+- `val` over `var` — immutability by default. Immutable collections (`List`, `Set`, `Map`) over mutable variants.
+- Default parameter values over function overloads.
+- Expression bodies (`fun foo() = expr`) for simple single-expression functions.
+- String templates (`"Hello $name"`) over concatenation.
+- Named arguments for functions with multiple same-type or boolean parameters.
+- Trailing commas at declaration sites.
+- Higher-order functions (`filter`, `map`, `flatMap`) over imperative loops when intent is clearer.
+- Scope functions: `apply` for object configuration, `let` for null-safe transforms, `also` for side effects, `run`/`with` for scope reduction.
+- Modifier order: visibility → `final`/`open`/`abstract`/`sealed`/`const` → `override` → `lateinit` → `suspend` → `inner` → `data` → `companion`.
+- 4-space indentation, no tabs. Annotations on separate lines before declaration.
+
+## Coroutines & Structured Concurrency
+
+- **Inject dispatchers** — never hardcode `Dispatchers.IO`/`Dispatchers.Default`. Accept as constructor parameter for testability.
+- `viewModelScope` for ViewModel coroutines. Never expose suspend functions from ViewModel — launch internally.
+- `lifecycleScope` + `repeatOnLifecycle(Lifecycle.State.STARTED)` for collecting flows in Activities/Fragments.
+- `withContext(ioDispatcher)` for I/O operations. `withContext(defaultDispatcher)` for CPU-bound work.
+- `coroutineScope { }` / `supervisorScope { }` for parallel work in data/domain layers.
+- Never use `GlobalScope` directly — inject `CoroutineScope` for work that must outlive the caller.
+- Never catch `CancellationException` — it breaks structured concurrency. Always rethrow it.
+- Call `ensureActive()` in long-running loops for cooperative cancellation.
+
+## Jetpack Compose
+
+- Composables are functions of state — no side effects in composition. Side effects go in `LaunchedEffect`, `DisposableEffect`, `SideEffect`.
+- `remember` for composition-scoped state. `rememberSaveable` for state surviving configuration changes and process death.
+- Hoist state: stateless composables receive state + event callbacks from parent. Stateful wrappers create state and pass it down.
+- `Modifier` is the first optional parameter. Chain modifiers — order matters (padding before/after background changes behavior).
+- Use `key` parameter in `LazyColumn`/`LazyRow` items for stable identity.
+- Minimize recomposition scope: extract frequently-changing UI into small composables. Use `derivedStateOf` for computed state.
+- Material 3 theming: `MaterialTheme.colorScheme`, `MaterialTheme.typography`, `MaterialTheme.shapes`. Dynamic color with `dynamicDarkColorScheme`/`dynamicLightColorScheme` on Android 12+.
+
+## Lifecycle & Configuration Changes
+
+- Activities/Fragments have ephemeral lifecycles — never store persistent data in them.
+- ViewModel persists through configuration changes (rotation, resize, fold). Use `SavedStateHandle` for process death survival.
+- `rememberSaveable` in Compose for UI state that survives both.
+- ViewModel must **never** hold references to Activity, Context, or View — causes memory leaks.
+- Use Application context (`@ApplicationContext`) for long-lived objects via Hilt.
+
+## Persistence
+
+- **Room** for structured data: `@Entity`, `@Dao`, `@Database`. Use KSP (not kapt). Singleton database instance. Suspend DAO functions for coroutine support. Migrations for version changes.
+- **DataStore** for key-value preferences (replaces SharedPreferences): fully async via Flow + coroutines, handles corruption.
+- **EncryptedSharedPreferences** for sensitive key-value data. Android Keystore for cryptographic keys.
+
+## Error Handling
+
+- Sealed `Result` types for operations that can fail. Forces exhaustive handling via `when`.
+- Catch specific exception types — never bare `catch (e: Exception)` unless rethrowing unknown exceptions.
+- **Never catch `CancellationException`** — always rethrow.
+- `requireNotNull()` / `checkNotNull()` for validation with descriptive messages.
+- Avoid `!!` (non-null assertion) — indicates a design problem. Use `?.`, `?:`, `let`, `requireNotNull()`.
+
+## Security
+
+- Never hardcode API keys, secrets, or credentials. Use `local.properties` or `secrets-gradle-plugin` for build-time secrets.
+- HTTPS for all network connections. Network security config for certificate pinning.
+- `android:exported=false` on all components not shared externally (required API 31+).
+- Parameterized queries in Room/ContentProvider — never string-concatenate SQL.
+- Never log PII or secrets in production. Strip logging in release builds via R8/ProGuard.
+- `SecureRandom` for cryptographic operations — never `java.util.Random`.
+
+## Permissions
+
+- Check permissions before each access — never assume previously granted.
+- Request only what's needed. Explain why before requesting.
+- Handle denial gracefully — degrade functionality, don't crash.
+- `ActivityResultContracts.RequestPermission()` for modern permission requests.
+
+## Build Configuration
+
+- Kotlin DSL (`.gradle.kts`) preferred for new projects.
+- Version catalog (`gradle/libs.versions.toml`) as single source of truth for dependency versions.
+- Enable `isMinifyEnabled = true` and `isShrinkResources = true` for release builds.
+- `compileSdk` = latest stable API. `targetSdk` = latest attested. `minSdk` = business requirement.
+
+## Resources
+
+- No hardcoded strings — use `strings.xml` for all user-facing text (enables localization).
+- No hardcoded dimensions — use `dimens.xml`.
+- No hardcoded colors — use Material theme tokens.
+- Qualifier directories for configuration-specific resources (night, landscape, locale).

--- a/adapters/android/manifest.json
+++ b/adapters/android/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "android",
+  "display_name": "Android / Kotlin",
+  "capabilities": [],
+  "implies_overlays": [],
+  "detection": [
+    { "type": "file_exists", "path": "build.gradle.kts" },
+    { "type": "file_exists", "path": "build.gradle" },
+    { "type": "file_exists", "path": "app/build.gradle.kts" },
+    { "type": "file_exists", "path": "app/build.gradle" }
+  ],
+  "stack_paths": {
+    "directories": ["app/src/main", "app/src/test", "app/src/androidTest", "android"],
+    "fallback_globs": ["**/*.kt", "**/*.java", "**/build.gradle.kts", "**/build.gradle", "**/AndroidManifest.xml", "gradle/libs.versions.toml"]
+  }
+}

--- a/adapters/android/reviewer-overlay.md
+++ b/adapters/android/reviewer-overlay.md
@@ -1,0 +1,87 @@
+# Android / Kotlin — Code Reviewer Overlay
+
+<!-- Injected into code-reviewer-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Domain Expertise
+
+You are a senior Android engineer with deep expertise in Kotlin, Jetpack Compose, Android SDK, Google's official app architecture guide (MVVM + Repository), Hilt dependency injection, coroutines and structured concurrency, Material Design 3, Room, WorkManager, and Android security. You review code for correctness, architecture adherence, lifecycle safety, performance, and platform best practices.
+
+## Review Categories
+
+### 1. Architecture Violations
+- UI layer accessing DataSource directly (must go through Repository)
+- ViewModel accessing DataSource directly (must go through Repository)
+- Business logic in Activity, Fragment, or Composable (belongs in ViewModel/UseCase/Repository)
+- Repository-to-repository coupling (combine in UseCase or ViewModel)
+- Exposing `MutableStateFlow` or `MutableLiveData` from ViewModel (must use backing property pattern)
+- Mutable data in UI state (UI state must be immutable `data class` or sealed type)
+- Missing unidirectional data flow — state must flow down, events flow up
+- ViewModel creating other ViewModels or accessing navigation directly
+
+### 2. Coroutines & Concurrency
+- Hardcoded `Dispatchers.IO`/`Dispatchers.Default` instead of injected dispatchers
+- Catching `CancellationException` without rethrowing (breaks structured concurrency)
+- `GlobalScope` usage instead of scoped coroutines (`viewModelScope`, injected `CoroutineScope`)
+- Bare `launch` in Activity/Fragment without `repeatOnLifecycle` for flow collection
+- Suspend functions not main-safe (I/O or computation without `withContext`)
+- Missing `ensureActive()` in long-running loops
+- Flow collected with `collect` in ViewModel instead of using `stateIn`/`shareIn`
+- `runBlocking` on main thread
+
+### 3. Lifecycle & State
+- ViewModel holding Activity, Context, Fragment, or View references (memory leak)
+- `setState` or UI update after lifecycle destruction (crash)
+- Data stored in Activity/Fragment instead of ViewModel (lost on configuration change)
+- Missing `SavedStateHandle` for state that must survive process death
+- `remember` used where `rememberSaveable` is needed (lost on process death)
+- Side effects in Compose composition (must use `LaunchedEffect`/`DisposableEffect`/`SideEffect`)
+- Missing disposal of resources in `DisposableEffect` onDispose / `onCleared()`
+
+### 4. Compose & UI
+- God composables (>200 lines) that should be decomposed
+- Missing `key` parameter in `LazyColumn`/`LazyRow` items (incorrect recomposition)
+- Modifier not as first optional parameter
+- State hoisting violations — stateful composable where stateless + hoisted state is needed
+- Missing `derivedStateOf` for computed state read during composition
+- Recomposition scope too broad — large composable rebuilds for small state change
+- Hardcoded strings, colors, or dimensions instead of resources/theme tokens
+- Missing Material 3 theme usage (direct color/typography values)
+
+### 5. Performance
+- Blocking the main thread with I/O, computation, or long-running work (ANR risk)
+- Missing baseline profile for critical user journeys
+- Concrete list in `LazyColumn`/`LazyRow` (all items composed eagerly)
+- Image loading without caching library (Coil/Glide)
+- Missing R8/ProGuard minification in release builds
+- Object allocation in frequently-called composition paths
+- Room queries without proper indexing on filtered/joined columns
+
+### 6. Security
+- Hardcoded API keys, secrets, or credentials in source
+- `android:exported=true` on components that should be internal
+- String-concatenated SQL queries (injection risk)
+- Missing HTTPS enforcement / network security config
+- PII or secrets logged in production
+- `java.util.Random` used for security-sensitive operations (must use `SecureRandom`)
+- Missing permission checks before accessing protected resources
+- Sensitive data in unencrypted SharedPreferences (use EncryptedSharedPreferences or DataStore)
+
+### 7. Dependency Injection
+- Manual object instantiation where Hilt should provide dependencies
+- Missing `@HiltViewModel` / `@Inject constructor` annotations
+- Incorrect Hilt scope (e.g., `@Singleton` where `@ViewModelScoped` is appropriate)
+- Missing `@Binds` for interface implementations (using concrete types directly)
+- `@Provides` with side effects in module (modules should be pure)
+- Using `@ApplicationContext` where Activity context is needed (or vice versa)
+
+### 8. Kotlin Best Practices
+- `var` where `val` is sufficient (value never reassigned)
+- Mutable collections exposed where immutable collections should be used
+- `!!` (non-null assertion) without justification — use `?.`, `?:`, `requireNotNull()`
+- Bare `catch (e: Exception)` swallowing all exceptions silently
+- `forEach` with function literal where `for` loop is clearer
+- Missing named arguments on functions with multiple same-type or boolean parameters
+- Missing sealed class/interface where exhaustive handling is needed
+- Platform types from Java interop not explicitly typed (null safety hole)
+- `lateinit` used for nullable state (should be nullable type + null check)
+- Missing KDoc on public API

--- a/adapters/android/scripts/build.py
+++ b/adapters/android/scripts/build.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Run Android build (assemble + lint) and output errors in a minimal table.
+Usage: python build.py [--project-dir /path/to/project] [--module app] [--variant debug]
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+import xml.etree.ElementTree as ET
+
+
+# ---------------------------------------------------------------------------
+# Gradle wrapper detection
+# ---------------------------------------------------------------------------
+
+def find_gradlew(project_dir):
+    """Find the Gradle wrapper executable."""
+    gradlew = os.path.join(project_dir, "gradlew")
+    if os.path.exists(gradlew):
+        if not os.access(gradlew, os.X_OK):
+            os.chmod(gradlew, 0o755)
+        return gradlew
+
+    # Check parent directory (multi-module project where we're in a submodule)
+    parent_gradlew = os.path.join(os.path.dirname(project_dir), "gradlew")
+    if os.path.exists(parent_gradlew):
+        return parent_gradlew
+
+    print("ERROR: Gradle wrapper (gradlew) not found in:")
+    print(f"  {project_dir}")
+    print("Run 'gradle wrapper' to generate it.")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Build steps
+# ---------------------------------------------------------------------------
+
+def run_assemble(project_dir, gradlew, module, variant):
+    """
+    Run Gradle assemble task.
+    Returns (stdout+stderr, returncode).
+    """
+    task = f":{module}:assemble{variant.capitalize()}"
+    print(f"Running: {gradlew} {task}")
+
+    cmd = [gradlew, task, "--no-daemon", "--console=plain"]
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+def run_lint(project_dir, gradlew, module, variant):
+    """
+    Run Android lint.
+    Returns (stdout+stderr, returncode, lint_xml_path).
+    """
+    task = f":{module}:lint{variant.capitalize()}"
+    print(f"Running: {gradlew} {task}")
+
+    cmd = [gradlew, task, "--no-daemon", "--console=plain"]
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    # Lint XML output location
+    lint_xml = os.path.join(
+        project_dir, module, "build", "reports", f"lint-results-{variant}.xml"
+    )
+    if not os.path.exists(lint_xml):
+        # Try alternate location
+        lint_xml = os.path.join(
+            project_dir, module, "build", "reports", "lint-results.xml"
+        )
+
+    return result.stdout + result.stderr, result.returncode, lint_xml
+
+
+# ---------------------------------------------------------------------------
+# Error parsing
+# ---------------------------------------------------------------------------
+
+def parse_gradle_errors(output):
+    """
+    Parse Gradle/Kotlin compiler errors from build output.
+    """
+    errors = []
+    warnings = []
+    seen = set()
+
+    # Kotlin compiler errors: e: file:///path/to/File.kt:10:5 message
+    kotlin_pattern = re.compile(
+        r"([ew]):\s+(?:file://)?([^\s]+\.(?:kt|java)):(\d+):(\d+)\s+(.+)"
+    )
+    for m in kotlin_pattern.finditer(output):
+        severity, filepath, line, col, message = m.groups()
+        parts = filepath.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+        message = message.strip()[:120]
+        key = (short_path, line, message)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {"file": short_path, "line": line, "col": col, "msg": message}
+        if severity == "e":
+            errors.append(entry)
+        else:
+            warnings.append(entry)
+
+    # Java compiler errors: path/to/File.java:10: error: message
+    java_pattern = re.compile(
+        r"([^\s]+\.java):(\d+):\s+(error|warning):\s+(.+)"
+    )
+    for m in java_pattern.finditer(output):
+        filepath, line, severity, message = m.groups()
+        parts = filepath.replace("\\", "/").split("/")
+        short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+        message = message.strip()[:120]
+        key = (short_path, line, message)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {"file": short_path, "line": line, "col": "-", "msg": message}
+        if severity == "error":
+            errors.append(entry)
+        else:
+            warnings.append(entry)
+
+    # Generic Gradle errors: > message or FAILURE: message
+    gradle_error_pattern = re.compile(
+        r"^(?:> |FAILURE: )(.+)$", re.MULTILINE
+    )
+    for m in gradle_error_pattern.finditer(output):
+        msg = m.group(1).strip()[:120]
+        if msg and not any(skip in msg.lower() for skip in ["build failed", "what went wrong"]):
+            key = ("-", "-", msg)
+            if key not in seen:
+                seen.add(key)
+                errors.append({"file": "-", "line": "-", "col": "-", "msg": msg})
+
+    return errors, warnings
+
+
+def parse_lint_xml(lint_xml_path):
+    """
+    Parse Android lint XML report.
+    Returns (errors, warnings).
+    """
+    errors = []
+    warnings = []
+
+    if not lint_xml_path or not os.path.exists(lint_xml_path):
+        return errors, warnings
+
+    try:
+        tree = ET.parse(lint_xml_path)
+        root = tree.getroot()
+
+        seen = set()
+        for issue in root.findall("issue"):
+            severity = issue.get("severity", "").lower()
+            issue_id = issue.get("id", "")
+            message = issue.get("message", "")[:120]
+
+            location = issue.find("location")
+            if location is not None:
+                filepath = location.get("file", "-")
+                parts = filepath.replace("\\", "/").split("/")
+                short_path = "/".join(parts[-3:]) if len(parts) > 3 else filepath
+                line = location.get("line", "-")
+            else:
+                short_path = "-"
+                line = "-"
+
+            key = (short_path, line, issue_id)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            entry = {
+                "file": short_path,
+                "line": line,
+                "col": "-",
+                "msg": f"{issue_id}: {message}",
+            }
+
+            if severity in ("error", "fatal"):
+                errors.append(entry)
+            elif severity == "warning":
+                warnings.append(entry)
+
+    except ET.ParseError as e:
+        print(f"Warning: Could not parse lint XML ({e})")
+
+    return errors, warnings
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_table(build_errors, build_warnings, lint_errors, lint_warnings,
+                build_rc, lint_rc, raw_output=None):
+    """Print results in the pipeline contract format."""
+    all_errors = build_errors + lint_errors
+    all_warnings = build_warnings + lint_warnings
+    failed = build_rc != 0
+
+    if not failed and not all_errors:
+        print(f"\nBUILD SUCCEEDED  |  {len(all_warnings)} warning(s)")
+        return
+
+    if failed and not all_errors:
+        print(f"\nBUILD FAILED  |  0 error(s)  |  {len(all_warnings)} warning(s)\n")
+        print("No parseable errors found. Showing relevant build output:\n")
+        if raw_output:
+            lines = raw_output.strip().splitlines()
+            filtered = [
+                l for l in lines
+                if l.strip()
+                and not any(skip in l for skip in [
+                    "Downloading", "Download ", "> Task",
+                    "BUILD SUCCESSFUL", "actionable task",
+                ])
+            ]
+            problem_lines = [
+                l for l in filtered
+                if any(kw in l.lower() for kw in [
+                    "error", "failed", "fatal", "cannot find",
+                    "not found", "unresolved", "exception",
+                ])
+            ]
+            if problem_lines:
+                print("\n".join(problem_lines[:30]))
+            else:
+                print("\n".join(filtered[-30:]))
+        sys.exit(1)
+
+    error_count = len(all_errors)
+    warning_count = len(all_warnings)
+    print(f"\nBUILD FAILED  |  {error_count} error(s)  |  {warning_count} warning(s)\n")
+
+    if build_errors:
+        print("Compilation Errors:")
+        _print_error_rows(build_errors)
+        print()
+
+    if lint_errors:
+        print("Lint Errors:")
+        _print_error_rows(lint_errors)
+        print()
+
+
+def _print_error_rows(errors):
+    """Print a formatted error table."""
+    fw = max(len(e["file"]) for e in errors)
+    lw = max(len(str(e["line"])) for e in errors)
+
+    header = f"  {'File':<{fw}}  {'Ln':>{lw}}  {'Error'}"
+    print(header)
+    print("  " + "-" * min(len(header) + 80, 120))
+
+    for e in errors:
+        print(f"  {e['file']:<{fw}}  {str(e['line']):>{lw}}  {e['msg']}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Android build (assemble + lint) and output errors in a minimal table."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument("--module", default="app", help="Gradle module name (default: app)")
+    parser.add_argument("--variant", default="debug", help="Build variant (default: debug)")
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    print(f"Building in: {project_dir}")
+
+    gradlew = find_gradlew(project_dir)
+    print(f"Gradle wrapper: {gradlew}")
+    print(f"Module: {args.module}")
+    print(f"Variant: {args.variant}")
+
+    # Step 1: Assemble
+    build_output, build_rc = run_assemble(project_dir, gradlew, args.module, args.variant)
+    build_errors, build_warnings = parse_gradle_errors(build_output)
+
+    if build_rc != 0:
+        print(f"Assemble: FAILED ({len(build_errors)} error(s))")
+    else:
+        print(f"Assemble: OK ({len(build_warnings)} warning(s))")
+
+    # Step 2: Lint (only if assemble succeeded)
+    lint_output = ""
+    lint_rc = 0
+    lint_errors = []
+    lint_warnings = []
+
+    if build_rc == 0:
+        lint_output, lint_rc, lint_xml = run_lint(
+            project_dir, gradlew, args.module, args.variant
+        )
+        lint_errors, lint_warnings = parse_lint_xml(lint_xml)
+
+        if lint_errors:
+            print(f"Lint: {len(lint_errors)} error(s), {len(lint_warnings)} warning(s)")
+        else:
+            print(f"Lint: OK ({len(lint_warnings)} warning(s))")
+
+    combined_output = (build_output + "\n" + lint_output).strip()
+
+    print_table(
+        build_errors, build_warnings,
+        lint_errors, lint_warnings,
+        build_rc, lint_rc,
+        raw_output=combined_output,
+    )
+
+    if build_rc != 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/android/scripts/test.py
+++ b/adapters/android/scripts/test.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Run Android unit tests and output a minimal results table.
+
+Usage examples:
+  # Auto-detect everything
+  python test.py --project-dir .
+
+  # Specific module and variant
+  python test.py --project-dir . --module app --variant debug
+
+  # Without coverage
+  python test.py --project-dir . --no-coverage
+"""
+
+import subprocess
+import sys
+import re
+import argparse
+import os
+import xml.etree.ElementTree as ET
+import glob as glob_mod
+
+
+# ---------------------------------------------------------------------------
+# Gradle wrapper detection
+# ---------------------------------------------------------------------------
+
+def find_gradlew(project_dir):
+    """Find the Gradle wrapper executable."""
+    gradlew = os.path.join(project_dir, "gradlew")
+    if os.path.exists(gradlew):
+        if not os.access(gradlew, os.X_OK):
+            os.chmod(gradlew, 0o755)
+        return gradlew
+
+    parent_gradlew = os.path.join(os.path.dirname(project_dir), "gradlew")
+    if os.path.exists(parent_gradlew):
+        return parent_gradlew
+
+    print("ERROR: Gradle wrapper (gradlew) not found in:")
+    print(f"  {project_dir}")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Test execution
+# ---------------------------------------------------------------------------
+
+def run_tests(project_dir, gradlew, module, variant):
+    """
+    Run Gradle unit test task.
+    Returns (stdout+stderr, returncode).
+    """
+    task = f":{module}:test{variant.capitalize()}UnitTest"
+    print(f"Running: {gradlew} {task}")
+
+    cmd = [gradlew, task, "--no-daemon", "--console=plain"]
+
+    result = subprocess.run(
+        cmd,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Result parsing
+# ---------------------------------------------------------------------------
+
+def parse_junit_xml(project_dir, module, variant):
+    """
+    Parse JUnit XML test results produced by Gradle.
+    Returns (total, passed, failed, skipped, failures).
+    """
+    # Gradle outputs JUnit XML in build/test-results/
+    results_dir = os.path.join(
+        project_dir, module, "build", "test-results",
+        f"test{variant.capitalize()}UnitTest"
+    )
+
+    if not os.path.isdir(results_dir):
+        # Try alternate paths
+        for alt in [
+            os.path.join(project_dir, module, "build", "test-results", "testDebugUnitTest"),
+            os.path.join(project_dir, module, "build", "test-results", "test"),
+            os.path.join(project_dir, "build", "test-results", f"test{variant.capitalize()}UnitTest"),
+        ]:
+            if os.path.isdir(alt):
+                results_dir = alt
+                break
+
+    if not os.path.isdir(results_dir):
+        return None
+
+    total = 0
+    passed = 0
+    failed = 0
+    skipped = 0
+    failures = []
+
+    xml_files = glob_mod.glob(os.path.join(results_dir, "TEST-*.xml"))
+
+    for xml_file in xml_files:
+        try:
+            tree = ET.parse(xml_file)
+            root = tree.getroot()
+
+            suite_name = root.get("name", os.path.basename(xml_file))
+            parts = suite_name.split(".")
+            short_suite = ".".join(parts[-2:]) if len(parts) > 2 else suite_name
+
+            suite_tests = int(root.get("tests", 0))
+            suite_failures = int(root.get("failures", 0))
+            suite_errors = int(root.get("errors", 0))
+            suite_skipped = int(root.get("skipped", 0))
+
+            total += suite_tests
+            failed += suite_failures + suite_errors
+            skipped += suite_skipped
+            passed += suite_tests - suite_failures - suite_errors - suite_skipped
+
+            # Extract individual failure details
+            for testcase in root.findall("testcase"):
+                failure = testcase.find("failure")
+                error = testcase.find("error")
+                fail_elem = failure if failure is not None else error
+
+                if fail_elem is not None:
+                    test_name = testcase.get("name", "unknown")
+                    classname = testcase.get("classname", "")
+                    cls_parts = classname.split(".")
+                    short_class = cls_parts[-1] if cls_parts else classname
+
+                    message = fail_elem.get("message", "")
+                    if not message:
+                        message = (fail_elem.text or "").split("\n")[0]
+                    message = message.strip()[:160]
+
+                    failures.append({
+                        "suite": short_class,
+                        "test": test_name,
+                        "msg": message,
+                    })
+
+        except ET.ParseError as e:
+            print(f"Warning: Could not parse {xml_file} ({e})")
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
+def parse_fallback(output):
+    """
+    Fallback parser when XML results are unavailable.
+    Parses Gradle text output.
+    """
+    total = 0
+    passed = 0
+    failed = 0
+    skipped = 0
+    failures = []
+
+    # Gradle test summary: X tests completed, Y failed, Z skipped
+    summary_pattern = re.compile(
+        r"(\d+)\s+tests?\s+completed,?\s*(?:(\d+)\s+failed)?,?\s*(?:(\d+)\s+skipped)?"
+    )
+    for m in summary_pattern.finditer(output):
+        total = int(m.group(1))
+        failed = int(m.group(2) or 0)
+        skipped = int(m.group(3) or 0)
+        passed = total - failed - skipped
+
+    # Individual test failures from Gradle output
+    fail_pattern = re.compile(
+        r"(\S+)\s*>\s*(\S+)(?:\([^)]*\))?\s+FAILED"
+    )
+    for m in fail_pattern.finditer(output):
+        classname, test_name = m.groups()
+        cls_parts = classname.split(".")
+        short_class = cls_parts[-1] if cls_parts else classname
+        failures.append({
+            "suite": short_class,
+            "test": test_name,
+            "msg": "",
+        })
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "failures": failures,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coverage parsing
+# ---------------------------------------------------------------------------
+
+def parse_jacoco_coverage(project_dir, module, variant):
+    """
+    Parse JaCoCo XML coverage report.
+    Returns dict with 'overall' (float %) and 'per_target' (list of strings), or None.
+    """
+    # Common JaCoCo report locations
+    candidates = [
+        os.path.join(project_dir, module, "build", "reports", "jacoco",
+                     f"test{variant.capitalize()}UnitTest", "jacocoTestReport.xml"),
+        os.path.join(project_dir, module, "build", "reports", "jacoco",
+                     "jacocoTestReport", "jacocoTestReport.xml"),
+        os.path.join(project_dir, module, "build", "reports", "jacoco", "test", "jacocoTestReport.xml"),
+    ]
+
+    xml_path = None
+    for path in candidates:
+        if os.path.exists(path):
+            xml_path = path
+            break
+
+    if not xml_path:
+        return None
+
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+
+        # Overall coverage from root counters
+        total_lines = 0
+        covered_lines = 0
+
+        for counter in root.findall("counter"):
+            if counter.get("type") == "LINE":
+                missed = int(counter.get("missed", 0))
+                covered = int(counter.get("covered", 0))
+                total_lines = missed + covered
+                covered_lines = covered
+                break
+
+        if total_lines == 0:
+            return None
+
+        overall = covered_lines / total_lines * 100
+
+        # Per-package coverage
+        per_target = []
+        for package in root.findall("package"):
+            pkg_name = package.get("name", "").replace("/", ".")
+            parts = pkg_name.split(".")
+            short_pkg = ".".join(parts[-2:]) if len(parts) > 2 else pkg_name
+
+            for counter in package.findall("counter"):
+                if counter.get("type") == "LINE":
+                    pkg_missed = int(counter.get("missed", 0))
+                    pkg_covered = int(counter.get("covered", 0))
+                    pkg_total = pkg_missed + pkg_covered
+                    if pkg_total > 0:
+                        pct = pkg_covered / pkg_total * 100
+                        per_target.append((short_pkg, pct, pkg_total))
+                    break
+
+        # Sort by total lines descending, take top entries
+        per_target.sort(key=lambda x: x[2], reverse=True)
+        per_target_strs = [f"{name}: {pct:.1f}%" for name, pct, _ in per_target[:8]]
+
+        return {"overall": overall, "per_target": per_target_strs}
+
+    except ET.ParseError as e:
+        print(f"Warning: Could not parse JaCoCo report ({e})")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_table(results, coverage=None):
+    """Print results in the pipeline contract format."""
+    if not results or results["total"] == 0:
+        print("\nNo test results parsed. Check diagnostic info above.")
+        return
+
+    total = results["total"]
+    passed = results["passed"]
+    failed = results["failed"]
+    skipped = results["skipped"]
+    failures = results["failures"]
+
+    coverage_str = f" | Coverage: {coverage['overall']:.1f}%" if coverage else ""
+    skip_str = f", Skipped: {skipped}" if skipped else ""
+    print(f"\nSummary: Total: {total}, Passed: {passed}, Failed: {failed}{skip_str}{coverage_str}\n")
+
+    if coverage and coverage.get("per_target"):
+        print("Coverage:  " + "  |  ".join(coverage["per_target"]))
+        print()
+
+    if not failures:
+        if failed == 0:
+            print("All tests passed.")
+        return
+
+    # Print failure table
+    sw = max(len(f["suite"]) for f in failures) if failures else 0
+    tw = max(len(f["test"]) for f in failures) if failures else 0
+    sw = max(sw, 5)
+    tw = max(tw, 4)
+
+    header = f"{'Suite':<{sw}}  {'Test':<{tw}}"
+    print(header)
+    print("-" * min(sw + tw + 4, 120))
+
+    for f in failures:
+        print(f"{f['suite']:<{sw}}  {f['test']:<{tw}}")
+        if f.get("msg"):
+            print(f"   > {f['msg']}")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Android unit tests and show minimal pass/fail table."
+    )
+    parser.add_argument("--project-dir", default=".", help="Path to project root")
+    parser.add_argument("--module", default="app", help="Gradle module name (default: app)")
+    parser.add_argument("--variant", default="debug", help="Build variant (default: debug)")
+    parser.add_argument("--no-coverage", action="store_true", help="Disable coverage report parsing")
+    args = parser.parse_args()
+
+    project_dir = os.path.abspath(args.project_dir)
+    collect_coverage = not args.no_coverage
+
+    print(f"Project dir: {project_dir}")
+
+    gradlew = find_gradlew(project_dir)
+    print(f"Gradle wrapper: {gradlew}")
+    print(f"Module: {args.module}")
+    print(f"Variant: {args.variant}")
+
+    raw_output, returncode = run_tests(project_dir, gradlew, args.module, args.variant)
+
+    # Parse results from JUnit XML
+    results = parse_junit_xml(project_dir, args.module, args.variant)
+
+    # Fallback to text parsing
+    if not results or results["total"] == 0:
+        results = parse_fallback(raw_output)
+
+    # Parse coverage
+    coverage = None
+    if collect_coverage:
+        coverage = parse_jacoco_coverage(project_dir, args.module, args.variant)
+
+    print_table(results, coverage=coverage)
+
+    # Diagnostic output when no results were parsed
+    if not results or results["total"] == 0:
+        print("\n--- Diagnostic Info ---")
+        if returncode != 0:
+            print(f"Gradle returned exit code {returncode}")
+        else:
+            print("Tests ran but no results were parsed.")
+
+        lines = raw_output.strip().splitlines()
+        filtered = [
+            l for l in lines
+            if l.strip()
+            and not any(skip in l for skip in [
+                "Downloading", "Download ", "> Task",
+                "BUILD SUCCESSFUL", "actionable task",
+            ])
+        ]
+        display = filtered if filtered else lines
+        print("\nLast 50 lines of output:")
+        print("\n".join(display[-50:]))
+
+        if returncode != 0:
+            sys.exit(1)
+        return
+
+    if results["failed"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/adapters/android/test-overlay.md
+++ b/adapters/android/test-overlay.md
@@ -1,0 +1,254 @@
+# Android / Kotlin — Test Overlay
+
+<!-- Injected into test-architect-agent at ADAPTER:TECH_STACK_CONTEXT marker -->
+
+## Test Framework: JUnit 4 + Android Testing Libraries
+
+Android tests live in two source sets. Test the architecture layers bottom-up: DataSources → Repositories → UseCases → ViewModels → UI.
+
+- **Local tests** (`src/test/`): Run on JVM without device. Fast. Use for unit tests, ViewModel tests, Robolectric.
+- **Instrumented tests** (`src/androidTest/`): Run on device/emulator. Use for UI tests (Espresso, Compose), integration tests.
+
+## Test Structure
+
+```
+app/src/
+  test/java/com/example/app/
+    feature/
+      data/
+        FeatureRepositoryTest.kt
+        FeatureDataSourceTest.kt
+      domain/
+        FeatureUseCaseTest.kt
+      ui/
+        FeatureViewModelTest.kt
+  androidTest/java/com/example/app/
+    feature/
+      ui/
+        FeatureScreenTest.kt
+    e2e/
+      CriticalFlowTest.kt
+```
+
+Naming: `fun \`description of behavior under test\`()` (backtick style) or `fun featureName_scenario_expectedResult()`.
+
+## Unit Tests (Local — JVM)
+
+Test ViewModels, Repositories, UseCases, and utility functions.
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeatureViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var viewModel: FeatureViewModel
+    private val fakeRepository = FakeFeatureRepository()
+
+    @Before
+    fun setup() {
+        viewModel = FeatureViewModel(
+            repository = fakeRepository,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
+    }
+
+    @Test
+    fun `loadData updates state to Success`() = runTest {
+        fakeRepository.emit(listOf(testItem))
+
+        viewModel.loadData()
+
+        assertThat(viewModel.uiState.value).isInstanceOf(UiState.Success::class.java)
+        val state = viewModel.uiState.value as UiState.Success
+        assertThat(state.items).hasSize(1)
+    }
+
+    @Test
+    fun `loadData updates state to Error on failure`() = runTest {
+        fakeRepository.shouldFail = true
+
+        viewModel.loadData()
+
+        assertThat(viewModel.uiState.value).isInstanceOf(UiState.Error::class.java)
+    }
+}
+```
+
+### MainDispatcherRule
+
+Required for testing ViewModels that use `viewModelScope`:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+### Mocking Strategy
+
+- **Fakes preferred over mocks** — manual implementations of interfaces that focus on behavior, not call verification.
+- **MockK** for Kotlin-first mocking when fakes would be verbose: `mockk<T>()`, `every { }`, `coEvery { }`, `verify { }`, `coVerify { }`.
+- **Mockito-Kotlin** as alternative: `mock<T>()`, `whenever().thenReturn()`, `verify()`.
+- Mock at boundaries: fake DataSources when testing Repositories, fake Repositories when testing ViewModels.
+- Never mock the class under test.
+
+### Flow Testing with Turbine
+
+```kotlin
+@Test
+fun `state emits Loading then Success`() = runTest {
+    viewModel.uiState.test {
+        assertThat(awaitItem()).isEqualTo(UiState.Loading)
+
+        viewModel.loadData()
+
+        assertThat(awaitItem()).isInstanceOf(UiState.Success::class.java)
+        cancelAndIgnoreRemainingEvents()
+    }
+}
+```
+
+Turbine handles timing, cancellation, and high-frequency emissions. Use `awaitItem()`, `awaitError()`, `awaitComplete()`, `cancelAndIgnoreRemainingEvents()`.
+
+### Coroutine Testing
+
+- `runTest { }` for all coroutine tests — auto-advances virtual time.
+- `StandardTestDispatcher()` for tests needing explicit time control (`advanceUntilIdle()`, `advanceTimeBy()`).
+- `UnconfinedTestDispatcher()` for tests where execution order doesn't matter.
+- Inject test dispatchers via constructor — never rely on `Dispatchers.Main` being the real main dispatcher.
+- All test dispatchers in a test should share the same `TestCoroutineScheduler`.
+
+### Room Testing
+
+```kotlin
+@RunWith(AndroidJUnit4::class)
+class FeatureDaoTest {
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    @Test
+    fun `insert and retrieve feature`() = runTest {
+        val entity = FeatureEntity(id = "1", name = "Test")
+        db.featureDao().insert(entity)
+
+        val result = db.featureDao().getById("1")
+        assertThat(result).isEqualTo(entity)
+    }
+}
+```
+
+## Compose UI Tests
+
+Use `ComposeTestRule` for testing individual composables.
+
+```kotlin
+class FeatureScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `displays loading indicator when loading`() {
+        composeTestRule.setContent {
+            FeatureScreen(uiState = UiState.Loading)
+        }
+
+        composeTestRule
+            .onNodeWithTag("loading_indicator")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `clicking item triggers callback`() {
+        var clickedId: String? = null
+
+        composeTestRule.setContent {
+            FeatureScreen(
+                uiState = UiState.Success(items = listOf(testItem)),
+                onItemClick = { clickedId = it },
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(testItem.name)
+            .performClick()
+
+        assertThat(clickedId).isEqualTo(testItem.id)
+    }
+}
+```
+
+### Key Compose Test APIs
+
+- `onNodeWithText("text")` — Find by displayed text.
+- `onNodeWithTag("tag")` — Find by test tag (`Modifier.testTag("tag")`).
+- `onNodeWithContentDescription("desc")` — Find by accessibility description.
+- `performClick()`, `performTextInput("text")`, `performScrollTo()` — User actions.
+- `assertIsDisplayed()`, `assertTextEquals("text")`, `assertDoesNotExist()` — Assertions.
+- `waitForIdle()` — Wait for pending recompositions.
+- `createAndroidComposeRule<Activity>()` — When Activity context is needed.
+
+## Espresso (View-based UI Tests)
+
+For legacy View-based UI or hybrid Compose+View screens.
+
+```kotlin
+@Test
+fun `clicking button shows message`() {
+    onView(withId(R.id.button)).perform(click())
+    onView(withText("Hello")).check(matches(isDisplayed()))
+}
+```
+
+## Assertions
+
+- **Truth** (Google): `assertThat(actual).isEqualTo(expected)`, `.isInstanceOf()`, `.hasSize()`, `.contains()`, `.isEmpty()`.
+- Preferred over JUnit `assertEquals` for readability and better failure messages.
+
+## Coverage
+
+Gradle task: `./gradlew testDebugUnitTest jacocoTestReport` (requires JaCoCo plugin configuration).
+
+### Coverage Exclusions
+
+Exclude from coverage calculations:
+- Hilt-generated: `*_Hilt*`, `*_Factory*`, `*_MembersInjector*`, `Hilt_*`
+- Dagger-generated: `*_Provide*Factory*`, `Dagger*Component*`
+- Room-generated: `*_Impl*`
+- Data binding: `*Binding*`, `*BindingImpl*`
+- Build config: `BuildConfig`, `*_BuildConfig*`
+- R class: `R.class`, `R$*.class`
+- Android framework: `*Activity*`, `*Fragment*` (test ViewModels instead)
+
+## Anti-Patterns
+
+- **Testing implementation details:** Don't verify internal state or call counts — test observable behavior (emitted state, returned values, rendered UI).
+- **Shared mutable state between tests:** Each test sets up its own fakes. Use `@Before` for shared setup.
+- **Hardcoded delays:** Never use `Thread.sleep()` or `delay()` in tests. Use `runTest` with `advanceUntilIdle()`, Turbine's `awaitItem()`, Compose's `waitForIdle()`.
+- **Testing framework code:** Don't test that Hilt injects correctly or Room compiles — test your business logic.
+- **Testing generated code:** Don't test Hilt components, Room DAOs' generated SQL, or data class `copy()`/`equals()`.
+- **Missing MainDispatcherRule:** ViewModel tests will fail or behave unexpectedly without replacing `Dispatchers.Main`.
+- **Collecting StateFlow without Turbine:** Manual collection is racy and flaky. Use Turbine or assert on `.value` directly.
+- **Over-mocking:** Prefer fakes for repositories and data sources. Mocks are for verifying interactions with external systems.


### PR DESCRIPTION
## Summary

- Adds complete Android/Kotlin adapter (10 files) with Google's official app architecture guide (MVVM + Repository), Jetpack Compose, Hilt DI, and coroutines with structured concurrency
- Encodes Kotlin coding conventions, Material Design 3, Android security (exported components, parameterized SQL, encrypted storage), lifecycle safety, and performance patterns
- Build script runs `./gradlew assembleDebug` + `./gradlew lintDebug` with lint XML parsing; test script parses JUnit XML results + JaCoCo coverage reports
- Designed for multi-stack use: `--stack=flutter --stack=swift-ios --stack=android` — Android adapter owns `android/**/*.kt`, `app/src/**/*.kt`, Gradle files

## Key design decisions

- **Architecture**: MVVM with UI Layer (Compose + ViewModel exposing StateFlow) + optional Domain Layer (UseCases) + Data Layer (Repository + DataSource) — per Google's official guide
- **Complexity mapping**: Composables and ViewModels are Haiku when contracts exist; architecture decisions (DI scoping, offline-first, navigation) escalate to Sonnet; build system design (convention plugins, R8 rules) also Sonnet
- **Essential overlay**: 12 rules, ~960 chars — within the 1000 char limit for Haiku tasks
- **Coroutines first-class**: Injected dispatchers, structured concurrency, CancellationException handling, Flow/Turbine testing patterns all encoded
- **No pipeline changes needed**: Discovered automatically from `manifest.json` — zero edits to `init.sh`, skills, or tests

## Test plan

- [x] `python3 tests/validate_structure.py` — 300 checks passed (adapter auto-discovered)
- [x] `python3 tests/test_contracts.py` — 51 tests passed
- [ ] Bootstrap smoke test with a real Android project (`bash init.sh /path/to/android-app --stack=android`)
- [ ] Verify Gradle error parsing with intentional compilation errors (Kotlin `e:` and Java patterns)
- [ ] Verify lint XML parsing with projects containing lint warnings/errors
- [ ] Verify JUnit XML result parsing with passing and failing tests
- [ ] Verify JaCoCo XML coverage parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)