### PR TITLE
fix(python-adapter): order-independent pytest summary parsing

### DIFF
--- a/adapters/python/scripts/test.py
+++ b/adapters/python/scripts/test.py
@@ -292,27 +292,30 @@ def parse_results(output):
     errors = 0
     failures = {}
 
-    # pytest summary line patterns:
-    # "5 passed in 0.12s"
-    # "3 passed, 2 failed in 0.45s"
-    # "1 passed, 1 failed, 1 error in 0.33s"
-    # "2 failed, 1 error in 0.50s"
-    summary_match = re.search(
-        r"(?:=+\s*)?"
-        r"(?:(\d+) passed)?"
-        r"(?:,?\s*(\d+) failed)?"
-        r"(?:,?\s*(\d+) error)?"
-        r"(?:,?\s*(\d+) warning)?"
-        r"(?:,?\s*(\d+) deselected)?"
-        r"(?:,?\s*(\d+) skipped)?"
-        r"\s+in\s+[\d.]+s",
-        output
-    )
+    # Locate the last pytest summary line — handles any token order, e.g.
+    # "17 failed, 520 passed in 2.00s" as well as "520 passed, 17 failed in 2.00s"
+    summary_line = None
+    for line in reversed(output.splitlines()):
+        stripped = line.strip()
+        if (re.search(r'\d+\s+(?:passed|failed|error)', stripped) and
+                re.search(r'\bin\s+[\d.]+\s*s\b', stripped)):
+            summary_line = stripped
+            break
 
-    if summary_match:
-        passed = int(summary_match.group(1) or 0)
-        failed = int(summary_match.group(2) or 0)
-        errors = int(summary_match.group(3) or 0)
+    if summary_line:
+        _plural = {'errors': 'error', 'warnings': 'warning'}
+        for m in re.finditer(
+            r'(\d+)\s+(passed|failed|errors?|skipped|deselected|warnings?)',
+            summary_line,
+        ):
+            n, kind = m.groups()
+            key = _plural.get(kind, kind)
+            if key == 'passed':
+                passed = int(n)
+            elif key == 'failed':
+                failed = int(n)
+            elif key == 'error':
+                errors = int(n)
         total = passed + failed + errors
 
     # Also try the short format: "N passed" or "N failed"

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -442,5 +442,51 @@ class TestAzureAuthOutput(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestPythonAdapterParseResults(unittest.TestCase):
+    """Regression tests for parse_results() in adapters/python/scripts/test.py.
+
+    Covers all pytest summary token orderings — critically including the
+    default 'N failed, M passed' order that the old fixed-order regex missed.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+        adapter_path = Path(__file__).resolve().parent.parent / "adapters/python/scripts/test.py"
+        spec = importlib.util.spec_from_file_location("_python_test_adapter", adapter_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls._parse = staticmethod(mod.parse_results)
+
+    def _run(self, summary_line: str):
+        total, passed, failed, errors, _ = self._parse(summary_line)
+        return total, passed, failed, errors
+
+    def test_passed_only(self) -> None:
+        total, passed, failed, errors = self._run("2 passed in 0.12s")
+        self.assertEqual((total, passed, failed, errors), (2, 2, 0, 0))
+
+    def test_failed_before_passed(self) -> None:
+        """Pytest default order when failures exist: failed token precedes passed."""
+        total, passed, failed, errors = self._run("17 failed, 520 passed in 2.00s")
+        self.assertEqual((total, passed, failed, errors), (537, 520, 17, 0))
+
+    def test_passed_before_failed(self) -> None:
+        total, passed, failed, errors = self._run("520 passed, 17 failed in 2.00s")
+        self.assertEqual((total, passed, failed, errors), (537, 520, 17, 0))
+
+    def test_passed_failed_error(self) -> None:
+        total, passed, failed, errors = self._run("1 passed, 1 failed, 1 error in 0.33s")
+        self.assertEqual((total, passed, failed, errors), (3, 1, 1, 1))
+
+    def test_passed_with_skipped(self) -> None:
+        total, passed, failed, errors = self._run("5 passed, 2 skipped in 0.1s")
+        self.assertEqual((total, passed, failed, errors), (5, 5, 0, 0))
+
+    def test_failed_and_error_only(self) -> None:
+        total, passed, failed, errors = self._run("3 failed, 1 error in 0.5s")
+        self.assertEqual((total, passed, failed, errors), (4, 0, 3, 1))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Replaces the fixed-order regex in `parse_results()` with a token-based parser that handles any permutation of pytest summary tokens
- The old regex silently dropped the failure count when `failed` preceded `passed` (pytest's default when failures exist), causing false all-green reports
- Adds 6 regression tests to `tests/test_contracts.py` covering all documented summary formats

## Test plan
- [ ] `python3 tests/test_contracts.py -v` passes all tests including 6 new `TestPythonAdapterParseResults` cases
- [ ] Verify `test_failed_before_passed` specifically catches the bug: `"17 failed, 520 passed in 2.00s"` → `failed=17, passed=520`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)