### PR TITLE
fix(react-adapter): resilient vitest/jest JSON parsing and text fallback

### DIFF
--- a/adapters/react/scripts/test.py
+++ b/adapters/react/scripts/test.py
@@ -128,7 +128,14 @@ def run_tests(project_dir, pm, framework, scheme=None, coverage=True):
                     cmd = ["npm", "run", scheme, "--"]
 
                 if framework == "vitest":
-                    cmd += ["--reporter=json", f"--outputFile={json_output_path}"]
+                    # Keep default reporter active so parse_fallback has text to match
+                    # if JSON parsing fails. --outputFile.json disambiguates output
+                    # when multiple reporters are active.
+                    cmd += [
+                        "--reporter=default",
+                        "--reporter=json",
+                        f"--outputFile.json={json_output_path}",
+                    ]
                     if coverage:
                         cmd += ["--coverage", "--coverage.reporter=json"]
                 else:
@@ -156,7 +163,11 @@ def run_tests(project_dir, pm, framework, scheme=None, coverage=True):
         else:
             cmd = ["npx", "vitest", "run"]
 
-        cmd += ["--reporter=json", f"--outputFile={json_output_path}"]
+        cmd += [
+            "--reporter=default",
+            "--reporter=json",
+            f"--outputFile.json={json_output_path}",
+        ]
         if coverage:
             cmd += ["--coverage", "--coverage.reporter=json"]
     else:
@@ -186,12 +197,12 @@ def run_tests(project_dir, pm, framework, scheme=None, coverage=True):
 # Result parsing
 # ---------------------------------------------------------------------------
 
-def parse_jest_json(json_path, raw_output):
+def parse_jest_json(json_path, raw_output, diagnostics=None):
     """
     Parse Jest JSON output.
-    Returns (total, passed, failed, skipped, test_suites, failures).
+    Returns same shape as parse_vitest_json.
     """
-    data = _load_json_results(json_path, raw_output)
+    data = _load_json_results(json_path, raw_output, diagnostics)
     if not data:
         return None
 
@@ -224,12 +235,12 @@ def parse_jest_json(json_path, raw_output):
     }
 
 
-def parse_vitest_json(json_path, raw_output):
+def parse_vitest_json(json_path, raw_output, diagnostics=None):
     """
     Parse Vitest JSON output.
     Returns same shape as parse_jest_json.
     """
-    data = _load_json_results(json_path, raw_output)
+    data = _load_json_results(json_path, raw_output, diagnostics)
     if not data:
         return None
 
@@ -282,15 +293,29 @@ def parse_vitest_json(json_path, raw_output):
     }
 
 
-def _load_json_results(json_path, raw_output):
-    """Try to load JSON from file, then from raw output as fallback."""
-    # Try the JSON output file first
+def _load_json_results(json_path, raw_output, diagnostics=None):
+    """Try to load JSON from file, then from raw output as fallback.
+
+    If ``diagnostics`` is a list, appends human-readable reasons when the
+    JSON file exists but can't be parsed — so failures don't vanish silently.
+    """
     if json_path and os.path.exists(json_path):
         try:
             with open(json_path) as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError):
-            pass
+                content = f.read()
+            stripped = content.strip()
+            if not stripped:
+                if diagnostics is not None:
+                    diagnostics.append(f"JSON output file is empty: {json_path}")
+            else:
+                try:
+                    return json.loads(stripped)
+                except json.JSONDecodeError as e:
+                    if diagnostics is not None:
+                        diagnostics.append(f"JSON output file is malformed ({e}): {json_path}")
+        except IOError as e:
+            if diagnostics is not None:
+                diagnostics.append(f"Could not read JSON output file ({e}): {json_path}")
 
     # Fallback: try to extract JSON from raw output
     # Jest sometimes writes JSON to stdout
@@ -327,27 +352,41 @@ def parse_fallback(raw_output):
     skipped = 0
     failures = []
 
