### PR TITLE
fix(bicep-adapter): use --file flag for az bicep build

### DIFF
--- a/adapters/bicep/scripts/build.py
+++ b/adapters/bicep/scripts/build.py
@@ -93,7 +93,11 @@ def run_bicep_build(project_dir, bicep_files, bicep_cmd):
     all_output = []
 
     for bicep_file in bicep_files:
-        cmd = bicep_cmd + ["build", bicep_file]
+        # `az bicep build` requires --file; standalone `bicep build` takes positional.
+        if bicep_cmd[0] == "az":
+            cmd = bicep_cmd + ["build", "--file", bicep_file]
+        else:
+            cmd = bicep_cmd + ["build", bicep_file]
         print(f"Running: {' '.join(cmd)}")
 
         result = subprocess.run(

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -507,6 +507,53 @@ class TestPythonAdapterParseResults(unittest.TestCase):
         self.assertEqual((total, passed, failed, errors), (4, 0, 3, 1))
 
 
+class TestBicepAdapterBuildCommand(unittest.TestCase):
+    """Regression tests for run_bicep_build() command construction.
+
+    Issue #25: `az bicep build` requires `--file <path>` but the runner was
+    passing the file positionally, which works for the standalone `bicep` CLI
+    but fails under `az bicep build`.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+        adapter_path = Path(__file__).resolve().parent.parent / "adapters/bicep/scripts/build.py"
+        spec = importlib.util.spec_from_file_location("_bicep_build_adapter", adapter_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls._mod = mod
+
+    def _capture(self, bicep_cmd):
+        """Run run_bicep_build with subprocess.run stubbed; return the cmd list."""
+        captured: list[list[str]] = []
+
+        class _FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return _FakeResult()
+
+        original = self._mod.subprocess.run
+        self._mod.subprocess.run = _fake_run
+        try:
+            self._mod.run_bicep_build(".", ["main.bicep"], bicep_cmd)
+        finally:
+            self._mod.subprocess.run = original
+        return captured[0]
+
+    def test_az_driver_uses_file_flag(self) -> None:
+        cmd = self._capture(["az", "bicep"])
+        self.assertEqual(cmd, ["az", "bicep", "build", "--file", "main.bicep"])
+
+    def test_standalone_driver_uses_positional(self) -> None:
+        cmd = self._capture(["bicep"])
+        self.assertEqual(cmd, ["bicep", "build", "main.bicep"])
+
+
 class TestReactAdapterParsers(unittest.TestCase):
     """Regression tests for parsers in adapters/react/scripts/test.py.
 


### PR DESCRIPTION
## Summary

Fixes #25 — `run_bicep_build` in `adapters/bicep/scripts/build.py` passed the bicep file positionally (`bicep_cmd + ["build", bicep_file]`), which works for the standalone `bicep` CLI but fails under `az bicep build`, which requires `--file <path>` and rejects the positional form. On a machine where only the Azure CLI is installed, every `.bicep` compile aborted with an argparse error before any diagnostics could be collected.

## Changes

**`adapters/bicep/scripts/build.py`**
- `run_bicep_build()` — branch on `bicep_cmd[0]`: if `az`, emit `["az", "bicep", "build", "--file", <path>]`; else keep the positional form. Matches the pattern already used in `run_bicep_lint` (line 140).

**`tests/test_contracts.py`**
- New `TestBicepAdapterBuildCommand` class — stubs `subprocess.run` and asserts the constructed command for both drivers.

## Test plan

- [x] `python3 tests/test_contracts.py -v` — 69 tests pass (2 new)
- [x] `python3 tests/validate_structure.py` — 330 checks pass
- [ ] Manual: on a machine with only Azure CLI (no standalone bicep), run `python3 .claude/scripts/bicep/build.py` against a project with `.bicep` files and confirm compilation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)