### PR TITLE
fix(pipeline): token efficiency guardrails for ledger, contracts, and refactor targets

### DIFF
--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -335,6 +335,11 @@ to only what the implementer needs to produce code.
 - [ ] Tasks that produce interfaces consumed by other tasks are in an earlier wave than
   their consumers.
 - [ ] Integration test tasks are in the final wave, after all component tasks complete.
+- [ ] **Implicit contract sequencing:** When two parallel tasks share an implicit contract
+  (Task A defines a function signature that Task B calls), they must NOT be in the same wave —
+  put Task A in an earlier wave and inline its output signature into Task B's brief. Parallel
+  tasks that each see only half of a shared contract produce runtime crashes that code review
+  cannot catch. If the contract cannot be pre-determined, add a Wave 0 task to define it first.
 
 ## Common Mistakes to Avoid
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -380,6 +380,14 @@ Prompt: |
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry after the initial agent launch (step `1a`) and after each SendMessage round in the clarification loop (step `1a:clarify-N`). For each entry, measure the composed prompt as `input_chars` and the agent's response as `output_chars`. Agent: `architect-agent`, model: `sonnet`.
 
+**TOKEN_LEDGER gate:** After Step 1a completes and `.claude/tmp/1a-spec.md` is written,
+verify that `TOKEN_LEDGER` contains at least one entry. If the ledger is empty, warn the user:
+
+> ⚠ TOKEN_LEDGER is empty after Step 1a — token tracking was skipped. Step 5 analysis
+> will reconstruct from `<usage>` blocks with reduced accuracy.
+
+Do NOT abort the pipeline. Continue with implementation but note the tracking gap.
+
 **Recovery:** If the pipeline is interrupted after 1a and `.claude/tmp/1a-spec.md` exists, skip 1a entirely and go directly to 1b. If `.claude/tmp/1b-plan.md` also exists, skip both 1a and 1b — present the saved plan to the user for confirmation and proceed to Step 1.5.
 
 ---

--- a/skills/token-analysis/SKILL.md
+++ b/skills/token-analysis/SKILL.md
@@ -42,6 +42,12 @@ against the 70/20/10 target:
 - **Sonnet** should be ~20%
 - **Opus** should be ~10%
 
+**Plan-type adjustment:** The 70/20/10 target assumes feature work where implementation
+dominates cost. For **refactor** plan types, planning and review inherently exceed
+implementation cost — use **50/40/10** as the comparison baseline instead. Identify the
+plan type from the 1b-plan.md `## Overview` section or the PR title prefix (`refactor:`).
+Flag deviations only against the appropriate baseline.
+
 Compute each model's share as: `model_cost / total_cost × 100`. Report BOTH cost-weighted
 percentages AND call-count percentages — but flag deviations based on the cost metric only.
 Call-count percentages can create a false sense of efficiency (e.g., "69% Haiku calls" while
@@ -75,7 +81,9 @@ Evaluate pipeline execution characteristics:
 - **Step token weight**: which steps consume the most tokens relative to their role (e.g.,
   clarification consuming more than implementation suggests unclear scope)
 - **Planning overhead**: ratio of planning tokens (1a + 1b) to implementation tokens (2 + 2.1 + 2.2).
-  Flag if planning > 40% of implementation — may indicate over-planning
+  Flag if planning > 40% of implementation for feature plan types. For refactor plan types,
+  planning > 100% of implementation is expected (dependency verification before deletes IS
+  the value of Step 1a) — use 100% as the flag threshold.
 - **Review cost ratio**: total review + fix tokens vs. implementation tokens. A ratio > 0.5
   suggests implementations are frequently failing review — possible quality issue in context briefs
 


### PR DESCRIPTION
## Summary
- **TOKEN_LEDGER gate**: After Step 1a completes, the orchestrate skill now warns if the ledger is empty rather than silently proceeding to a low-quality Step 5 reconstruction
- **Implicit contract sequencing rule**: Adds a fourth wave-ordering validation rule to the architect-planner skill: parallel tasks sharing an implicit function-signature contract must be sequenced across waves, not run together
- **Refactor distribution targets**: The token-analysis skill now uses 50/40/10 (not 70/20/10) as the model distribution baseline for refactor plan types, and raises the planning overhead flag threshold to 100% for refactors

## Test plan
- [ ] Read `skills/orchestrate/SKILL.md` and verify the TOKEN_LEDGER gate language is clear and correctly placed (after Step 1a token tracking paragraph, before Recovery)
- [ ] Read `skills/architect-planner/SKILL.md` and verify the implicit contract sequencing bullet is the fourth item in the wave-ordering validation checklist
- [ ] Read `skills/token-analysis/SKILL.md` and verify the plan-type adjustment note appears after the Haiku/Sonnet/Opus bullet list in Section 2, and the planning overhead bullet in Section 5 is updated

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)