-    # Jest text summary: Tests: X failed, Y passed, Z total
-    jest_summary = re.search(
-        r"Tests:\s+(?:(\d+)\s+failed,?\s*)?(?:(\d+)\s+skipped,?\s*)?(?:(\d+)\s+passed,?\s*)?(\d+)\s+total",
-        raw_output,
-    )
-    if jest_summary:
-        failed = int(jest_summary.group(1) or 0)
-        skipped = int(jest_summary.group(2) or 0)
-        passed = int(jest_summary.group(3) or 0)
-        total = int(jest_summary.group(4) or 0)
+    # Jest summary line: "Tests:   2 failed, 3 passed, 5 total"
+    # Token-based parse so any ordering of failed/passed/skipped works.
+    jest_summary_line = re.search(r"^\s*Tests:.*?\btotal\b", raw_output, re.MULTILINE)
+    if jest_summary_line:
+        line = jest_summary_line.group(0)
+        for m in re.finditer(r"(\d+)\s+(failed|passed|skipped|todo|total)", line):
+            n, kind = int(m.group(1)), m.group(2)
+            if kind == "failed":
+                failed = n
+            elif kind == "passed":
+                passed = n
+            elif kind in ("skipped", "todo"):
+                skipped += n
+            elif kind == "total":
+                total = n
 
-    # Vitest text summary: Tests  X failed | Y passed (Z)
-    vitest_summary = re.search(
-        r"Tests\s+(?:(\d+)\s+failed\s*\|?\s*)?(?:(\d+)\s+skipped\s*\|?\s*)?(?:(\d+)\s+passed)?\s*\((\d+)\)",
-        raw_output,
-    )
-    if vitest_summary and total == 0:
-        failed = int(vitest_summary.group(1) or 0)
-        skipped = int(vitest_summary.group(2) or 0)
-        passed = int(vitest_summary.group(3) or 0)
-        total = int(vitest_summary.group(4) or 0)
+    # Vitest summary line: "Tests  2 failed | 3 passed (5)" or "Tests  5 passed (5)"
+    # Token-based parse; the "(N)" at the end is authoritative for the total.
+    if total == 0:
+        vitest_summary_line = re.search(
+            r"^\s*Tests\s+.*?\(\s*\d+\s*\)\s*$", raw_output, re.MULTILINE,
+        )
+        if vitest_summary_line:
+            line = vitest_summary_line.group(0)
+            for m in re.finditer(r"(\d+)\s+(failed|passed|skipped|todo)", line):
+                n, kind = int(m.group(1)), m.group(2)
+                if kind == "failed":
+                    failed = n
+                elif kind == "passed":
+                    passed = n
+                elif kind in ("skipped", "todo"):
+                    skipped += n
+            paren = re.search(r"\(\s*(\d+)\s*\)\s*$", line)
+            if paren:
+                total = int(paren.group(1))
 
     # Extract failure details from text output
     fail_pattern = re.compile(r"(?:FAIL|FAILED)\s+([^\n]+)\n([\s\S]*?)(?=(?:FAIL|PASS|Test Suites:|$))")
@@ -637,11 +676,13 @@ def main():
         coverage=collect_coverage,
     )
 
-    # Parse results
+    # Parse results. Collect JSON-load diagnostics so we can report why parsing
+    # failed (empty file, malformed JSON) rather than silently falling through.
+    json_diagnostics = []
     if framework == "vitest":
-        results = parse_vitest_json(json_path, raw_output)
+        results = parse_vitest_json(json_path, raw_output, json_diagnostics)
     else:
-        results = parse_jest_json(json_path, raw_output)
+        results = parse_jest_json(json_path, raw_output, json_diagnostics)
 
     # Fallback to text parsing if JSON didn't work
     if not results or results["total"] == 0:
@@ -653,34 +694,46 @@ def main():
         exclude_patterns=args.exclude_from_coverage,
     ) if collect_coverage else None
 
