### PR TITLE
fix(pipeline): support clone installs in /update-pipeline; honor venv in python adapter

### DIFF
--- a/adapters/python/scripts/test.py
+++ b/adapters/python/scripts/test.py
@@ -15,6 +15,41 @@ import re
 import argparse
 import os
 import json
+import shutil
+
+
+# ---------------------------------------------------------------------------
+# Interpreter selection
+# ---------------------------------------------------------------------------
+
+def _python_cmd(project_dir):
+    """Return the Python interpreter command prefix for this project.
+
+    Resolution order — first match wins:
+      1. ``<project_dir>/.venv/bin/python`` (or ``Scripts/python.exe`` on Windows)
+      2. ``<project_dir>/venv/bin/python``  (or ``Scripts/python.exe`` on Windows)
+      3. ``uv run python`` if ``uv`` is on PATH and ``pyproject.toml`` is present
+      4. system ``python3``
+
+    Why: bare ``python3`` resolves to the system interpreter, which won't see project
+    deps installed in a project-local virtual environment (uv, poetry, plain ``venv``).
+    Pointing at the venv's interpreter directly works for any venv flavor and avoids a
+    hard dependency on uv being present.
+    """
+    venv_python_rel = (
+        os.path.join("Scripts", "python.exe") if os.name == "nt"
+        else os.path.join("bin", "python")
+    )
+    for venv_dir in (".venv", "venv"):
+        candidate = os.path.join(project_dir, venv_dir, venv_python_rel)
+        if os.path.isfile(candidate):
+            return [candidate]
+
+    if (shutil.which("uv") and
+            os.path.isfile(os.path.join(project_dir, "pyproject.toml"))):
+        return ["uv", "run", "python"]
+
+    return ["python3"]
 
 
 # ---------------------------------------------------------------------------
@@ -34,10 +69,11 @@ def detect_test_config(project_dir):
     pyproject_path = os.path.join(project_dir, "pyproject.toml")
     setup_cfg_path = os.path.join(project_dir, "setup.cfg")
 
-    # Check for pytest-cov availability
+    # Check for pytest-cov availability — use the project's interpreter so a venv
+    # installation of pytest-cov is detected even when the system python3 lacks it.
     try:
         result = subprocess.run(
-            ["python3", "-c", "import pytest_cov"],
+            _python_cmd(project_dir) + ["-c", "import pytest_cov"],
             cwd=project_dir, capture_output=True, text=True, check=False
         )
         info["has_pytest_cov"] = result.returncode == 0
@@ -125,7 +161,7 @@ def detect_test_config(project_dir):
 
 def run_tests(project_dir, scheme=None, coverage=True, exclude_patterns=None, test_config=None):
     """Run pytest and return (stdout+stderr, returncode, coverage_json_path)."""
-    cmd = ["python3", "-m", "pytest", "--tb=short", "-q"]
+    cmd = _python_cmd(project_dir) + ["-m", "pytest", "--tb=short", "-q"]
 
     # Add coverage flags if enabled and pytest-cov is available
     coverage_json_path = None

--- a/skills/update-pipeline/SKILL.md
+++ b/skills/update-pipeline/SKILL.md
@@ -11,27 +11,39 @@ description: >
 
 Updates the pipeline submodule to the latest version with validation and automatic rollback on failure.
 
-## Step 1: Locate Pipeline
+## Step 1: Locate Pipeline and Detect Install Mode
 
