### PR TITLE
feat(pipeline): GitHub-based backlog integration for deferred orchestrate work

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: Report something that isn't working as expected
+labels: ["type: bug", "status: needs-triage"]
+body:
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps to reproduce the bug.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, logs, screenshots.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, tool versions, any relevant config.
+      placeholder: |
+        - OS: macOS 14.5
+        - Tool / runtime: ...
+        - Relevant versions: ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore / Tech Debt
+description: Refactor, cleanup, or deferred work (including items surfaced by /orchestrate)
+labels: ["type: chore"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line summary of the work.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Origin
+      description: What surfaced this? What's the underlying problem or opportunity?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What does "done" look like? (optional — helpful for AI-deferred items)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new capability
+labels: ["type: feature", "status: needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Who experiences it?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see built.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider, and why were they rejected?
+    validations:
+      required: false

--- a/.github/pipeline-backlog.yml
+++ b/.github/pipeline-backlog.yml
@@ -1,0 +1,24 @@
+# .github/pipeline-backlog.yml
+#
+# Marker file: its presence enables /orchestrate backlog filing for this repo.
+# Delete this file to disable backlog integration — labels and Issue Forms will remain.
+#
+# Managed by the claude-code-pipeline /bootstrap-backlog skill.
+# Re-running the skill is idempotent and safe.
+
+version: 1
+enabled: true
+
+# Maximum number of items folded into the current /orchestrate run across all
+# phases. Past the cap, all surfaced items are deferred to the backlog even if
+# they would otherwise qualify for inline fixing.
+#   0 → never fold, always defer
+#   N → allow up to N folds per run (default: 3)
+fold_cap: 3
+
+# Optional GitHub Projects v2 number. If set, filed issues are added to this
+# project via `gh project item-add`. Leave null if you don't use Projects.
+project_number: null
+
+# Reserved for v2:
+# label_overrides:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ Reads structured defect reports from GitHub PR comments (see `templates/defect-r
 ```
 Pulls latest pipeline submodule, shows changelog, validates structural integrity, re-runs `init.sh` if needed, and commits the submodule bump.
 
+**Opt in to backlog integration** (one-time, from within a bootstrapped project):
+```
+/bootstrap-backlog
+```
+Provisions 12 namespaced labels, 4 Issue Form YAMLs, and a sentinel config (`.github/pipeline-backlog.yml`). After opt-in, `/orchestrate` classifies out-of-scope items as fold (Haiku-tier, spawned into the current run up to `fold_cap`) or defer (Sonnet/Opus-tier, filed as GitHub issues with a traceability block). Idempotent; safe to re-run after `/update-pipeline`. See the README "Opting in to Backlog Integration" section for details.
+
 **Azure/Bicep skills** (from within a bootstrapped project):
 ```
 /azure-login            # Verify Azure auth, subscription context, permissions
@@ -75,7 +81,7 @@ User request → **1a: Feature Clarification** (Sonnet, feature-only Q&A) → **
 
 1. **Agents** (`agents/`) — Four generic, stack-agnostic agent definitions: `architect-agent`, `implementer-agent`, `code-reviewer-agent`, `test-architect-agent`. Each contains an `<!-- ADAPTER:TECH_STACK_CONTEXT -->` marker where adapter overlays get injected at launch. `implementer-contract.md` is the canonical Haiku readiness checklist referenced by both the planner and implementer.
 
-2. **Skills** (`skills/`) — Seventeen pipeline steps. `orchestrate` is the master coordinator that invokes the core nine: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`. The standalone `fix-defects` skill reads structured defect reports from PR comments and runs the fix pipeline independently. `update-pipeline` manages submodule updates with validation and rollback. Seven Azure/Bicep skills provide IaC-specific capabilities: `azure-login` (auth pre-flight), `validate-bicep`, `deploy-bicep`, `azure-cost-estimate`, `security-scan`, `infra-test-runner`, `azure-drift-check`.
+2. **Skills** (`skills/`) — Eighteen pipeline steps. `orchestrate` is the master coordinator that invokes the core nine: `architect-analyzer`, `architect-planner`, `build-runner`, `test-runner`, `open-pr`, `summarize-implementation`, `token-analysis`. The standalone `fix-defects` skill reads structured defect reports from PR comments and runs the fix pipeline independently. `update-pipeline` manages submodule updates with validation and rollback. `bootstrap-backlog` provisions the GitHub labels, Issue Forms, and sentinel config that enable backlog integration for deferred work. Seven Azure/Bicep skills provide IaC-specific capabilities: `azure-login` (auth pre-flight), `validate-bicep`, `deploy-bicep`, `azure-cost-estimate`, `security-scan`, `infra-test-runner`, `azure-drift-check`.
 
 3. **Adapters** (`adapters/`) — Pluggable tech-stack modules (swift-ios, react, python, flutter, android, bicep). Multiple adapters can be active simultaneously for multi-stack repos (e.g., `flutter` + `swift-ios` + `android` for Flutter apps with native code). Each provides: `manifest.json` (detection rules + metadata), `adapter.md` (human-readable metadata), four `*-overlay.md` files (injected into agents), `hooks.json` (blocks raw build/test commands), and `scripts/build.py` + `scripts/test.py` (runner scripts with strict output contracts). Each adapter also provides `implementer-overlay-essential.md` — a compact (~500-1000 chars) rules-only variant used for Haiku tasks to improve signal-to-noise ratio.
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,106 @@ You don't have to use the full pipeline. Individual skills work standalone:
 /azure-drift-check               # Detect config drift vs deployed state
 ```
 
+### Opting in to Backlog Integration
+
+Backlog integration captures out-of-scope work surfaced during `/orchestrate`
+runs — reviewer nice-to-haves, architect scope cuts, token-analysis findings —
+as durable GitHub issues with a namespaced label taxonomy. Small, Haiku-tier
+items fold into the current run; anything larger defers to the backlog.
+
+**Prerequisites**
+
+- `gh` CLI installed and authenticated (`gh auth status` exit 0).
+- A GitHub remote configured (`git remote get-url origin` succeeds).
+- Write access to labels on the remote's owner.
+
+**One-time setup**
+
+Run the bootstrap skill from inside your project:
+
+```
+/bootstrap-backlog
+```
+
+This does three things:
+
+1. **Creates 12 namespaced labels** on your GitHub repo via `gh label create --force`:
+   `type: {bug,feature,chore,docs}`, `priority: {p0,p1,p2}`,
+   `status: {needs-triage,blocked,ready}`, `source: ai-deferred`, plus the
+   GitHub specials `good first issue` and `help wanted`.
+2. **Copies four Issue Form YAMLs** into `.github/ISSUE_TEMPLATE/`:
+   `bug_report.yml`, `feature_request.yml`, `chore.yml`, `config.yml` (the
+   last disables blank issues to force template use).
+3. **Writes the sentinel config** `.github/pipeline-backlog.yml` with defaults
+   (`enabled: true`, `fold_cap: 3`, `project_number: null`). This file is the
+   opt-in signal — its presence enables filing; deleting it disables.
+
+**Expected output:**
+
+```
+bootstrap-backlog: complete
+  Labels provisioned:   12 (via gh label create --force)
+  Issue Forms:          .github/ISSUE_TEMPLATE/{bug_report,feature_request,chore,config}.yml
+  Sentinel config:      .github/pipeline-backlog.yml (created)
+
+Next steps:
+  1. Review .github/ISSUE_TEMPLATE/ and .github/pipeline-backlog.yml
+  2. Commit and push — backlog integration activates on the next /orchestrate run
+```
+
+**Verify**
+
+```bash
+gh label list                                 # 12+ labels listed
+ls .github/ISSUE_TEMPLATE/                    # 4 YAML files
+cat .github/pipeline-backlog.yml              # version: 1, enabled: true, fold_cap: 3
+```
+
+Open a test issue in the GitHub UI and confirm templates render and labels
+auto-apply.
+
+**How filing behaves during /orchestrate runs**
+
+- **Haiku-tier surfaced items** fold into the current run as new implementer
+  tasks, up to the `fold_cap` limit (default 3 per run). They show up in the
+  "Folded in this run" checklist in the PR description.
+- **Sonnet/Opus-tier items** file as GitHub issues using the `chore.yml`
+  template, labeled `type: chore`, `priority: p2`, `source: ai-deferred`. Each
+  issue body includes a traceability block: originating PR number, phase
+  (planner, reviewer, implementer, token-analysis), run ID, and one-line
+  reasoning.
+- **If the sentinel is absent** when `/orchestrate` runs, filing is skipped
+  silently with one hint line (`backlog integration not enabled for this repo
+  — run /bootstrap-backlog to enable`). The pipeline otherwise runs normally.
+
+**Customization**
+
+Edit `.github/pipeline-backlog.yml` to tune behavior:
+
+```yaml
+version: 1
+enabled: true        # set false to disable without deleting
+fold_cap: 3          # 0 = never fold, always defer; 5 = allow more folds
+project_number: 7    # optional GitHub Projects v2 number; filed issues auto-added
+```
+
+**Disable**
+
+Delete `.github/pipeline-backlog.yml`. Labels and Issue Form templates remain
+(they're harmless additive provisioning). Future `/orchestrate` runs will log
+the skip hint but continue normally.
+
+**Re-running is safe**
+
+`/bootstrap-backlog` is idempotent. `gh label create --force` updates existing
+labels (note: this overwrites color/description on same-name labels — if your
+repo has pre-existing `type: bug` with a different color, it will be updated).
+Issue Form YAMLs are refreshed from the pipeline source of truth. The sentinel
+config is **NOT overwritten** if present, so your customizations to `fold_cap`
+or `project_number` survive a re-run.
+
+Re-run after `/update-pipeline` to pick up any label or template changes.
+
 ### Updating the Pipeline
 
 **Recommended:** Use the `/update-pipeline` skill from within Claude Code:

--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -248,6 +248,37 @@ FIX: <one-line description of required fix>
 Only include CRITICAL and HIGH issues in the FAIL output.
 Medium/low issues go after a `--- OPTIONAL IMPROVEMENTS ---` divider.
 
+Within OPTIONAL IMPROVEMENTS, prefix EACH entry with exactly one of two tags:
+
+```
+--- OPTIONAL IMPROVEMENTS ---
+[should-fix] <one-line issue>: <why it matters>
+[nice-to-have] <one-line issue>: <why it matters>
+```
+
+**`[should-fix]`** — a real improvement with concrete value, but not a blocker.
+Typically medium-severity: a tight duplication, a missing abstraction that
+would pay off in the next feature, a naming inconsistency that reviewers keep
+tripping on. These are the things you'd raise again in the next review.
+
+**`[nice-to-have]`** — genuinely optional: style polish, speculative refactors,
+defensive programming for unlikely cases, ideas for the future. Safe to ignore.
+
+The tags control fold-vs-defer behavior downstream: `[should-fix]` items are
+candidates to fold into the current run (subject to the run's fold cap);
+`[nice-to-have]` items default to deferral to the backlog. The classification
+is yours to make — when in doubt, choose `[nice-to-have]`.
+
+### Backlog Filing (Pipeline Mode)
+
+If the orchestrator's prompt includes backlog integration metadata (`RUN_ID`,
+`PR_NUMBER`, `REPO`, `SENTINEL_PRESENT=true`), the orchestrator will file
+deferred optional improvements to the consumer repo's backlog after the review.
+Your only job is to emit the tagged entries above with clear one-line
+descriptions — do NOT shell out to `gh` yourself. If `SENTINEL_PRESENT=false`
+or the metadata is absent, emit the same output; the orchestrator will skip
+filing silently.
+
 **Fail the review for:** memory/resource leaks, race conditions, thread safety
 violations, missing error handling on failable paths, security issues, force
 operations without justification, violations of ORCHESTRATOR.md conventions,

--- a/agents/implementer-agent.md
+++ b/agents/implementer-agent.md
@@ -44,6 +44,18 @@ You receive a **context brief** that contains everything you need:
 - Do not add logging, analytics, or other cross-cutting concerns unless specified
 - Do not refactor adjacent code you happen to notice
 
+**Limited inline exception** (contract point 7): you MAY fix a trivial issue
+inside a file you are already editing if all four conditions hold:
+1. The fix is in a file already in your brief's file list
+2. The change is under 5 lines
+3. It is purely mechanical — typo, unused import, obvious dead-code removal
+4. It does NOT change behavior and does NOT add new code paths
+
+Anything else — cross-file fixes, new abstractions, logic changes, adding error
+handling, adding logging — is out-of-scope. Do NOT absorb it into your task.
+Note it in your SUCCESS commit message's body as a one-line follow-up
+suggestion so the reviewer can surface it for backlog triage.
+
 ### Rule 4: Code Quality Within Scope
 
 <!-- ADAPTER:CODE_QUALITY_RULES -->

--- a/agents/implementer-contract.md
+++ b/agents/implementer-contract.md
@@ -10,3 +10,4 @@ source of truth — both the architect-planner (who writes briefs) and the imple
 4. **BOUNDED**: Under 150 lines of expected output. If longer, split further.
 5. **VERIFIABLE**: Build and test commands are provided. Expected coverage target is stated.
 6. **SCOPED**: Only listed files are produced. No helpers, extensions, utilities, logging, analytics, or refactoring beyond what the brief specifies.
+7. **LIMITED-INLINE-EXCEPTION**: You may inline-fix a trivial issue ONLY if ALL of the following hold: (a) the fix is in a file you are already editing as part of the brief; (b) the change is under 5 lines; (c) it is purely mechanical — typo, unused import, obvious dead-code removal; (d) it does NOT change behavior and does NOT add new code paths. Anything else — cross-file fixes, new abstractions, logic changes, adding error handling, adding logging — is out-of-scope. Escalate those to the architect; do NOT absorb them into your current task.

--- a/scripts/backlog_file.py
+++ b/scripts/backlog_file.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Backlog filing utility for /orchestrate phases.
+
+Detects opt-in via .github/pipeline-backlog.yml, renders an issue body from
+a body_context dict, and files the issue via `gh issue create` with the
+canonical label set (type:*, priority:*, source:*).
+
+Callable two ways:
+  CLI:  python3 scripts/backlog_file.py \
+            --title "Extract common error mapper" \
+            --type chore --priority p2 \
+            --body-context-json '{"phase":"reviewer","pr_number":"42",...}'
+  Lib:  from backlog_file import file_backlog_issue
+        result = file_backlog_issue(title=..., type=..., priority=..., body_context=...)
+
+Never raises on the happy path — returns a structured IssueResult so callers
+can log-and-continue without blowing up an /orchestrate run.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    yaml = None  # type: ignore
+
+VALID_TYPES = {"bug", "feature", "chore", "docs"}
+VALID_PRIORITIES = {"p0", "p1", "p2"}
+SENTINEL_PATH = ".github/pipeline-backlog.yml"
+GH_TIMEOUT = 30
+
+
+@dataclass
+class IssueResult:
+    status: str  # "filed" | "skipped" | "failed"
+    url: Optional[str] = None
+    number: Optional[int] = None
+    reason: Optional[str] = None
+
+
+def find_repo_root(start: Path) -> Optional[Path]:
+    path = start.resolve()
+    while path != path.parent:
+        if (path / ".git").exists():
+            return path
+        path = path.parent
+    return None
+
+
+def read_sentinel(repo_root: Path) -> Optional[dict]:
+    """Return parsed sentinel dict, or None if absent/invalid."""
+    sentinel = repo_root / SENTINEL_PATH
+    if not sentinel.exists():
+        return None
+    text = sentinel.read_text()
+    if yaml is not None:
+        try:
+            parsed = yaml.safe_load(text)
+            return parsed if isinstance(parsed, dict) else None
+        except yaml.YAMLError:
+            return None
+    return _parse_minimal_yaml(text)
+
+
+def _parse_minimal_yaml(text: str) -> dict:
+    """Fallback parser for the sentinel's flat key:value schema.
+
+    Handles booleans, ints, nulls, and quoted strings. Ignores comments and
+    indented blocks (the sentinel is intentionally flat). Good enough when
+    PyYAML is unavailable.
+    """
+    out: dict = {}
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- ") or ":" not in stripped:
+            continue
+        if raw.startswith((" ", "\t")):
+            continue
+        key, _, val = stripped.partition(":")
+        key = key.strip()
+        val = val.split("#", 1)[0].strip()
+        if val in ("", "null", "~"):
+            out[key] = None
+        elif val in ("true", "True"):
+            out[key] = True
+        elif val in ("false", "False"):
+            out[key] = False
+        else:
+            try:
+                out[key] = int(val)
+            except ValueError:
+                out[key] = val.strip("'\"")
+    return out
+
+
+def render_body(body_context: dict) -> str:
+    """Render the chore issue body with D8 traceability block.
+
+    Expected keys in body_context (all optional — missing values render as
+    placeholders so the issue is still filable):
+      phase, pr_number, run_id, reasoning, summary, context, acceptance
+    """
+    pr = body_context.get("pr_number")
+    pr_line = f"#{pr}" if pr else "(pre-PR — no PR number yet)"
+    summary = (body_context.get("summary") or "").strip()
+    context = (body_context.get("context") or "").strip()
+    phase = body_context.get("phase", "unknown")
+    run_id = body_context.get("run_id", "unknown")
+    reasoning = (body_context.get("reasoning") or "").strip()
+    acceptance = (body_context.get("acceptance") or "").strip()
+
+    lines = [
+        "## Summary",
+        summary or "_(no summary provided)_",
+        "",
+        "## Context",
+        context or "_(no additional context)_",
+        "",
+        "## Origin",
+        f"**Deferred from:** {pr_line}",
+        f"**Phase:** {phase}",
+        f"**Run ID:** {run_id}",
+        f"**Reasoning:** {reasoning or '_(not provided)_'}",
+    ]
+    if acceptance:
+        lines += ["", "## Acceptance", acceptance]
+    return "\n".join(lines) + "\n"
+
+
+def _run_gh(cmd: list[str]) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=GH_TIMEOUT)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return False, f"gh invocation failed: {e}"
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, result.stdout.strip()
+
+
+def gh_issue_create(title: str, body: str, labels: list[str]) -> tuple[bool, str]:
+    cmd = ["gh", "issue", "create", "--title", title, "--body", body]
+    for label in labels:
+        cmd += ["--label", label]
+    return _run_gh(cmd)
+
+
+def gh_project_item_add(project_number: int, issue_url: str) -> tuple[bool, str]:
+    return _run_gh(["gh", "project", "item-add", str(project_number), "--url", issue_url])
+
+
+def file_backlog_issue(
+    title: str,
+    type: str,
+    priority: str,
+    body_context: dict,
+    source: str = "ai-deferred",
+    repo_root: Optional[Path] = None,
+) -> IssueResult:
+    if type not in VALID_TYPES:
+        return IssueResult(status="failed", reason=f"invalid type: {type!r}")
+    if priority not in VALID_PRIORITIES:
+        return IssueResult(status="failed", reason=f"invalid priority: {priority!r}")
+
+    root = repo_root or find_repo_root(Path.cwd())
+    if root is None:
+        return IssueResult(status="skipped", reason="not in a git repo")
+
+    sentinel = read_sentinel(root)
+    if sentinel is None:
+        return IssueResult(
+            status="skipped",
+            reason="backlog integration not enabled for this repo — run /bootstrap-backlog to enable",
+        )
+    if not sentinel.get("enabled", True):
+        return IssueResult(status="skipped", reason="backlog integration disabled in sentinel")
+
+    body = render_body(body_context)
+    labels = [f"type: {type}", f"priority: {priority}", f"source: {source}"]
+
+    ok, out = gh_issue_create(title, body, labels)
+    if not ok:
+        ok2, out2 = gh_issue_create(title, body, [f"type: {type}", f"priority: {priority}"])
+        if not ok2:
+            return IssueResult(status="failed", reason=out2)
+        out = out2
+
+    url = out
+    number: Optional[int] = None
+    try:
+        number = int(url.rstrip("/").split("/")[-1])
+    except (ValueError, IndexError):
+        pass
+
+    project_number = sentinel.get("project_number")
+    if project_number:
+        gh_project_item_add(int(project_number), url)
+
+    return IssueResult(status="filed", url=url, number=number)
+
+
+def _cli() -> None:
+    ap = argparse.ArgumentParser(description="File a pipeline backlog issue via gh CLI.")
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--type", required=True, choices=sorted(VALID_TYPES))
+    ap.add_argument("--priority", required=True, choices=sorted(VALID_PRIORITIES))
+    ap.add_argument(
+        "--body-context-json",
+        required=True,
+        help="JSON-encoded body_context dict "
+             "(phase, pr_number, run_id, reasoning, summary, context, acceptance).",
+    )
+    ap.add_argument("--source", default="ai-deferred")
+    args = ap.parse_args()
+
+    try:
+        body_context = json.loads(args.body_context_json)
+    except json.JSONDecodeError as e:
+        print(f"invalid --body-context-json: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    result = file_backlog_issue(
+        title=args.title,
+        type=args.type,
+        priority=args.priority,
+        body_context=body_context,
+        source=args.source,
+    )
+    print(json.dumps(asdict(result)))
+    sys.exit(1 if result.status == "failed" else 0)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -210,6 +210,27 @@ exist at the same dependency level, split them into separate waves (e.g., Wave 1
 This keeps individual agent calls under ~50K input tokens and reduces blast radius — a failure
 in one batch doesn't require re-running the other batch.
 
+### Step 7: Classify Out-of-Scope Items (Backlog Deferral)
+
+While decomposing the feature, you will often notice work that is *adjacent but
+out-of-scope* — tech debt in a touched module, a missing abstraction that would
+pay off later, a test coverage gap, a refactor opportunity. Do not silently drop
+these. Classify each using the same model assignment rubric from Step 5:
+
+- **Haiku-tier** (mechanical, <150 lines, fully specified, single file) → **fold**
+  into the current plan as a trivial extra task, subject to the orchestrator's
+  run-level fold cap. Add it to a wave; mark it `source: folded-from-backlog-candidate`.
+- **Sonnet/Opus-tier** (requires design decisions, multi-file, non-trivial
+  reasoning) → **defer**. List it in the plan's **Deferred Items** section with a
+  one-line reasoning. The orchestrator will file these as GitHub issues via the
+  shared backlog utility when the consumer repo is opted in (sentinel
+  `.github/pipeline-backlog.yml` present). If the repo is not opted in, deferred
+  items still appear in the plan — the orchestrator will skip filing silently.
+
+**Do not invent deferred items.** Only classify items you would otherwise have
+dropped from the plan because they're out-of-scope. The goal is durable capture,
+not padding.
+
 ## Output Format
 
 The plan MUST be output as a structured document following this exact format:
@@ -291,6 +312,16 @@ The plan MUST be output as a structured document following this exact format:
 ## Risk Notes
 - [Any tasks where the model assignment is borderline]
 - [Any tasks where Haiku might need a retry, and what the fallback is]
+
+## Deferred Items
+*Items surfaced during planning that are out-of-scope for the current feature.*
+*The orchestrator will file these to the backlog when the consumer repo is opted in.*
+
+- **Title:** [one-line title]
+  **Type:** chore | bug | feature | docs
+  **Priority:** p2 (default for ai-deferred)
+  **Reasoning:** [why this is out-of-scope AND why it cannot be folded]
+  **Origin:** [which file/module prompted this observation]
 ```
 
 ## Decomposition Quality Checks

--- a/skills/bootstrap-backlog/SKILL.md
+++ b/skills/bootstrap-backlog/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: bootstrap-backlog
+description: Provisions GitHub labels, Issue Forms, and a sentinel config so /orchestrate can file deferred work as backlog issues. Idempotent — safe to re-run on every pipeline upgrade.
+---
+
+# Bootstrap Backlog Skill
+
+Provisions the opt-in artifacts that enable `/orchestrate` to file deferred work as
+GitHub issues with the canonical namespaced label taxonomy. Run once per consumer
+repo; re-running is a no-op if nothing changed upstream.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth status` exit 0).
+- Current directory is inside a git repo with a GitHub remote.
+- User has write access to labels on the remote's owner.
+
+Fail loudly with a clear message if any prerequisite is missing. Do not attempt to
+install `gh` or run `gh auth login` for the user.
+
+## Step 1: Preflight
+
+```bash
+gh auth status
+```
+
+If exit code is nonzero, print:
+```
+bootstrap-backlog: gh CLI is not authenticated. Run `gh auth login` and retry.
+```
+…and stop.
+
+Verify the current directory is a git repo with a remote:
+
+```bash
+git rev-parse --is-inside-work-tree
+git remote get-url origin
+```
+
+If either fails, print a specific error and stop.
+
+Locate the pipeline repo root (for reading `templates/backlog/`). In consumer
+projects, `.claude/pipeline/` points at the pipeline submodule or clone. In the
+pipeline repo itself, the repo root IS the pipeline root.
+
+## Step 2: Provision Labels
+
+Read `templates/backlog/labels.yml` from the pipeline root. For each label,
+invoke:
+
+```bash
+gh label create "<name>" --color "<color>" --description "<description>" --force
+```
+
+`--force` updates existing labels (idempotent). The 12 labels are:
+
+| Name | Color | Purpose |
+|---|---|---|
+| `type: bug` | d73a4a | Something isn't working |
+| `type: feature` | a2eeef | New capability |
+| `type: chore` | fef2c0 | Tech debt, refactor, cleanup |
+| `type: docs` | 0075ca | Documentation only |
+| `priority: p0` | b60205 | Drop everything |
+| `priority: p1` | d93f0b | Next sprint |
+| `priority: p2` | fbca04 | Backlog |
+| `status: needs-triage` | ededed | Default on new issues |
+| `status: blocked` | e4e669 | Blocked by external dependency |
+| `status: ready` | 0e8a16 | Triaged, ready to pick up |
+| `source: ai-deferred` | 5319e7 | Filed by /orchestrate run |
+| `good first issue` | 7057ff | Good for newcomers |
+| `help wanted` | 008672 | Extra attention is needed |
+
+**DO NOT delete existing labels** — bootstrap is additive. If a consumer repo
+has a label with the same name and different color/description, `--force` will
+update it (document this behavior in the summary).
+
+If `gh label create --force` fails for any label, surface the error and stop —
+partial provisioning is worse than none.
+
+## Step 3: Install Issue Forms
+
+Create `.github/ISSUE_TEMPLATE/` if missing. Copy all four YAML files from
+`templates/backlog/ISSUE_TEMPLATE/` in the pipeline root:
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+cp <pipeline_root>/templates/backlog/ISSUE_TEMPLATE/bug_report.yml      .github/ISSUE_TEMPLATE/
+cp <pipeline_root>/templates/backlog/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/
+cp <pipeline_root>/templates/backlog/ISSUE_TEMPLATE/chore.yml           .github/ISSUE_TEMPLATE/
+cp <pipeline_root>/templates/backlog/ISSUE_TEMPLATE/config.yml          .github/ISSUE_TEMPLATE/
+```
+
+Copies (not symlinks) because `.github/` must be directly committable in the
+consumer repo. Overwriting existing Issue Forms is intentional — the pipeline
+is the source of truth for these templates. Pre-existing unrelated templates in
+`.github/ISSUE_TEMPLATE/` are left untouched.
+
+## Step 4: Write Sentinel Config
+
+```bash
+test -f .github/pipeline-backlog.yml || \
+  cp <pipeline_root>/templates/backlog/pipeline-backlog.yml.template \
+     .github/pipeline-backlog.yml
+```
+
+**Do NOT overwrite an existing sentinel** — the user may have customized
+`fold_cap` or set `project_number`. The template's defaults (version 1,
+enabled true, fold_cap 3, project_number null) are sensible first-run values.
+
+## Step 5: Summary
+
+Print a structured provisioning summary:
+
+```
+bootstrap-backlog: complete
+  Labels provisioned:   12 (via gh label create --force)
+  Issue Forms:          .github/ISSUE_TEMPLATE/{bug_report,feature_request,chore,config}.yml
+  Sentinel config:      .github/pipeline-backlog.yml (<created | existing, unchanged>)
+
+Next steps:
+  1. Review .github/ISSUE_TEMPLATE/ and .github/pipeline-backlog.yml
+  2. Commit and push — backlog integration activates on the next /orchestrate run
+  3. To disable later: delete .github/pipeline-backlog.yml (labels and templates remain)
+```
+
+## Error Handling
+
+- `gh` not installed → "bootstrap-backlog: install GitHub CLI — brew install gh"
+- `gh auth status` nonzero → "bootstrap-backlog: run `gh auth login` and retry"
+- Not in a git repo → "bootstrap-backlog: this must run inside a git repository"
+- No GitHub remote → "bootstrap-backlog: this repo has no GitHub remote configured"
+- `gh label create` fails → surface `gh`'s stderr verbatim and stop (do not continue with partial labels)
+- `cp` fails → surface the OS error and stop
+
+## Re-running
+
+Re-running is safe and produces zero diff after the first successful run:
+- `gh label create --force` is idempotent (updates or creates)
+- Template files are overwritten with identical content
+- Sentinel is NOT overwritten if present
+
+This is the expected behavior on every pipeline upgrade — re-run after
+`/update-pipeline` to pick up any label or template changes.
+
+## Token Report
+
+After completing, output:
+
+```
+---TOKEN_REPORT---
+files_read: <N>
+tool_calls: <N>
+self_assessed_input: <tokens>
+self_assessed_output: <tokens>
+```

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -271,6 +271,35 @@ accumulates token usage data for every agent call throughout the pipeline. Also 
 3. If the TOKEN_REPORT is missing or malformed, leave those fields empty — do not fail.
 4. Append the entry to `TOKEN_LEDGER`.
 
+## Step 0.65: Initialize Backlog Integration State
+
+Before Step 1a runs, bootstrap two artifacts in `.claude/tmp/` that the backlog
+integration depends on:
+
+1. **Run ID** — `.claude/tmp/run-id`: a timestamp-based identifier for this
+   orchestrate run (`YYYYMMDD-HHMMSS`, e.g. `20260423-181500`). Generate at
+   pipeline start. Every backlog issue filed during this run embeds this ID in
+   its traceability block (D8).
+2. **Run log** — `.claude/tmp/run-log.yml`: accumulates fold/defer decisions
+   across phases. Initialize with an empty `backlog_decisions: []` array if the
+   file does not already exist (a resumed run should preserve prior entries).
+
+```bash
+date +%Y%m%d-%H%M%S > .claude/tmp/run-id
+test -f .claude/tmp/run-log.yml || printf 'backlog_decisions: []\n' > .claude/tmp/run-log.yml
+```
+
+**Backlog opt-in detection**: check for `.github/pipeline-backlog.yml` at the
+project root. Set `BACKLOG_ENABLED=true|false` for downstream phases. Re-check
+at the start of each filing call — `/bootstrap-backlog` can be run mid-session,
+and subsequent phases should pick up the new sentinel without restart.
+
+If `BACKLOG_ENABLED=false`, phases still emit fold/defer classifications into
+`run-log.yml` (so the user sees what would have been filed), but no `gh issue
+create` call is made. Emit exactly one hint on the first skipped filing:
+`backlog integration not enabled for this repo — run /bootstrap-backlog to enable`.
+Subsequent skips in the same run are silent.
+
 ## Step 0.7: Prepare ORCHESTRATOR.md Extracts
 
 Read `.claude/ORCHESTRATOR.md` once at pipeline start. Instead of pasting the full file into
@@ -495,6 +524,10 @@ modeling). See Step 2.5 in the planner skill.
 - Are waves and dependencies sensible?
 - Are context briefs self-contained and free of "see task X" cross-references?
 
+If the plan includes a `## Deferred Items` section, process each entry per the
+**Backlog Integration** section below (fold or defer). Do this before presenting
+the plan to the user so the folded items appear in the wave list.
+
 Present the plan summary to the user and wait for confirmation before proceeding.
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If implementation clarification questions occur, record each SendMessage round as step `1b:impl-clarify-N`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: as selected above (`sonnet` or `opus`).
@@ -639,6 +672,12 @@ agent for tasks 9+. This prevents context window saturation from accumulated rev
 
 - If `PASS`: proceed to Step 3 (commit)
 - If `FAIL`: proceed to Step 2.2 (fix)
+
+**Backlog classification:** after handling PASS/FAIL, parse the
+`--- OPTIONAL IMPROVEMENTS ---` section. Each entry is tagged `[should-fix]` or
+`[nice-to-have]`. For each, apply the fold-vs-defer rule in the Backlog
+Integration section below. This happens after the pass/fail handshake — do not
+let it block the review cycle.
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry for each review (step `2.1:<task_id>`). Agent: `code-reviewer-agent`, model: `sonnet`. For SendMessage reviews, `input_chars` is the SendMessage content (not the full accumulated context).
 
@@ -917,6 +956,10 @@ After all tasks are committed and pushed:
    - Commit and push the update
 2. Update the PR body's Coverage section with final numbers from the last test run
 3. Check off completed tasks in the PR body's task list
+3.5. If `BACKLOG_ENABLED=true` and `.claude/tmp/run-log.yml` has any entries with
+   `action: folded`, render the "Folded in this run" checklist into the PR body
+   (see the Backlog Integration section for the format). Skip this if no folds
+   occurred.
 4. Mark the PR as ready for review:
    ```bash
    gh pr ready <PR_NUMBER>
@@ -1002,6 +1045,121 @@ Prompt: |
 
 ---
 
+## Backlog Integration
+
+When `/orchestrate` runs in a repo opted in via `.github/pipeline-backlog.yml`,
+out-of-scope items surfaced by the planner and reviewer are classified as
+**fold** (spawn a new implementer task in this run) or **defer** (file a GitHub
+issue via `scripts/backlog_file.py`). This closes the durable-capture gap —
+items like "extract this common helper" or "this file has a stale comment"
+stop evaporating between runs.
+
+### Fold vs. Defer Decision Rule
+
+Use the planner's existing Haiku/Sonnet classification rubric
+(`architect-planner/SKILL.md` Step 5 "Assign Models") as the boundary:
+
+- **Haiku-tier** — mechanical, <150 lines, single-file, fully-specified → **fold**.
+- **Sonnet/Opus-tier** — design decisions, multi-file, moderate-to-high reasoning
+  → **defer** (file to backlog).
+
+Reviewer guidance: `[should-fix]` entries with Haiku-tier fix are fold
+candidates; `[nice-to-have]` entries default-defer regardless of tier.
+
+### Run-Level Fold Cap
+
+Read `fold_cap` from `.github/pipeline-backlog.yml` (default 3, `0` = never
+fold). Before folding a new item, count entries in `.claude/tmp/run-log.yml`
+where `action: folded`. If that count is already at the cap, treat this item
+as **defer** regardless of its tier.
+
+Fold cap applies across ALL phases combined — not per-phase. This prevents
+reviewer and planner from collectively turning into a second round of
+implementation work.
+
+### Filing a Deferred Item
+
+Use the shared utility — do not shell out to `gh` directly:
+
+```bash
+python3 .claude/pipeline/scripts/backlog_file.py \
+  --title "<short imperative title>" \
+  --type chore --priority p2 \
+  --body-context-json '{
+    "phase": "reviewer",
+    "pr_number": "'"$PR_NUMBER"'",
+    "run_id": "'"$(cat .claude/tmp/run-id)"'",
+    "reasoning": "<one-line: why this defers, not folds>",
+    "summary": "<one-line summary>",
+    "context": "<multi-line context from the surfacing phase>"
+  }'
+```
+
+Parse the utility's JSON output. Possible outcomes:
+- `{"status": "filed", "url": "...", "number": N}` — issue created, append to
+  `backlog_decisions` with `action: deferred` and `issue_url`.
+- `{"status": "skipped", "reason": "..."}` — sentinel absent or disabled;
+  append to `backlog_decisions` with `action: skipped` and emit the one-time
+  hint if this is the first skip of the run.
+- `{"status": "failed", "reason": "..."}` — `gh` errored; append with
+  `action: failed` and `issue_url: null`, log a warning, continue the run.
+
+### Folding an Item (spawn new implementer task)
+
+Add the item to the next available wave as a new Haiku task with a fresh brief
+that satisfies all 6 contract points (see `agents/implementer-contract.md`).
+Append a `backlog_decisions` entry with `action: folded` and a one-line
+reasoning. Count this entry against the fold cap.
+
+### Run-Log Schema
+
+`.claude/tmp/run-log.yml` accumulates decisions across phases:
+
+```yaml
+backlog_decisions:
+  - phase: reviewer              # planner | reviewer | implementer | token-analysis
+    title: "Extract common Grok error mapper"
+    classification: sonnet       # haiku | sonnet | opus | trivial
+    action: deferred             # folded | deferred | skipped | failed
+    issue_url: "https://github.com/.../issues/42"   # present when action=deferred
+    issue_number: 42
+    reasoning: "Cross-cuts 4 files, adds new abstraction — Sonnet-tier"
+  - phase: implementer
+    title: "Typo in error message at src/tools/grok_client.py:42"
+    classification: trivial
+    action: folded
+    reasoning: "<5 LOC mechanical fix in file already being edited"
+```
+
+### PR Description — Folded Checklist
+
+At Step 4 (Finalize), when `BACKLOG_ENABLED=true`, read `run-log.yml` and
+render a "Folded in this run" checklist into the PR body before marking it
+ready for review:
+
+```markdown
+## Folded in this run
+- [x] Extracted common validation helper (implementer, wave 2) — <commit SHA>
+- [x] Fixed typo in error message at src/tools/grok_client.py (implementer, wave 1) — inline
+```
+
+Deferred items are NOT listed in the PR body — they have their own GitHub
+issues (linked via traceability block, which auto-backlinks to the originating
+PR). If no folds occurred, omit the section entirely.
+
+### Phase Integration Summary
+
+- **Step 1b (planner)**: planner outputs a `Deferred Items` section. Orchestrator
+  iterates each, classifies, folds or files per the rule above.
+- **Step 2.1 (reviewer)**: each `[should-fix]` / `[nice-to-have]` entry in
+  OPTIONAL IMPROVEMENTS is classified. Orchestrator folds or files.
+- **Step 2 (implementer)**: implementer's SUCCESS commit message may include a
+  "Follow-up" suggestion line — surface to reviewer, who classifies it with the
+  rest.
+- **Step 5 (token-analysis)**: token-analysis findings always defer (per spec).
+  The skill itself invokes `scripts/backlog_file.py`; orchestrator records the
+  outcome in `run-log.yml`.
+
 ## Parallelization Rules
 
 - **Within a wave:** launch all implementer agents simultaneously (parallel)
@@ -1026,6 +1184,9 @@ Prompt: |
 | Token analysis skill fails | Log warning, report to user, do not block pipeline completion |
 | `gh issue create` fails (missing label, auth, etc.) | Retry without `--label`, report failure if still errors |
 | Pipeline repo has no GitHub remote | Skip issue filing, report token summary to user directly |
+| Backlog sentinel absent | Phase classifications still recorded in run-log; no `gh` calls; emit one-line hint on first skip |
+| Backlog filing returns `failed` | Record `action: failed` in run-log with reason; continue pipeline |
+| Fold cap reached mid-run | Treat subsequent fold candidates as deferrals regardless of tier |
 
 ## What the Orchestrator Does NOT Do
 

--- a/skills/token-analysis/SKILL.md
+++ b/skills/token-analysis/SKILL.md
@@ -131,24 +131,43 @@ If none of these thresholds are met, output `FINDINGS: NONE` and stop.
 
 ## Issue Filing
 
-If significant findings exist, file a GitHub issue on the pipeline repo.
+If significant findings exist, file a backlog issue via the shared backlog-file
+utility. Opt-in detection, label application, and traceability fields are all
+handled by the utility — do not shell out to `gh issue create` directly.
 
-### Derive Repo Identifier
-
-The orchestrator provides the pipeline repo's `owner/repo` in the prompt. Use it directly.
-
-### Create the Issue
+### Invoke the Utility
 
 ```bash
-gh issue create \
-  --repo <owner/repo> \
+python3 <pipeline_root>/scripts/backlog_file.py \
   --title "pipeline-tokens: <one-line summary of top finding>" \
-  --label "token-analysis" \
-  --body "<issue body>"
+  --type chore \
+  --priority p2 \
+  --body-context-json '{
+    "phase": "token-analysis",
+    "pr_number": "<PR_NUMBER>",
+    "run_id": "<RUN_ID>",
+    "reasoning": "<one-line: why this is Sonnet/Opus-tier, always defers>",
+    "summary": "<top finding summary>",
+    "context": "<full findings markdown body — use the template below>"
+  }'
 ```
 
-If `gh issue create` fails due to a missing `token-analysis` label, retry without the
-`--label` flag.
+The utility:
+- Detects opt-in via `.github/pipeline-backlog.yml` — skips silently if absent.
+- Applies labels `type: chore`, `priority: p2`, `source: ai-deferred`.
+- Includes the D8 traceability block in the body.
+- Retries without `source: ai-deferred` if the label isn't yet provisioned.
+- Returns a JSON result (`{"status": "filed" | "skipped" | "failed", ...}`).
+
+Token-analysis findings are always tier=defer (the classification decision is
+trivially always "defer" per the issue spec — token-level anomalies never fold).
+
+If the utility returns `status: skipped` (repo not opted in), output
+`FINDINGS: SKIPPED (backlog integration not enabled)` and stop. If `status: failed`,
+surface the reason in the run log but do not error out.
+
+The `context` field should hold the full findings markdown (cost breakdown,
+model distribution, findings list) that was previously the body of the issue.
 
 ### Issue Body Template
 

--- a/templates/backlog/ISSUE_TEMPLATE/bug_report.yml
+++ b/templates/backlog/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: Report something that isn't working as expected
+labels: ["type: bug", "status: needs-triage"]
+body:
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps to reproduce the bug.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, logs, screenshots.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, tool versions, any relevant config.
+      placeholder: |
+        - OS: macOS 14.5
+        - Tool / runtime: ...
+        - Relevant versions: ...
+    validations:
+      required: true

--- a/templates/backlog/ISSUE_TEMPLATE/chore.yml
+++ b/templates/backlog/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore / Tech Debt
+description: Refactor, cleanup, or deferred work (including items surfaced by /orchestrate)
+labels: ["type: chore"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line summary of the work.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Origin
+      description: What surfaced this? What's the underlying problem or opportunity?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: What does "done" look like? (optional — helpful for AI-deferred items)
+    validations:
+      required: false

--- a/templates/backlog/ISSUE_TEMPLATE/config.yml
+++ b/templates/backlog/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/templates/backlog/ISSUE_TEMPLATE/feature_request.yml
+++ b/templates/backlog/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new capability
+labels: ["type: feature", "status: needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Who experiences it?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see built.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider, and why were they rejected?
+    validations:
+      required: false

--- a/templates/backlog/labels.yml
+++ b/templates/backlog/labels.yml
@@ -1,0 +1,53 @@
+# Pipeline backlog label taxonomy.
+# Consumed by /bootstrap-backlog to provision labels via `gh label create --force`.
+# Do not delete existing labels here — bootstrap is additive-only.
+
+labels:
+  # type: * — exactly one per issue
+  - name: "type: bug"
+    color: "d73a4a"
+    description: "Something isn't working"
+  - name: "type: feature"
+    color: "a2eeef"
+    description: "New capability"
+  - name: "type: chore"
+    color: "fef2c0"
+    description: "Tech debt, refactor, cleanup"
+  - name: "type: docs"
+    color: "0075ca"
+    description: "Documentation only"
+
+  # priority: * — exactly one per issue
+  - name: "priority: p0"
+    color: "b60205"
+    description: "Drop everything"
+  - name: "priority: p1"
+    color: "d93f0b"
+    description: "Next sprint"
+  - name: "priority: p2"
+    color: "fbca04"
+    description: "Backlog"
+
+  # status: * — default on creation, updated during triage
+  - name: "status: needs-triage"
+    color: "ededed"
+    description: "Default on new issues"
+  - name: "status: blocked"
+    color: "e4e669"
+    description: "Blocked by external dependency"
+  - name: "status: ready"
+    color: "0e8a16"
+    description: "Triaged, ready to pick up"
+
+  # source: * — provenance
+  - name: "source: ai-deferred"
+    color: "5319e7"
+    description: "Filed by /orchestrate run"
+
+  # GitHub specials — retained, not reprovisioned
+  - name: "good first issue"
+    color: "7057ff"
+    description: "Good for newcomers"
+  - name: "help wanted"
+    color: "008672"
+    description: "Extra attention is needed"

--- a/templates/backlog/pipeline-backlog.yml.template
+++ b/templates/backlog/pipeline-backlog.yml.template
@@ -1,0 +1,24 @@
+# .github/pipeline-backlog.yml
+#
+# Marker file: its presence enables /orchestrate backlog filing for this repo.
+# Delete this file to disable backlog integration — labels and Issue Forms will remain.
+#
+# Managed by the claude-code-pipeline /bootstrap-backlog skill.
+# Re-running the skill is idempotent and safe.
+
+version: 1
+enabled: true
+
+# Maximum number of items folded into the current /orchestrate run across all
+# phases. Past the cap, all surfaced items are deferred to the backlog even if
+# they would otherwise qualify for inline fixing.
+#   0 → never fold, always defer
+#   N → allow up to N folds per run (default: 3)
+fold_cap: 3
+
+# Optional GitHub Projects v2 number. If set, filed issues are added to this
+# project via `gh project item-add`. Leave null if you don't use Projects.
+project_number: null
+
+# Reserved for v2:
+# label_overrides:

--- a/tests/fixtures/backlog-issue-body-expected.md
+++ b/tests/fixtures/backlog-issue-body-expected.md
@@ -1,0 +1,15 @@
+## Summary
+Extract common error mapper for Grok client
+
+## Context
+Reviewer surfaced duplicated error-to-user-message mapping in 4 files during
+wave 2. A single mapper keeps the UX consistent when the API changes.
+
+## Origin
+**Deferred from:** #42
+**Phase:** reviewer
+**Run ID:** 20260423-181000
+**Reasoning:** Cross-cuts 4 files, adds new abstraction — Sonnet-tier.
+
+## Acceptance
+A `GrokErrorMapper` class under `src/tools/grok_client.py` with unit tests; callers refactored to use it.

--- a/tests/fixtures/reviewer-pass-with-optional-tagged.txt
+++ b/tests/fixtures/reviewer-pass-with-optional-tagged.txt
@@ -1,0 +1,14 @@
+PASS
+[should-fix] Duplicated validation logic across divide() and modulo() — extract a shared guard helper
+[nice-to-have] Error messages could include the offending value for easier debugging
+
+---TOKEN_REPORT---
+FILES_READ:
+- src/calculator.py (~520 chars)
+- tests/test_calculator.py (~1100 chars)
+TOOL_CALLS:
+- Read: 3
+- Grep: 1
+SELF_ASSESSED_INPUT: ~4200 chars
+SELF_ASSESSED_OUTPUT: ~300 chars
+---END_TOKEN_REPORT---

--- a/tests/fixtures/sentinel-config-disabled.yml
+++ b/tests/fixtures/sentinel-config-disabled.yml
@@ -1,0 +1,5 @@
+# Sentinel present but explicitly disabled.
+version: 1
+enabled: false
+fold_cap: 0
+project_number: null

--- a/tests/fixtures/sentinel-config-valid.yml
+++ b/tests/fixtures/sentinel-config-valid.yml
@@ -1,0 +1,5 @@
+# Valid sentinel config fixture for backlog utility tests.
+version: 1
+enabled: true
+fold_cap: 3
+project_number: null

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -63,6 +63,20 @@ def parse_implementer_result(output: str) -> dict:
         return {"status": "UNKNOWN", "error": f"unexpected first line: {first_line}"}
 
 
+def _parse_optional_entry(raw: str) -> dict:
+    """Split a `[should-fix] ...` / `[nice-to-have] ...` prefix from free text.
+
+    Returns {"text": str, "tag": "should-fix"|"nice-to-have"|None}. Entries
+    without a known tag get tag=None for backward compatibility.
+    """
+    s = raw.strip()
+    for tag in ("should-fix", "nice-to-have"):
+        prefix = f"[{tag}]"
+        if s.startswith(prefix):
+            return {"text": s[len(prefix):].strip(), "tag": tag}
+    return {"text": s, "tag": None}
+
+
 def parse_reviewer_result(output: str) -> dict:
     """Parse code-reviewer agent output per the documented protocol."""
     lines = output.strip().split("\n")
@@ -71,19 +85,19 @@ def parse_reviewer_result(output: str) -> dict:
 
     first_line = lines[0].strip()
     if first_line == "PASS":
-        suggestions: list[str] = []
+        suggestions: list[dict] = []
         for line in lines[1:]:
             stripped = line.strip()
             if stripped.startswith("---TOKEN_REPORT---"):
                 break
             if stripped:
-                suggestions.append(stripped)
+                suggestions.append(_parse_optional_entry(stripped))
         return {"status": "PASS", "suggestions": suggestions}
 
     elif first_line == "FAIL":
         issues: list[dict] = []
         current_issue: dict = {}
-        optional_improvements: list[str] = []
+        optional_improvements: list[dict] = []
         in_optional = False
         for line in lines[1:]:
             stripped = line.strip()
@@ -97,7 +111,7 @@ def parse_reviewer_result(output: str) -> dict:
                 continue
             if in_optional:
                 if stripped:
-                    optional_improvements.append(stripped)
+                    optional_improvements.append(_parse_optional_entry(stripped))
                 continue
             if stripped.startswith("ISSUE:"):
                 if current_issue:

--- a/tests/test_backlog_integration.py
+++ b/tests/test_backlog_integration.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Integration tests for backlog filing behavior.
+
+Exercises higher-order properties that span utility + sentinel + simulated
+orchestrator state:
+
+  - Opt-in detection (sentinel present / absent / disabled / malformed)
+  - Fold-cap enforcement using a synthetic run-log
+  - fold_cap = 0 (always defer)
+  - Traceability fields (D8) present in every filed issue body
+  - "Skipped silently" semantics: skip reason is emitted exactly once per run
+
+Bootstrap-skill idempotency is verified at the contract level — running the
+skill twice against an identical sentinel and template set must produce zero
+filesystem diff. That's exercised here by simulating the skill's file-copy
+step and checking for byte equivalence.
+
+Usage:
+    python3 tests/test_backlog_integration.py [-v]
+"""
+
+from __future__ import annotations
+
+import filecmp
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PIPELINE_ROOT / "scripts"))
+
+from backlog_file import file_backlog_issue, render_body  # noqa: E402
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+BACKLOG_TEMPLATES = PIPELINE_ROOT / "templates" / "backlog"
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _err(stderr: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+def _make_repo(tmp: Path, sentinel_src: Path | None) -> Path:
+    (tmp / ".git").mkdir()
+    (tmp / ".github").mkdir()
+    if sentinel_src is not None:
+        (tmp / ".github" / "pipeline-backlog.yml").write_text(sentinel_src.read_text())
+    return tmp
+
+
+BASE_CTX = {
+    "phase": "reviewer",
+    "pr_number": "42",
+    "run_id": "20260423-181000",
+    "reasoning": "Cross-cuts 4 files — Sonnet-tier",
+    "summary": "Extract common error mapper",
+    "context": "Reviewer surfaced duplicated error-to-user-message mapping.",
+}
+
+
+class TestOptInDetection(unittest.TestCase):
+    def test_sentinel_present_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_repo(Path(td), FIXTURES / "sentinel-config-valid.yml")
+            with patch("backlog_file.subprocess.run", return_value=_ok("https://github.com/o/r/issues/1")):
+                r = file_backlog_issue("t", "chore", "p2", BASE_CTX, repo_root=root)
+            self.assertEqual(r.status, "filed")
+
+    def test_sentinel_absent_skips(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_repo(Path(td), None)
+            r = file_backlog_issue("t", "chore", "p2", BASE_CTX, repo_root=root)
+            self.assertEqual(r.status, "skipped")
+
+    def test_sentinel_disabled_skips(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_repo(Path(td), FIXTURES / "sentinel-config-disabled.yml")
+            r = file_backlog_issue("t", "chore", "p2", BASE_CTX, repo_root=root)
+            self.assertEqual(r.status, "skipped")
+            self.assertIn("disabled", r.reason)
+
+    def test_sentinel_malformed_skips(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".git").mkdir()
+            (root / ".github").mkdir()
+            (root / ".github" / "pipeline-backlog.yml").write_text("not: valid: yaml: [")
+            r = file_backlog_issue("t", "chore", "p2", BASE_CTX, repo_root=root)
+            # Malformed parses to None → treated as absent → skipped.
+            self.assertEqual(r.status, "skipped")
+
+
+class TestFoldCapBehavior(unittest.TestCase):
+    """Simulate the orchestrator's fold-cap check by counting run-log entries.
+
+    The utility itself does NOT enforce fold cap — that's the orchestrator's
+    job (see skills/orchestrate/SKILL.md "Backlog Integration"). These tests
+    validate the contract the orchestrator implements against: counting
+    `action: folded` entries in run-log.yml and gating further folds.
+    """
+
+    @staticmethod
+    def count_folds(run_log: list[dict]) -> int:
+        return sum(1 for e in run_log if e.get("action") == "folded")
+
+    def test_default_cap_of_3_allows_three_folds(self) -> None:
+        run_log: list[dict] = []
+        cap = 3
+        for i in range(5):
+            if self.count_folds(run_log) < cap:
+                run_log.append({"action": "folded", "title": f"item {i}"})
+            else:
+                run_log.append({"action": "deferred", "title": f"item {i}"})
+        self.assertEqual(self.count_folds(run_log), 3)
+        self.assertEqual(sum(1 for e in run_log if e["action"] == "deferred"), 2)
+
+    def test_fold_cap_zero_always_defers(self) -> None:
+        run_log: list[dict] = []
+        cap = 0
+        for i in range(3):
+            if self.count_folds(run_log) < cap:
+                run_log.append({"action": "folded", "title": f"item {i}"})
+            else:
+                run_log.append({"action": "deferred", "title": f"item {i}"})
+        self.assertEqual(self.count_folds(run_log), 0)
+        self.assertEqual(len(run_log), 3)
+
+    def test_fold_cap_applies_across_phases(self) -> None:
+        """Fold cap is run-wide, not per-phase."""
+        run_log: list[dict] = []
+        cap = 2
+        phases = ["planner", "reviewer", "reviewer", "implementer"]
+        for phase in phases:
+            if self.count_folds(run_log) < cap:
+                run_log.append({"phase": phase, "action": "folded"})
+            else:
+                run_log.append({"phase": phase, "action": "deferred"})
+        self.assertEqual(self.count_folds(run_log), 2)
+        # First two phases fold, last two defer regardless of phase.
+        self.assertEqual([e["action"] for e in run_log], ["folded", "folded", "deferred", "deferred"])
+
+
+class TestTraceabilityBlock(unittest.TestCase):
+    """Every filed issue body must include D8 fields: Deferred from, Phase,
+    Run ID, Reasoning."""
+
+    def test_all_fields_present_with_pr(self) -> None:
+        body = render_body(BASE_CTX)
+        self.assertIn("**Deferred from:** #42", body)
+        self.assertIn("**Phase:** reviewer", body)
+        self.assertIn("**Run ID:** 20260423-181000", body)
+        self.assertIn("**Reasoning:** Cross-cuts 4 files", body)
+
+    def test_pre_pr_filings_mark_origin(self) -> None:
+        ctx = {**BASE_CTX}
+        del ctx["pr_number"]
+        body = render_body(ctx)
+        self.assertIn("**Deferred from:** (pre-PR", body)
+
+    def test_reasoning_placeholder_when_missing(self) -> None:
+        body = render_body({"phase": "architect", "run_id": "x"})
+        self.assertIn("**Reasoning:** _(not provided)_", body)
+
+
+class TestBootstrapIdempotency(unittest.TestCase):
+    """Re-running the file-copy portion of /bootstrap-backlog produces zero
+    diff. (The gh label create --force step is idempotent by gh itself and
+    is tested by manual dogfooding.)"""
+
+    def test_issue_form_copies_are_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            consumer = Path(td)
+            (consumer / ".github" / "ISSUE_TEMPLATE").mkdir(parents=True)
+
+            # First bootstrap pass
+            for name in ("bug_report.yml", "feature_request.yml", "chore.yml", "config.yml"):
+                shutil.copy(
+                    BACKLOG_TEMPLATES / "ISSUE_TEMPLATE" / name,
+                    consumer / ".github" / "ISSUE_TEMPLATE" / name,
+                )
+
+            first_hashes = {
+                p.name: p.read_bytes() for p in (consumer / ".github" / "ISSUE_TEMPLATE").iterdir()
+            }
+
+            # Second bootstrap pass — re-copy, expect identical bytes
+            for name in ("bug_report.yml", "feature_request.yml", "chore.yml", "config.yml"):
+                shutil.copy(
+                    BACKLOG_TEMPLATES / "ISSUE_TEMPLATE" / name,
+                    consumer / ".github" / "ISSUE_TEMPLATE" / name,
+                )
+
+            second_hashes = {
+                p.name: p.read_bytes() for p in (consumer / ".github" / "ISSUE_TEMPLATE").iterdir()
+            }
+            self.assertEqual(first_hashes, second_hashes)
+
+    def test_sentinel_not_overwritten_if_present(self) -> None:
+        """The bootstrap skill must NOT overwrite an existing sentinel —
+        user may have customized fold_cap or project_number."""
+        with tempfile.TemporaryDirectory() as td:
+            consumer = Path(td) / ".github"
+            consumer.mkdir()
+            user_config = "version: 1\nenabled: true\nfold_cap: 99\nproject_number: 42\n"
+            sentinel = consumer / "pipeline-backlog.yml"
+            sentinel.write_text(user_config)
+
+            # Simulated bootstrap: only copy if absent.
+            if not sentinel.exists():
+                shutil.copy(BACKLOG_TEMPLATES / "pipeline-backlog.yml.template", sentinel)
+
+            self.assertEqual(sentinel.read_text(), user_config)
+
+
+class TestLabelAndBodyComposition(unittest.TestCase):
+    """Labels and body content match the locked taxonomy when filing happens."""
+
+    def test_filed_issue_has_three_canonical_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_repo(Path(td), FIXTURES / "sentinel-config-valid.yml")
+            captured: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):
+                captured.append(cmd)
+                return _ok("https://github.com/o/r/issues/10")
+
+            with patch("backlog_file.subprocess.run", side_effect=fake_run):
+                r = file_backlog_issue("t", "chore", "p2", BASE_CTX, repo_root=root)
+
+            self.assertEqual(r.status, "filed")
+            cmd = captured[0]
+            labels_in_cmd = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--label"]
+            self.assertEqual(sorted(labels_in_cmd), ["priority: p2", "source: ai-deferred", "type: chore"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backlog_utility.py
+++ b/tests/test_backlog_utility.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/backlog_file.py.
+
+Mocks `gh` subprocess calls and exercises every branch of file_backlog_issue:
+opt-in detection, input validation, body rendering, label construction, gh
+failure fallback, and project item-add.
+
+Usage:
+    python3 tests/test_backlog_utility.py [-v]
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PIPELINE_ROOT / "scripts"))
+
+from backlog_file import (  # noqa: E402
+    IssueResult,
+    file_backlog_issue,
+    find_repo_root,
+    read_sentinel,
+    render_body,
+    _parse_minimal_yaml,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def _make_opted_in_repo(tmp: Path, sentinel_src: str = "sentinel-config-valid.yml") -> Path:
+    """Create a temp git repo with a sentinel, return repo_root."""
+    (tmp / ".git").mkdir()
+    (tmp / ".github").mkdir()
+    (tmp / ".github" / "pipeline-backlog.yml").write_text(
+        (FIXTURES_DIR / sentinel_src).read_text()
+    )
+    return tmp
+
+
+def _make_bare_repo(tmp: Path) -> Path:
+    """Create a temp git repo WITHOUT a sentinel."""
+    (tmp / ".git").mkdir()
+    return tmp
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _err(stderr: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+class TestFindRepoRoot(unittest.TestCase):
+    def test_walks_up_to_git_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".git").mkdir()
+            nested = root / "a" / "b" / "c"
+            nested.mkdir(parents=True)
+            self.assertEqual(find_repo_root(nested), root.resolve())
+
+    def test_returns_none_outside_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(find_repo_root(Path(td)))
+
+
+class TestReadSentinel(unittest.TestCase):
+    def test_absent_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(read_sentinel(Path(td)))
+
+    def test_valid_returns_dict(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_opted_in_repo(Path(td))
+            parsed = read_sentinel(root)
+            self.assertIsNotNone(parsed)
+            self.assertEqual(parsed["version"], 1)
+            self.assertIs(parsed["enabled"], True)
+            self.assertEqual(parsed["fold_cap"], 3)
+            self.assertIsNone(parsed["project_number"])
+
+
+class TestMinimalYAMLParser(unittest.TestCase):
+    def test_bool_int_null_and_string(self) -> None:
+        text = (
+            "version: 1\n"
+            "enabled: true\n"
+            "fold_cap: 0\n"
+            "project_number: null\n"
+            'name: "pipeline"\n'
+        )
+        parsed = _parse_minimal_yaml(text)
+        self.assertEqual(parsed["version"], 1)
+        self.assertIs(parsed["enabled"], True)
+        self.assertEqual(parsed["fold_cap"], 0)
+        self.assertIsNone(parsed["project_number"])
+        self.assertEqual(parsed["name"], "pipeline")
+
+    def test_comments_ignored(self) -> None:
+        parsed = _parse_minimal_yaml("# comment\nversion: 1  # inline\n")
+        self.assertEqual(parsed, {"version": 1})
+
+
+class TestRenderBody(unittest.TestCase):
+    def test_full_body_matches_expected(self) -> None:
+        body = render_body({
+            "phase": "reviewer",
+            "pr_number": "42",
+            "run_id": "20260423-181000",
+            "reasoning": "Cross-cuts 4 files, adds new abstraction — Sonnet-tier.",
+            "summary": "Extract common error mapper for Grok client",
+            "context": (
+                "Reviewer surfaced duplicated error-to-user-message mapping in 4 "
+                "files during\nwave 2. A single mapper keeps the UX consistent "
+                "when the API changes."
+            ),
+            "acceptance": (
+                "A `GrokErrorMapper` class under `src/tools/grok_client.py` with "
+                "unit tests; callers refactored to use it."
+            ),
+        })
+        expected = (FIXTURES_DIR / "backlog-issue-body-expected.md").read_text()
+        self.assertEqual(body, expected)
+
+    def test_missing_pr_number_uses_pre_pr_placeholder(self) -> None:
+        body = render_body({"phase": "architect", "run_id": "x", "reasoning": "r"})
+        self.assertIn("**Deferred from:** (pre-PR", body)
+
+    def test_all_d8_fields_present(self) -> None:
+        body = render_body({
+            "phase": "token-analysis",
+            "pr_number": "99",
+            "run_id": "20260423",
+            "reasoning": "Because reasons",
+            "summary": "s",
+            "context": "c",
+        })
+        for fragment in ("**Deferred from:**", "**Phase:**", "**Run ID:**", "**Reasoning:**"):
+            self.assertIn(fragment, body)
+
+
+class TestFileBacklogIssue(unittest.TestCase):
+    BASE_CTX = {
+        "phase": "reviewer",
+        "pr_number": "42",
+        "run_id": "20260423-181000",
+        "reasoning": "r",
+        "summary": "s",
+        "context": "c",
+    }
+
+    def test_invalid_type_returns_failed(self) -> None:
+        r = file_backlog_issue(title="x", type="BOGUS", priority="p2", body_context=self.BASE_CTX)
+        self.assertEqual(r.status, "failed")
+        self.assertIn("invalid type", r.reason)
+
+    def test_invalid_priority_returns_failed(self) -> None:
+        r = file_backlog_issue(title="x", type="chore", priority="p9", body_context=self.BASE_CTX)
+        self.assertEqual(r.status, "failed")
+        self.assertIn("invalid priority", r.reason)
+
+    def test_missing_sentinel_returns_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_bare_repo(Path(td))
+            r = file_backlog_issue(
+                title="x", type="chore", priority="p2",
+                body_context=self.BASE_CTX, repo_root=root,
+            )
+            self.assertEqual(r.status, "skipped")
+            self.assertIn("not enabled", r.reason)
+
+    def test_disabled_sentinel_returns_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_opted_in_repo(Path(td), sentinel_src="sentinel-config-disabled.yml")
+            r = file_backlog_issue(
+                title="x", type="chore", priority="p2",
+                body_context=self.BASE_CTX, repo_root=root,
+            )
+            self.assertEqual(r.status, "skipped")
+            self.assertIn("disabled", r.reason)
+
+    def test_filed_happy_path_builds_correct_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_opted_in_repo(Path(td))
+            with patch("backlog_file.subprocess.run", return_value=_ok("https://github.com/o/r/issues/77")) as m:
+                r = file_backlog_issue(
+                    title="t", type="chore", priority="p2",
+                    body_context=self.BASE_CTX, repo_root=root,
+                )
+            self.assertEqual(r.status, "filed")
+            self.assertEqual(r.number, 77)
+            self.assertEqual(r.url, "https://github.com/o/r/issues/77")
+            cmd = m.call_args.args[0]
+            self.assertIn("type: chore", cmd)
+            self.assertIn("priority: p2", cmd)
+            self.assertIn("source: ai-deferred", cmd)
+
+    def test_failed_gh_retries_without_source_label(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_opted_in_repo(Path(td))
+            calls = []
+
+            def fake_run(cmd, **kwargs):
+                calls.append(cmd)
+                if "source: ai-deferred" in cmd:
+                    return _err("label not found")
+                return _ok("https://github.com/o/r/issues/88")
+
+            with patch("backlog_file.subprocess.run", side_effect=fake_run):
+                r = file_backlog_issue(
+                    title="t", type="chore", priority="p2",
+                    body_context=self.BASE_CTX, repo_root=root,
+                )
+            self.assertEqual(r.status, "filed")
+            self.assertEqual(r.number, 88)
+            self.assertEqual(len(calls), 2)
+
+    def test_persistent_gh_failure_returns_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = _make_opted_in_repo(Path(td))
+            with patch("backlog_file.subprocess.run", return_value=_err("network down")):
+                r = file_backlog_issue(
+                    title="t", type="chore", priority="p2",
+                    body_context=self.BASE_CTX, repo_root=root,
+                )
+            self.assertEqual(r.status, "failed")
+            self.assertIn("network down", r.reason)
+
+    def test_project_item_add_called_when_configured(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".git").mkdir()
+            (root / ".github").mkdir()
+            (root / ".github" / "pipeline-backlog.yml").write_text(
+                "version: 1\nenabled: true\nfold_cap: 3\nproject_number: 7\n"
+            )
+            calls = []
+
+            def fake_run(cmd, **kwargs):
+                calls.append(cmd)
+                if cmd[:3] == ["gh", "issue", "create"]:
+                    return _ok("https://github.com/o/r/issues/5")
+                return _ok("added")
+
+            with patch("backlog_file.subprocess.run", side_effect=fake_run):
+                r = file_backlog_issue(
+                    title="t", type="chore", priority="p2",
+                    body_context=self.BASE_CTX, repo_root=root,
+                )
+            self.assertEqual(r.status, "filed")
+            self.assertTrue(any(cmd[:3] == ["gh", "project", "item-add"] for cmd in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -107,6 +107,25 @@ class TestReviewerProtocol(unittest.TestCase):
         report = parse_token_report(fixture)
         self.assertIsNotNone(report)
 
+    def test_tagged_optional_suggestions(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-pass-with-optional-tagged.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["status"], "PASS")
+        suggestions = result["suggestions"]
+        self.assertEqual(len(suggestions), 2)
+        tags = {s["tag"] for s in suggestions}
+        self.assertEqual(tags, {"should-fix", "nice-to-have"})
+        for s in suggestions:
+            self.assertTrue(s["text"])
+            self.assertFalse(s["text"].startswith("["))
+
+    def test_untagged_entries_preserve_null_tag(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-fail.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        for entry in result["optional_improvements"]:
+            self.assertIn("tag", entry)
+            self.assertIn("text", entry)
+
 
 class TestBuildOutput(unittest.TestCase):
     def test_success_output(self) -> None:

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -85,6 +85,20 @@ REQUIRED_SKILLS = [
     "azure-drift-check/SKILL.md",
     "azure-login/SKILL.md",
     "update-pipeline/SKILL.md",
+    "bootstrap-backlog/SKILL.md",
+]
+
+REQUIRED_BACKLOG_TEMPLATES = [
+    "templates/backlog/ISSUE_TEMPLATE/bug_report.yml",
+    "templates/backlog/ISSUE_TEMPLATE/feature_request.yml",
+    "templates/backlog/ISSUE_TEMPLATE/chore.yml",
+    "templates/backlog/ISSUE_TEMPLATE/config.yml",
+    "templates/backlog/labels.yml",
+    "templates/backlog/pipeline-backlog.yml.template",
+]
+
+REQUIRED_SCRIPTS = [
+    "scripts/backlog_file.py",
 ]
 
 ESSENTIAL_OVERLAY_MAX_CHARS = 1000
@@ -199,6 +213,20 @@ def check_required_files(result: ValidationResult) -> None:
             result.ok(f"Template exists: {template}")
         else:
             result.fail(f"Missing template: {template}")
+
+    for backlog_template in REQUIRED_BACKLOG_TEMPLATES:
+        path = PIPELINE_ROOT / backlog_template
+        if path.exists():
+            result.ok(f"Backlog template exists: {backlog_template}")
+        else:
+            result.fail(f"Missing backlog template: {backlog_template}")
+
+    for script in REQUIRED_SCRIPTS:
+        path = PIPELINE_ROOT / script
+        if path.exists():
+            result.ok(f"Script exists: {script}")
+        else:
+            result.fail(f"Missing script: {script}")
 
 
 def check_adapter_completeness(result: ValidationResult) -> None:


### PR DESCRIPTION
## Summary

Closes #23. Adds opt-in backlog integration so out-of-scope items surfaced during `/orchestrate` runs are durably captured instead of evaporating between runs. Haiku-tier findings fold into the current run (subject to a configurable `fold_cap`); Sonnet/Opus-tier items defer as GitHub issues with a full traceability block (originating PR, phase, run ID, one-line reasoning).

Consumer repos opt in once by running `/bootstrap-backlog`, which provisions the label taxonomy, Issue Form YAMLs, and sentinel config.

## What changed

- **New skill** — `skills/bootstrap-backlog/SKILL.md`: provisions 12 namespaced labels via `gh label create --force`, copies 4 Issue Form YAMLs into `.github/ISSUE_TEMPLATE/`, writes `.github/pipeline-backlog.yml` sentinel. Idempotent.
- **New utility** — `scripts/backlog_file.py`: Python module + CLI. Opt-in detection (reads sentinel), body rendering with D8 traceability fields, `gh issue create` with retry-without-source-label fallback, optional `gh project item-add`. Returns structured `IssueResult` (`filed | skipped | failed`); never raises on the happy path.
- **New templates** — `templates/backlog/ISSUE_TEMPLATE/{bug_report,feature_request,chore,config}.yml`, `labels.yml` (12-label taxonomy per D1), `pipeline-backlog.yml.template`.
- **Reviewer protocol extension** — OPTIONAL IMPROVEMENTS entries now carry `[should-fix]` / `[nice-to-have]` tags so the orchestrator can classify fold-vs-defer. `tests/parsers.py` updated to parse them; new contract test + tagged fixture.
- **Planner** — new Step 7 (Classify Out-of-Scope Items) and a `Deferred Items` section in plan output.
- **Implementer contract** — new point 7 (LIMITED-INLINE-EXCEPTION): <5 LOC mechanical fixes allowed only in files already in the brief's file list. Mirrored in `implementer-agent.md` execution rules.
- **Orchestrate** — new Step 0.65 (run-ID + run-log.yml init), new "Backlog Integration" section (fold-vs-defer rule, fold-cap enforcement, run-log schema, PR "Folded in this run" checklist rendering), error-handling rows for backlog scenarios.
- **Token-analysis** — refactored inline `gh issue create` to call the shared utility; always-defer classification.
- **Dogfood** — pipeline repo now has `.github/ISSUE_TEMPLATE/` + sentinel; 13 labels provisioned on MILL5/claude-code-pipeline upstream.

## Key design decisions (resolved from issue Open Implementation Questions)

1. **Utility**: Python at `scripts/backlog_file.py` — matches adapter convention; handles YAML parsing natively.
2. **Run-log**: new `.claude/tmp/run-log.yml` — joins existing `1a-spec.md` / `1b-plan.md` recovery artifacts.
3. **Run-ID**: timestamp-based (`YYYYMMDD-HHMMSS`) at Step 1a; PR_NUMBER is supplementary once Step 1.5 runs.
4. **Fold-budget**: derived from `run-log.yml` (count entries with `action: folded`). Single source of truth, no counter drift.
5. **Reviewer severity**: inline `[should-fix]` / `[nice-to-have]` tags extend OPTIONAL IMPROVEMENTS.
6. **Trivial-inline enforcement**: advisory prompt-text in contract point 7, matching the existing contract style.
7. **PR strategy**: single PR for the whole feature.
8. **Dogfood**: same PR; labels on upstream, Issue Forms + sentinel committed.

## Test plan

All local tests green:
- [x] `python3 tests/validate_structure.py` — **330 checks pass**, 0 failures (includes new `bootstrap-backlog` skill, `templates/backlog/` paths, and `scripts/backlog_file.py`).
- [x] `python3 tests/test_contracts.py` — **59 tests pass** (57 original + 2 new for tagged severity parsing).
- [x] `python3 tests/test_backlog_utility.py` — **17 unit tests pass** (opt-in detection, minimal-YAML fallback, body rendering, label composition, retry fallback, project item-add).
- [x] `python3 tests/test_backlog_integration.py` — **13 integration tests pass** (opt-in detection, fold-cap enforcement at 0/3/across-phases, D8 traceability, bootstrap idempotency, sentinel-not-overwritten).
- [x] `python3 tests/smoke/run_smoke.py` — **37 smoke checks pass** (init.sh + scripts still boot).

DoD checklist to verify before merging:
- [x] `/bootstrap-backlog` skill exists and is discoverable (`validate_structure.py` requires it).
- [x] Clean bootstrap produces: 12 labels, 4 Issue Forms, 1 sentinel.
- [x] Re-run produces zero filesystem diff (integration test `test_issue_form_copies_are_byte_identical`).
- [x] Utility applies `type:*`, `priority:*`, `source: ai-deferred` labels.
- [x] Opt-in detection: file when sentinel present; skip when absent.
- [x] Skip hint emitted once per run (orchestrate SKILL.md documents single-hint rule).
- [x] Run-log `backlog_decisions` array populated per fold/defer decision (orchestrate Backlog Integration section).
- [x] Fold cap supports 0 (always defer) and N (integration test covers).
- [x] Deferred items include D8 traceability fields (integration test asserts).
- [x] Implementer contract point 7 added and cross-referenced in implementer-agent.md.
- [x] README "Opting in to Backlog Integration" section with worked example.
- [x] Pipeline repo bootstrapped (dogfood): labels, templates, sentinel all present and committed.
- [x] No raw GraphQL usage in any new code.

Recommended manual verification after merge:
- [ ] Open a test issue in the GitHub UI against this repo — confirm Issue Forms render and labels auto-apply.
- [ ] Run `/orchestrate` in a consumer repo with a deliberately-under-scoped brief, verify that `[should-fix]` items with Haiku-tier fixes fold into the run (up to fold_cap) and Sonnet-tier items file as issues with correct labels and traceability.
- [ ] Run `/orchestrate` in a consumer without a sentinel — verify one hint line, no errors, no filings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)