-    # Clean up JSON output file
+    print_table(results, coverage=coverage)
+
+    parsed_ok = bool(results) and results["total"] > 0
+
+    # Diagnostic output when no results were parsed OR the test runner exited
+    # non-zero despite parsed results (coverage threshold, setup warnings, etc.).
+    needs_diagnostic = (not parsed_ok) or returncode != 0
+    if needs_diagnostic:
+        print("\n--- Diagnostic Info ---")
+        if returncode != 0:
+            print(f"Test runner returned exit code {returncode}")
+        if not parsed_ok:
+            print("Tests ran but no results were parsed.")
+        for diag in json_diagnostics:
+            print(diag)
+        if json_path and os.path.exists(json_path):
+            print(f"JSON output file preserved for inspection: {json_path}")
+
+        lines = raw_output.strip().splitlines()
+        # Only strip deep-nested stack frames ("    at ... node_modules/..."),
+        # not top-level error messages that happen to mention node_modules —
+        # those are often the only clue to vitest setup failures.
+        node_stack_re = re.compile(r"^\s+at\s+.*node_modules/")
+        filtered = [l for l in lines if l.strip() and not node_stack_re.match(l)]
+        display = filtered if filtered else lines
+        print("\nLast 50 lines of output:")
+        print("\n".join(display[-50:]))
+
+    # Clean up JSON output file last, so diagnostics above can reference it.
     if json_path and os.path.exists(json_path):
         try:
             os.remove(json_path)
         except OSError:
             pass
 
-    print_table(results, coverage=coverage)
-
-    # Diagnostic output when no results were parsed
-    if not results or results["total"] == 0:
-        print("\n--- Diagnostic Info ---")
-        if returncode != 0:
-            print(f"Test runner returned exit code {returncode}")
-        else:
-            print("Tests ran but no results were parsed.")
-
-        lines = raw_output.strip().splitlines()
-        # Filter node_modules noise
-        filtered = [l for l in lines if "node_modules/" not in l and l.strip()]
-        display = filtered if filtered else lines
-        print("\nLast 50 lines of output:")
-        print("\n".join(display[-50:]))
-
-        if returncode != 0:
-            sys.exit(1)
-        return
-
+    # Exit 1 only when we genuinely can't parse results or there are failures.
+    # A non-zero returncode with passing tests (e.g. coverage threshold warning)
+    # should not mask a successful run.
+    if not parsed_ok:
+        sys.exit(1)
     if results["failed"] > 0:
         sys.exit(1)
 

--- a/tests/fixtures/jest-text-mixed.txt
+++ b/tests/fixtures/jest-text-mixed.txt
@@ -1,0 +1,9 @@
+PASS  src/smoke.test.ts
+FAIL  src/components/CoinTile.test.tsx
+  ● CoinTile › shows price
+    AssertionError: expected 'BTC' to equal 'ETH'
+
+Test Suites: 1 failed, 1 passed, 2 total
+Tests:       2 failed, 3 passed, 5 total
+Snapshots:   0 total
+Time:        1.234 s