-1. Check if `.gitmodules` exists in the project root.
-2. If it exists, find the submodule entry whose `path` matches the pipeline (look for a path
-   that contains `pipeline` or matches the `pipeline_root` from `.claude/pipeline.config`).
-3. Extract the submodule `path` (e.g., `pipeline` or `.claude/pipeline`).
-4. If `.gitmodules` does not exist or no pipeline submodule is found:
-   - Read `pipeline_root` from `.claude/pipeline.config`
-   - **Resolve:** if `pipeline_root` does not start with `/`, resolve it against the project root (the directory containing `.claude/`).
-   - Check if that path is a git repository (`git -C <path> rev-parse --is-inside-work-tree`)
-   - If it is a plain clone (not a submodule), inform the user:
-     "Pipeline is not installed as a submodule. To update manually:
-     `cd <pipeline_root> && git pull origin main`
-     Then re-run `bash <pipeline_root>/init.sh . --force` if init.sh changed."
-   - Stop here.
+The skill works for all three install types. Detect which is in use so Step 7 can commit
+correctly (or skip the commit) at the end.
+
+1. Read `pipeline_root` from `.claude/pipeline.config`. If `pipeline_root` does not start
+   with `/`, resolve it against the project root (the directory containing `.claude/`).
+   Record as `PIPELINE_PATH`.
+2. If `PIPELINE_PATH/.git` does not exist, abort: "Pipeline not installed at `<PIPELINE_PATH>`.
+   Re-run the bootstrap from the pipeline repo."
+3. Classify `INSTALL_MODE`:
+   - **`submodule`** — `.gitmodules` exists at the project root AND contains a submodule
+     entry whose `path` matches `PIPELINE_PATH` (relative to project root). Record that
+     relative path as `SUBMODULE_PATH` for Step 7.
+   - **`submodule-orphaned`** — `PIPELINE_PATH/.git` is a **file** (a gitlink pointing at
+     the parent repo's `modules/...` directory) AND `.gitmodules` is missing or has no
+     matching entry. The parent repo has a stale submodule reference but the registration
+     was lost. Warn the user: "Submodule registration at `<PIPELINE_PATH>` is inconsistent —
+     `.git` is a gitlink but `.gitmodules` has no entry. Update will proceed in clone-semantics
+     mode (no submodule bump will be committed). To repair, run:
+     `git submodule add <pipeline_remote_url> <PIPELINE_PATH>` after the update completes."
+     Treat this mode as `clone` for Step 7 purposes.
+   - **`clone`** — `PIPELINE_PATH/.git` is a **directory** (a full clone). No submodule
+     tracking, no parent-repo commit needed at the end.
+
+Steps 2–6 below run identically for all three modes, operating on `PIPELINE_PATH`. Only
+Step 7 branches on `INSTALL_MODE`.
 
 ## Step 2: Pre-Flight Checks
 
-1. `cd <submodule_path>`
+1. `cd <PIPELINE_PATH>`
 2. Check for uncommitted changes: `git status --porcelain`
-   - If dirty, abort: "Pipeline submodule has uncommitted changes. Commit or discard them first."
+   - If dirty, abort: "Pipeline has uncommitted changes. Commit or discard them first."
 3. Record current state:
    ```
    OLD_SHA=$(git rev-parse HEAD)
@@ -49,8 +61,8 @@ Updates the pipeline submodule to the latest version with validation and automat
 3. Attempt fast-forward merge: `git merge origin/$BRANCH --ff-only`
 4. If merge fails (non-fast-forward):
    - Warn the user: "Pipeline has diverged from the remote branch. This usually means local
-     changes were made to the submodule. Resolve manually with:
-     `cd <submodule_path> && git log --oneline origin/$BRANCH..HEAD` to see local commits."
+     changes were made to the pipeline checkout. Resolve manually with:
+     `cd <PIPELINE_PATH> && git log --oneline origin/$BRANCH..HEAD` to see local commits."
    - Abort — do NOT force-reset.
 
 ## Step 4: Show Changelog
@@ -78,17 +90,17 @@ Updates the pipeline submodule to the latest version with validation and automat
    ```
 2. If `OLD_INIT_SHA != NEW_INIT_SHA`:
    - Inform user: "init.sh has changed — re-running bootstrap to update config and symlinks."
-   - Run: `bash <submodule_path>/init.sh <project_root> --force`
+   - Run: `bash <PIPELINE_PATH>/init.sh <project_root> --force`
    - Report the init.sh output.
 3. Regardless of init.sh changes, check for new local templates:
-   - For each file in `<submodule_path>/templates/local/*.template`:
+   - For each file in `<PIPELINE_PATH>/templates/local/*.template`:
      - Extract the base name (e.g., `project-overlay.md` from `project-overlay.md.template`)
      - If `.claude/local/<base_name>` does not exist, copy the template
      - Report any new files created
 
 ## Step 6: Validate
 
-1. Run structural validation: `python3 <submodule_path>/tests/validate_structure.py`
+1. Run structural validation: `python3 <PIPELINE_PATH>/tests/validate_structure.py`
 2. If validation **passes**: proceed to Step 7.
 3. If validation **fails**:
    - Show the failure output to the user.
@@ -97,17 +109,22 @@ Updates the pipeline submodule to the latest version with validation and automat
    - Ask the user: "Would you like to roll back to the previous version ($OLD_VERSION, $OLD_SHA)?"
    - If user says **yes**:
      ```
-     cd <submodule_path>
+     cd <PIPELINE_PATH>
      git checkout $OLD_SHA
      ```
      Report: "Rolled back to $OLD_VERSION."
    - If user says **no**: proceed without committing. Report: "Keeping new version but NOT
-     committing. Fix the validation issues, then run `git add <submodule_path> && git commit`."
+     committing. Fix the validation issues, then (for submodule installs) run
+     `git add <SUBMODULE_PATH> && git commit`."
 
-## Step 7: Commit Submodule Bump
+## Step 7: Commit (submodule mode only)
+
+Behavior branches on the `INSTALL_MODE` captured in Step 1.
+
+### `INSTALL_MODE=submodule`
 
 1. Return to project root: `cd <project_root>`
-2. Stage the submodule: `git add <submodule_path>`
+2. Stage the submodule: `git add <SUBMODULE_PATH>`
 3. If init.sh was re-run (Step 5), also stage any changed config files:
    ```
    git add .claude/pipeline.config .claude/settings.json
@@ -122,6 +139,20 @@ Updates the pipeline submodule to the latest version with validation and automat
    - "Commit created but NOT pushed. Review the changes, then push when ready."
    - If init.sh was re-run: "Config and symlinks were also updated."
 
+### `INSTALL_MODE=clone` or `INSTALL_MODE=submodule-orphaned`
+
+No parent-repo submodule bump to commit — the pipeline checkout at `<PIPELINE_PATH>` is not
+registered as a submodule in this project.
+
+1. If init.sh was re-run (Step 5), the config and symlinks in `.claude/` may have changed.
+   Remind the user: "init.sh re-ran — review `git status` and commit any changes under
+   `.claude/` yourself if they should be tracked."
+2. Report:
+   - "Pipeline updated at `<PIPELINE_PATH>`: $OLD_VERSION → $NEW_VERSION"
+   - "No submodule bump committed — pipeline is a `<INSTALL_MODE>` install."
+   - For `submodule-orphaned`: repeat the repair hint from Step 1 so the user can fix the
+     inconsistency at their leisure.
+
 ## Error Handling
 
 - **Network failure during fetch**: Report the error and suggest the user check connectivity.
@@ -129,6 +160,7 @@ Updates the pipeline submodule to the latest version with validation and automat
 - **Validation failure**: Always offer rollback. Never auto-commit a broken state.
 - **Missing VERSION file**: Treat version as "unknown" — the skill still works, just without
   version numbers in messages.
-- **Submodule at unexpected path**: The skill discovers the path from `.gitmodules`, so it
-  works regardless of where the submodule is located (e.g., `pipeline/`, `.claude/pipeline/`,
-  `tools/pipeline/`).
+- **Pipeline at unexpected path**: The skill reads `pipeline_root` from
+  `.claude/pipeline.config` and resolves it against the project root, so it works regardless
+  of where the pipeline lives (e.g., `pipeline/`, `.claude/pipeline/`, `tools/pipeline/`,
+  or an absolute path for legacy clone installs).

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -552,6 +553,83 @@ class TestBicepAdapterBuildCommand(unittest.TestCase):
     def test_standalone_driver_uses_positional(self) -> None:
         cmd = self._capture(["bicep"])
         self.assertEqual(cmd, ["bicep", "build", "main.bicep"])
+
+
+class TestPythonAdapterInterpreter(unittest.TestCase):
+    """Regression tests for _python_cmd() in adapters/python/scripts/test.py.
+
+    Issue #32: bare `python3` was used for both pytest-cov detection and the
+    pytest run, which fails for projects with project-local virtual environments
+    (uv, poetry, plain venv) — system python3 cannot import the project's deps.
+    The helper resolves to a venv interpreter when present, then to `uv run python`,
+    then falls back to system `python3`.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+        adapter_path = Path(__file__).resolve().parent.parent / "adapters/python/scripts/test.py"
+        spec = importlib.util.spec_from_file_location("_python_test_adapter", adapter_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls._mod = mod
+
+    def setUp(self) -> None:
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _make_venv(self, name: str) -> str:
+        """Create a fake venv interpreter inside the tmp project. Returns its path."""
+        bin_dir = "Scripts" if os.name == "nt" else "bin"
+        exe_name = "python.exe" if os.name == "nt" else "python"
+        venv_bin = os.path.join(self._tmpdir, name, bin_dir)
+        os.makedirs(venv_bin, exist_ok=True)
+        path = os.path.join(venv_bin, exe_name)
+        with open(path, "w") as f:
+            f.write("#!/bin/sh\nexec /usr/bin/env python3 \"$@\"\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_dotvenv_takes_priority(self) -> None:
+        venv_python = self._make_venv(".venv")
+        # Even with a `venv/` and uv available, .venv wins.
+        self._make_venv("venv")
+        with open(os.path.join(self._tmpdir, "pyproject.toml"), "w"):
+            pass
+        cmd = self._mod._python_cmd(self._tmpdir)
+        self.assertEqual(cmd, [venv_python])
+
+    def test_venv_used_when_dotvenv_absent(self) -> None:
+        venv_python = self._make_venv("venv")
+        cmd = self._mod._python_cmd(self._tmpdir)
+        self.assertEqual(cmd, [venv_python])
+
+    def test_uv_run_when_pyproject_present_no_venv(self) -> None:
+        with open(os.path.join(self._tmpdir, "pyproject.toml"), "w"):
+            pass
+        # Stub shutil.which inside the adapter module to simulate uv on PATH.
+        original_which = self._mod.shutil.which
+        self._mod.shutil.which = lambda name: "/fake/uv" if name == "uv" else None
+        try:
+            cmd = self._mod._python_cmd(self._tmpdir)
+            self.assertEqual(cmd, ["uv", "run", "python"])
+        finally:
+            self._mod.shutil.which = original_which
+
+    def test_falls_back_to_python3(self) -> None:
+        # No venvs, no pyproject — fallback path. Stub uv away to ensure determinism.
+        original_which = self._mod.shutil.which
+        self._mod.shutil.which = lambda name: None
+        try:
+            cmd = self._mod._python_cmd(self._tmpdir)
+            self.assertEqual(cmd, ["python3"])
+        finally:
+            self._mod.shutil.which = original_which
 
 
 class TestReactAdapterParsers(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #31 and #32 in one PR — they touch different files but were investigated together in the same session.

### #31 — \`update-pipeline\` skill: support clone and submodule-orphaned modes

The skill previously gated everything past Step 1 on finding a submodule entry in \`.gitmodules\`. Clone-mode consumers had to remember the manual \`git -C <pipeline> pull\` + conditional \`init.sh --force\` dance. It also failed silently for the \"submodule-orphaned\" state observed in the wild (gitlink at \`<PIPELINE_PATH>/.git\` but no \`.gitmodules\` entry — happens when bootstrap is interrupted between clone and \`git submodule add\`).

**Changes** to \`skills/update-pipeline/SKILL.md\`:
- **Step 1** now classifies \`INSTALL_MODE\` as \`submodule\` / \`submodule-orphaned\` / \`clone\` based on the combination of \`.gitmodules\` and the type of \`<PIPELINE_PATH>/.git\` (file gitlink vs. directory). Aborts only when no \`.git\` exists at all.
- **Steps 2–6** use generic \`<PIPELINE_PATH>\` language (no longer \"submodule\"). Behavior is unchanged for submodule installs.
- **Step 7** branches on \`INSTALL_MODE\`. Submodule installs commit the bump as before. Clone and submodule-orphaned installs report success and skip the parent-repo commit. Submodule-orphaned re-prints the repair hint so the user can fix the inconsistency at their leisure.

### #32 — python adapter: prefer project-local venv over system python3

\`adapters/python/scripts/test.py\` invoked \`python3 -m pytest\` directly. In projects with a project-local virtual environment (uv, poetry, or plain \`venv\`), system \`python3\` cannot import project deps — pytest either fails to start or runs but can't import the project's own packages, producing empty coverage and confusing failures.

**Changes** to \`adapters/python/scripts/test.py\`:
- New \`_python_cmd(project_dir)\` helper. Resolution order: \`.venv/bin/python\` → \`venv/bin/python\` → \`uv run python\` (when \`uv\` is on PATH and \`pyproject.toml\` exists) → system \`python3\`.
- Both call sites updated: the \`import pytest_cov\` probe at line 39 and the pytest invocation at line 128.

**Why broader than the proposed patch** in #32: the proposed patch fired only when uv + .venv were both present. The broader fix handles plain \`python -m venv\` and poetry's in-project venv too — those have the same problem and the proposed patch wouldn't help them. Pointing at \`.venv/bin/python\` directly works for any venv flavor and doesn't introduce a hard dependency on \`uv\` being installed.

## Tests

- \`TestPythonAdapterInterpreter\` (4 new tests): \`.venv\` priority over \`venv\`, \`venv\` fallback, \`uv run python\` when \`pyproject.toml\` exists with no \`.venv\`, and system \`python3\` fallback.
- 73/73 contract tests pass.
- 330/330 structural checks pass.

## Test plan

- [x] \`python3 tests/test_contracts.py -v\`
- [x] \`python3 tests/validate_structure.py\`
- [ ] Manual: bootstrap a uv project with a \`.venv\`, run \`python3 .claude/scripts/python/test.py --project-dir .\` and confirm pytest runs against the venv interpreter (not system python3)
- [ ] Manual: in a clone-install consumer, run \`/update-pipeline\` and confirm Steps 2–6 execute and Step 7 reports the no-commit case correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)