### PR TITLE
fix(init): unstage previously-tracked paths now covered by .gitignore

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -592,6 +592,20 @@ GIEOF
     info "Generated .claude/.gitignore"
 fi
 
+# --- Step 7.7: Unstage previously-tracked paths now covered by .gitignore ---
+# When migrating from an older layout, symlinks like scripts/ or agents/ may
+# already be in the git index.  The new .gitignore hides them from the working
+# tree, but git still tracks the index entry → shows as "D (unstaged delete)".
+# Fix: remove them from the index so the .gitignore takes full effect.
+if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    for ignored_path in agents overlays scripts tmp; do
+        if git -C "$PROJECT_DIR" ls-files --error-unmatch ".claude/$ignored_path" >/dev/null 2>&1; then
+            git -C "$PROJECT_DIR" rm -r --cached --quiet ".claude/$ignored_path" 2>/dev/null || true
+            info "Unstaged previously-tracked $ignored_path (now in .gitignore)"
+        fi
+    done
+fi
+
 # --- Step 8: Summary ---
 echo ""
 echo "========================================"


### PR DESCRIPTION
## Summary
- After migrating from external-clone to submodule mode, `.claude/scripts` (and potentially `agents`, `overlays`, `tmp`) would show as "D (unstaged delete)" in the host repo because `init.sh` removed the old tracked symlink with `rm` but never cleaned the git index
- Adds Step 7.7 after `.gitignore` generation that detects still-indexed paths and runs `git rm -r --cached` to eliminate the spurious dirty state

## Test plan
- [ ] Clone a host repo that has `.claude/scripts` committed as a tracked symlink
- [ ] Run `git submodule add ... .claude/pipeline && bash .claude/pipeline/init.sh .`
- [ ] Verify `git status` no longer shows `.claude/scripts` as "D (unstaged delete)"
- [ ] Run `python3 tests/validate_structure.py` — all 320 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)