--- a/tests/fixtures/vitest-results.json
+++ b/tests/fixtures/vitest-results.json
@@ -1,0 +1,39 @@
+{
+  "numTotalTestSuites": 2,
+  "numPassedTestSuites": 1,
+  "numFailedTestSuites": 1,
+  "numTotalTests": 5,
+  "numPassedTests": 3,
+  "numFailedTests": 2,
+  "numPendingTests": 0,
+  "numTodoTests": 0,
+  "testResults": [
+    {
+      "name": "/abs/path/frontend/src/smoke.test.ts",
+      "status": "passed",
+      "assertionResults": [
+        {"status": "passed", "ancestorTitles": [], "title": "renders"},
+        {"status": "passed", "ancestorTitles": [], "title": "adds numbers"},
+        {"status": "passed", "ancestorTitles": [], "title": "handles empty"}
+      ]
+    },
+    {
+      "name": "/abs/path/frontend/src/components/CoinTile.test.tsx",
+      "status": "failed",
+      "assertionResults": [
+        {
+          "status": "failed",
+          "ancestorTitles": ["CoinTile"],
+          "title": "shows price",
+          "failureMessages": ["AssertionError: expected 'BTC' to equal 'ETH'\n    at /abs/path/node_modules/vitest/dist/index.js:42"]
+        },
+        {
+          "status": "failed",
+          "ancestorTitles": ["CoinTile"],
+          "title": "handles missing data",
+          "failureMessages": ["TypeError: Cannot read properties of undefined"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/vitest-text-mixed.txt
+++ b/tests/fixtures/vitest-text-mixed.txt
@@ -1,0 +1,13 @@
+ RUN  v2.1.9 /abs/path/frontend
+
+ ✓ src/smoke.test.ts (3)
+ ❯ src/components/CoinTile.test.tsx (2) [FAIL]
+   ✗ CoinTile > shows price
+     AssertionError: expected 'BTC' to equal 'ETH'
+   ✗ CoinTile > handles missing data
+     TypeError: Cannot read properties of undefined
+
+ Test Files  1 failed | 1 passed (2)
+      Tests  2 failed | 3 passed (5)
+   Start at  10:00:00
+   Duration  1.45s

--- a/tests/fixtures/vitest-text-success.txt
+++ b/tests/fixtures/vitest-text-success.txt
@@ -1,0 +1,12 @@
+ RUN  v2.1.9 /abs/path/frontend
+
+ ✓ src/smoke.test.ts (2)
+ ✓ src/components/CoinTile.test.tsx (1)
+ ✓ src/components/CoinDetail.test.tsx (2)
+
+ Test Files  3 passed (3)
+      Tests  5 passed (5)
+   Start at  10:00:00
+   Duration  1.23s (transform 123ms, setup 45ms, collect 89ms, tests 234ms)
+
+JSON report written to /abs/path/frontend/.pipeline-test-results.json

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -507,5 +507,102 @@ class TestPythonAdapterParseResults(unittest.TestCase):
         self.assertEqual((total, passed, failed, errors), (4, 0, 3, 1))
 
 
+class TestReactAdapterParsers(unittest.TestCase):
+    """Regression tests for parsers in adapters/react/scripts/test.py.
+
+    Covers the vitest/jest JSON parsers, the text-summary fallback, and the
+    JSON-load diagnostic capture. Issue #26: the test runner swallowed green
+    vitest runs because --reporter=json suppresses the text summary, the
+    JSON file occasionally fails to parse, and the fallback regex required a
+    fixed token order.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+        adapter_path = Path(__file__).resolve().parent.parent / "adapters/react/scripts/test.py"
+        spec = importlib.util.spec_from_file_location("_react_test_adapter", adapter_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls._mod = mod
+
+    def test_vitest_json_mixed_results(self) -> None:
+        fixture = str(FIXTURES_DIR / "vitest-results.json")
+        result = self._mod.parse_vitest_json(fixture, "")
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 3)
+        self.assertEqual(result["failed"], 2)
+        self.assertEqual(len(result["failures"]), 2)
+        self.assertIn("CoinTile", result["failures"][0]["test"])
+
+    def test_jest_json_uses_top_level_counts(self) -> None:
+        # Jest & vitest share the same JSON shape; parse_jest_json relies on
+        # the numTotalTests/numPassedTests/numFailedTests top-level keys.
+        fixture = str(FIXTURES_DIR / "vitest-results.json")
+        result = self._mod.parse_jest_json(fixture, "")
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 3)
+        self.assertEqual(result["failed"], 2)
+
+    def test_fallback_vitest_success(self) -> None:
+        fixture = (FIXTURES_DIR / "vitest-text-success.txt").read_text()
+        result = self._mod.parse_fallback(fixture)
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 5)
+        self.assertEqual(result["failed"], 0)
+
+    def test_fallback_vitest_mixed_order_independent(self) -> None:
+        fixture = (FIXTURES_DIR / "vitest-text-mixed.txt").read_text()
+        result = self._mod.parse_fallback(fixture)
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 3)
+        self.assertEqual(result["failed"], 2)
+
+    def test_fallback_vitest_passed_before_failed(self) -> None:
+        # Reversed token order — old regex dropped 'failed' when it came
+        # after 'passed'. Token-based parse must handle either order.
+        text = """ Test Files  1 failed | 1 passed (2)
+      Tests  3 passed | 2 failed (5)
+"""
+        result = self._mod.parse_fallback(text)
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 3)
+        self.assertEqual(result["failed"], 2)
+
+    def test_fallback_jest_failed_before_passed(self) -> None:
+        fixture = (FIXTURES_DIR / "jest-text-mixed.txt").read_text()
+        result = self._mod.parse_fallback(fixture)
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["passed"], 3)
+        self.assertEqual(result["failed"], 2)
+
+    def test_load_json_empty_file_records_diagnostic(self) -> None:
+        import tempfile, os as _os
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            empty_path = f.name
+        try:
+            diagnostics: list[str] = []
+            result = self._mod._load_json_results(empty_path, "", diagnostics)
+            self.assertIsNone(result)
+            self.assertEqual(len(diagnostics), 1)
+            self.assertIn("empty", diagnostics[0].lower())
+        finally:
+            _os.remove(empty_path)
+
+    def test_load_json_malformed_records_diagnostic(self) -> None:
+        import tempfile, os as _os
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            f.write("{ not valid json")
+            bad_path = f.name
+        try:
+            diagnostics: list[str] = []
+            result = self._mod._load_json_results(bad_path, "", diagnostics)
+            self.assertIsNone(result)
+            self.assertEqual(len(diagnostics), 1)
+            self.assertIn("malformed", diagnostics[0].lower())
+        finally:
+            _os.remove(bad_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #26 — `adapters/react/scripts/test.py` reported failure for green vitest runs due to four compounding bugs:

1. `--reporter=json` replaced the default reporter, so the text summary that `parse_fallback` needs was never printed.
2. When the JSON output file was empty or malformed, `_load_json_results` silently returned `None` — no diagnostic explaining why.
3. The diagnostic filter stripped any line containing `node_modules/`, hiding the vitest setup errors (e.g. `expect is not defined` from `@testing-library/jest-dom`) that were often the only clue to the real problem.
4. A non-zero exit from vitest (coverage threshold failure, setup warning) was treated as a test failure even when the JSON results showed all tests passed.

## Changes

**`adapters/react/scripts/test.py`**
- `run_tests()` — use `--reporter=default --reporter=json --outputFile.json=<path>` for vitest so both text summary and JSON file are produced.
- `_load_json_results()` — accepts optional `diagnostics` list that captures empty / malformed / unreadable JSON file errors.
- `parse_fallback()` — token-based parsing; handles `N failed | M passed` or `M passed | N failed` in either order (same pattern as the python adapter fix in #18).
- `main()` — only strip deep stack frames (`    at ... node_modules/...`) from diagnostics; preserve JSON file until after diagnostics print; exit 0 when tests parsed OK and `failed == 0` even if vitest returned non-zero.

**`tests/test_contracts.py`**
- New `TestReactAdapterParsers` class (8 tests) covering JSON parsers, text fallback for both orderings, and empty/malformed file diagnostics.

**Fixtures**
- `vitest-results.json`, `vitest-text-success.txt`, `vitest-text-mixed.txt`, `jest-text-mixed.txt`

No overlay or agent changes — script-only fix.

## Test plan

- [x] `python3 tests/test_contracts.py -v` — 67 tests pass (8 new)
- [x] `python3 tests/validate_structure.py` — 330 checks pass
- [ ] Manual: in a consumer repo with the react adapter on vitest, confirm `python3 .claude/scripts/react/test.py --project-dir frontend` reports `Summary: Total: N, Passed: N, Failed: 0 | Coverage: X.X%` for a green suite
- [ ] Manual: verify failures produce the failure table with suite/test/message details

🤖 Generated with [Claude Code](https://claude.com/claude-code)