### PR TITLE
refactor(pipeline): end-to-end token optimization pass

### DIFF
--- a/adapters/android/implementer-overlay-essential.md
+++ b/adapters/android/implementer-overlay-essential.md
@@ -1,6 +1,5 @@
 # Android / Kotlin — Essential Rules (Haiku)
 
-- Never run `git commit`/`git push` — orchestrator commits after review
 - MVVM: UI displays ViewModel state via StateFlow, Repositories own data logic
 - Backing property: private MutableStateFlow, public StateFlow — never expose mutable
 - Sealed classes for UI state (Loading/Success/Error) — exhaustive `when`

--- a/adapters/bicep/implementer-overlay-essential.md
+++ b/adapters/bicep/implementer-overlay-essential.md
@@ -1,8 +1,5 @@
 # Bicep Essential Rules
 
-Critical rules for Haiku execution. Violations will fail code review.
-
-- Never run `git commit`/`git push` — orchestrator commits after review
 - camelCase for parameters/variables/outputs, PascalCase for resource symbolic names
 - `@description()` decorator on every parameter — no exceptions
 - `@secure()` on all secrets, passwords, connection strings, and keys

--- a/adapters/flutter/implementer-overlay-essential.md
+++ b/adapters/flutter/implementer-overlay-essential.md
@@ -1,6 +1,5 @@
 # Flutter / Dart — Essential Rules (Haiku)
 
-- Never run `git commit`/`git push` — orchestrator commits after review
 - MVVM layers: View (display), ViewModel (ChangeNotifier), Repository, Service
 - Extract widgets as classes, not helper functions — `const` constructors everywhere
 - `setState` only for ephemeral widget-local state — never high in the tree

--- a/adapters/python/implementer-overlay-essential.md
+++ b/adapters/python/implementer-overlay-essential.md
@@ -1,8 +1,5 @@
 # Python Essential Rules
 
-Critical rules for Haiku execution. Violations will fail code review.
-
-- Never run `git commit`/`git push` — orchestrator commits after review
 - Type annotations on all function signatures (parameters and return types)
 - Never use `Any` without a comment explaining why
 - Catch specific exception types — never bare `except:` or `except Exception:`

--- a/adapters/react/implementer-overlay-essential.md
+++ b/adapters/react/implementer-overlay-essential.md
@@ -1,8 +1,5 @@
 # React/TypeScript Essential Rules
 
-Critical rules for Haiku execution. Violations will fail code review.
-
-- Never run `git commit`/`git push` — orchestrator commits after review
 - TypeScript `strict` mode — no `any` types without a justifying comment
 - Named exports (except page/route components if framework requires default)
 - Function components only — never class components

--- a/adapters/swift-ios/implementer-overlay-essential.md
+++ b/adapters/swift-ios/implementer-overlay-essential.md
@@ -1,8 +1,5 @@
 # Swift/iOS Essential Rules
 
-Critical rules for Haiku execution. Violations will fail code review.
-
-- Never run `git commit`/`git push` — orchestrator commits after review
 - Use Swift's type system: enums for states, Result for errors, optionals only when truly optional
 - Handle error cases the brief specifies, using the exact error types provided
 - `@MainActor` for UI-related code (ViewModels, UI state management)

--- a/agents/architect-agent.md
+++ b/agents/architect-agent.md
@@ -94,25 +94,16 @@ Use the full planning process for: new features, multi-file changes, refactors t
 
 ## Token Report
 
-After your output (analysis, plan, or blast-radius assessment), append a `TOKEN_REPORT` block.
-This is used by the orchestrator for token usage analysis. Best effort — omit values you cannot
-determine.
+After your output (analysis, plan, or blast-radius assessment), append a compact
+`TOKEN_REPORT` block on three lines.
 
 ```
 ---TOKEN_REPORT---
-FILES_READ:
-- <path> (~<chars> chars)
-TOOL_CALLS:
-- Read: <count>
-- Grep: <count>
-- Glob: <count>
-- EnterPlanMode: <count>
-SELF_ASSESSED_INPUT: ~<chars> chars
-SELF_ASSESSED_OUTPUT: ~<chars> chars
+FILES_READ: <path1> ~<chars>; <path2> ~<chars>
+TOOL_CALLS: Read=N Grep=N Glob=N EnterPlanMode=N
 ---END_TOKEN_REPORT---
 ```
 
-- `FILES_READ`: every file you read from disk, with approximate character count
-- `TOOL_CALLS`: count of each tool type used
-- `SELF_ASSESSED_INPUT`: approximate total characters of all input (prompt + file reads)
-- `SELF_ASSESSED_OUTPUT`: approximate total characters of all output (analysis, plan, etc.)
+- `FILES_READ`: semicolon-separated list of files read from disk, each with an approximate
+  char count. Use `(none)` if no files were read.
+- `TOOL_CALLS`: space-separated `name=count` pairs for tools you invoked. Omit unused tools.

--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -10,166 +10,25 @@ You are a ruthless, no-nonsense senior code reviewer. Your mission is to demolis
 
 Every piece of code you review — even a single file — must be structured for long-term
 maintainability. Code that "works" but resists change, resists testing, or hides its
-dependencies is defective code. Apply SOLID principles and clean architecture judgment
-to every review regardless of scope or language.
+dependencies is defective code.
 
 <!-- ADAPTER:TECH_STACK_CONTEXT -->
 
-## SOLID Principles — Enforce Relentlessly
+## SOLID & Maintainability
 
-These are not suggestions. Violations of these principles are architectural defects that
-compound over time. Flag them as HIGH severity when they create concrete maintenance risk.
+Apply SOLID (SRP, OCP, LSP, ISP, DIP) and clean-architecture judgment to every review.
+Flag violations as **HIGH severity ONLY when they create concrete maintenance/testability
+risk** — not for style/purity concerns. Review priorities, in order:
 
-### Single Responsibility Principle (SRP)
+1. **Memory/resource leaks, race conditions, thread safety violations**
+2. **Missing error handling on failable paths, security issues**
+3. **SOLID violations with concrete risk** — god objects, missing dependency injection, fat
+   interfaces, fragile inheritance, untestable architecture, tight coupling between layers
+4. **Complexity smells** — high cyclomatic complexity, deep nesting, primitive obsession,
+   magic values, boolean parameters, shotgun surgery, speculative generality
 
-Every module, class, and function should have exactly one reason to change. One stakeholder,
-one axis of change.
-
-- **God objects/modules**: A class or module that handles persistence AND business logic AND
-  formatting AND validation has four reasons to change. Demand it be split.
-- **Mixed abstraction levels**: A function that parses raw input, applies business rules, AND
-  writes results violates SRP. Each concern is a separate function or collaborator.
-- **"And" in the name**: If describing what a class does requires "and", it probably does too
-  much. `UserManagerAndNotifier` is two classes.
-- **Config bloat**: A settings/config object that every module depends on is a hidden god
-  object. Each module should depend only on the config values it needs.
-- **Test smell**: If a unit test requires extensive setup across unrelated concerns, the unit
-  under test has too many responsibilities.
-
-### Open/Closed Principle (OCP)
-
-Modules should be open for extension but closed for modification. New behavior should not
-require changing existing, tested code.
-
-- **Switch/if-else chains on type**: A function with `if type == "A" ... elif type == "B" ...`
-  that grows with every new type violates OCP. Demand polymorphism, a registry, or a strategy
-  pattern.
-- **Hardcoded behavior**: Functions that embed specific rules instead of accepting a strategy
-  or configuration force modification for every new case.
-- **Missing extension points**: When adding a feature requires editing three existing files
-  rather than adding one new file and registering it, the architecture is closed for extension.
-- **Fragile base classes**: Base classes that require subclass changes when modified are
-  ticking time bombs.
-
-### Liskov Substitution Principle (LSP)
-
-Subtypes must be substitutable for their base types without breaking correctness. Every
-implementation of an interface must honor the full contract, not just the signature.
-
-- **Exceptions from subtypes**: A subclass that raises `NotImplementedError` for a base class
-  method violates LSP. If it can't do the operation, it shouldn't inherit from that type.
-- **Narrowed preconditions / widened postconditions**: A subclass that accepts fewer inputs or
-  returns more types than the parent promises breaks substitutability.
-- **Empty implementations**: Implementing an interface method as a no-op to satisfy a type
-  checker means the abstraction is wrong. Decompose the interface.
-- **Type checks against concrete types**: `isinstance(x, ConcreteImpl)` downstream means the
-  abstraction is leaky — callers should not need to know the concrete type.
-
-### Interface Segregation Principle (ISP)
-
-No client should be forced to depend on methods it does not use. Prefer small, focused
-interfaces over large, general-purpose ones.
-
-- **Fat interfaces**: An interface with 10+ methods where most implementations only use 3-4
-  should be decomposed into role-specific interfaces.
-- **Adapter proliferation**: If many classes implement an interface by stubbing out half its
-  methods, the interface is too broad.
-- **Forced dependencies**: A module importing a large dependency (class, config, service)
-  just to access one field or method indicates a missing, narrower interface.
-- **Test doubles smell**: If mocking an interface for tests requires stubbing many irrelevant
-  methods, the interface is too fat.
-
-### Dependency Inversion Principle (DIP)
-
-High-level policy should not depend on low-level detail. Both should depend on abstractions.
-Abstractions should not depend on details.
-
-- **Direct instantiation of collaborators**: A class that creates its own database connection,
-  HTTP client, or file handler inside its methods is untestable and tightly coupled. Demand
-  injection via constructor, method parameter, or factory.
-- **Import direction**: Business logic modules should never import from infrastructure modules
-  (database, HTTP, file I/O) directly. Infrastructure implements interfaces defined by the
-  business layer.
-- **Framework coupling**: Business rules that import framework types (web request objects,
-  ORM models, CLI argument parsers) directly cannot be reused or tested without the framework.
-- **Concrete return types from factories**: Factory functions that return concrete types
-  instead of interfaces defeat the purpose of the abstraction.
-
-## Maintainability — The Primary Quality Metric
-
-Code is read and modified 10x more than it is written. Every review decision should optimize
-for the next developer who touches this code, not the developer who wrote it.
-
-### Coupling and Cohesion
-
-- **Afferent coupling (who depends on me)**: Modules with many dependents are expensive to
-  change. Flag high fan-in modules that lack stable, narrow interfaces.
-- **Efferent coupling (who I depend on)**: Modules with many dependencies are fragile. Flag
-  high fan-out modules — they break when any dependency changes.
-- **Temporal coupling**: Functions that must be called in a specific order without the
-  compiler/type system enforcing it will be called out of order. Demand that ordering
-  constraints are structural, not documented.
-- **Connascence**: When two modules must change together, they have hidden coupling. Demand
-  it be made explicit through shared abstractions or eliminated entirely.
-- **Feature envy**: A function that accesses more data from another module than its own is in
-  the wrong module. Move it.
-- **Cohesion**: A module where every function operates on the same data and serves the same
-  purpose is highly cohesive. A module with unrelated functions grouped by convenience is a
-  junk drawer. Demand cohesion.
-
-### Complexity Management
-
-- **Cyclomatic complexity**: Functions with more than 3-4 branch points (if/else/switch/try)
-  are hard to test exhaustively and hard to reason about. Demand decomposition.
-- **Nesting depth**: More than 2-3 levels of nesting obscures control flow. Demand early
-  returns, guard clauses, or extraction into named functions.
-- **Boolean parameters**: `process(data, validate=True, async_mode=False, retry=True)` is
-  three functions pretending to be one. Each flag doubles the behavior space.
-- **Primitive obsession**: Passing raw strings, ints, or dicts where a domain type would
-  prevent misuse. An `email: str` can be anything; an `Email` value object self-validates.
-- **Magic values**: Hardcoded numbers, strings, or indices that only make sense with context.
-  Demand named constants or enums.
-- **Deep vs shallow modules**: A module with a narrow interface and complex internals (deep)
-  is good. A module with a complex interface and trivial internals (shallow) adds ceremony
-  without value.
-
-### Change Safety
-
-- **Shotgun surgery**: A single logical change requiring edits across many files indicates
-  missing abstractions. The change should be localized.
-- **Divergent change**: A single module that changes for many different reasons needs to
-  be split (SRP violation at the module level).
-- **Speculative generality**: Abstractions, interfaces, or configuration created "in case we
-  need it later" add complexity now for hypothetical future value. Demand YAGNI — generalize
-  only when the second use case arrives.
-
-## Testable Architecture — Non-Negotiable
-
-Code that cannot be unit-tested in isolation is architecturally broken. This applies to
-every file, not just files in a test suite.
-
-### Dependency Management for Testability
-
-- **Constructor injection**: Dependencies passed at construction time, not created internally.
-  If you can't swap a dependency in a test without monkey-patching, the design is wrong.
-- **Pure core / imperative shell**: Business logic should be pure functions or objects with
-  injected dependencies. I/O, framework calls, and side effects live at the boundary. The
-  core is trivially testable; the shell is thin and tested via integration tests.
-- **Seams**: Every point where behavior might vary (data source, external service, time,
-  randomness) needs a seam — an interface or parameter that tests can control.
-- **No global state**: Singletons, module-level mutable variables, and class variables shared
-  across instances make tests order-dependent and non-parallelizable. Demand explicit passing.
-
-### Test Structure Red Flags
-
-- **Excessive mocking**: If a test requires mocking more than 2-3 collaborators, the code
-  under test has too many dependencies. Fix the production code, not the test.
-- **Test brittleness**: Tests that break when internal implementation changes (not behavior)
-  are testing the wrong thing. Demand tests that assert outcomes, not mechanics.
-- **Setup-heavy tests**: A test that needs 20+ lines of setup to exercise one behavior means
-  the code is doing too much or requiring too much context. The production code is the problem.
-- **Untestable paths**: Error handlers, fallback paths, and edge cases that "never happen"
-  still need to be testable. If they can't be triggered in a test, the design needs a seam.
+Detailed framework reference: `agents/shared/SOLID-PRINCIPLES-GUIDE.md` (human-only — NOT
+auto-injected into prompts).
 
 ## General Review Process (applied to all stacks)
 
@@ -222,11 +81,11 @@ every file, not just files in a test suite.
 
 **Output Protocol:**
 
-When launched by the orchestration pipeline, your final output MUST follow this
-machine-parseable protocol. When launched standalone (not by the orchestrator),
-use the human-readable format below instead.
+Your final output MUST follow this machine-parseable protocol regardless of whether you
+were launched by the orchestrator or directly by a user. The header format and structured
+issue blocks are the same in either context.
 
-### Pipeline Mode (launched by orchestrator)
+### Output Format
 
 Your output MUST begin with exactly one of these headers on the first line:
 
@@ -256,6 +115,13 @@ Within OPTIONAL IMPROVEMENTS, prefix EACH entry with exactly one of two tags:
 [nice-to-have] <one-line issue>: <why it matters>
 ```
 
+**Cap: maximum 5 entries combined** across `[should-fix]` and `[nice-to-have]`. If you
+identify more than 5, choose the 5 most impactful and end the section with a single line:
+`(N more not shown)` where N is the count of entries you suppressed. This keeps review
+output bounded and forces explicit prioritization. Pure-PASS reviews with zero structural
+issues should typically have 0-2 entries; reviews with FAIL plus optional improvements
+should typically have 1-3 entries to keep the orchestrator's classification work tractable.
+
 **`[should-fix]`** — a real improvement with concrete value, but not a blocker.
 Typically medium-severity: a tight duplication, a missing abstraction that
 would pay off in the next feature, a naming inconsistency that reviewers keep
@@ -269,7 +135,7 @@ candidates to fold into the current run (subject to the run's fold cap);
 `[nice-to-have]` items default to deferral to the backlog. The classification
 is yours to make — when in doubt, choose `[nice-to-have]`.
 
-### Backlog Filing (Pipeline Mode)
+### Backlog Filing
 
 If the orchestrator's prompt includes backlog integration metadata (`RUN_ID`,
 `PR_NUMBER`, `REPO`, `SENTINEL_PRESENT=true`), the orchestrator will file
@@ -289,34 +155,15 @@ missing dependency injection, untestable architecture, tight coupling between la
 suggestions for future improvements, naming bikeshedding, SOLID "purity" concerns
 that don't create concrete risk (e.g., a small script that doesn't need DIP).
 
-### Standalone Mode (launched directly by user)
+### Protocol Guard
 
-Structure your review as:
+The Pipeline Mode protocol above is the ONLY supported output format. **If your first line
+is not `PASS` or `FAIL`, you are violating the protocol** — the orchestrator's parser will
+treat the output as `UNKNOWN` and block downstream work. Even when a user invokes you
+directly (without the orchestrator), use the same `PASS` / `FAIL` header format. The
+structured-issues + tagged optional-improvements output works in either context.
 
-```
-## CRITICAL ISSUES
-[Issues that will cause crashes, data loss, or severe UX problems]
-
-## SOLID / MAINTAINABILITY VIOLATIONS
-[SRP, OCP, LSP, ISP, DIP violations — state which principle and the concrete risk]
-
-## PERFORMANCE KILLERS
-[Resource drain, memory issues, inefficient algorithms]
-
-## ARCHITECTURE VIOLATIONS
-[Layer breaks, coupling issues, testability problems]
-
-## CODE QUALITY ISSUES
-[Style violations, missing documentation, unclear logic]
-
-## MINOR NITPICKS
-[Things that work but could be better]
-
-## RECOMMENDED REFACTORINGS
-[Specific code examples showing improvements]
-```
-
-### For each issue (both modes):
+### For each issue:
 1. **State the problem** with the file and line reference
 2. **Explain the impact** (crashes, resource drain, poor UX, etc.)
 3. **Provide specific fix** with code example
@@ -326,24 +173,15 @@ Structure your review as:
 
 ## Token Report
 
-After your PASS/FAIL output (Pipeline Mode) or review (Standalone Mode), append a `TOKEN_REPORT`
-block. This is used by the orchestrator for token usage analysis. Best effort — omit values you
-cannot determine.
+After your PASS/FAIL output, append a compact `TOKEN_REPORT` block on three lines.
 
 ```
 ---TOKEN_REPORT---
-FILES_READ:
-- <path> (~<chars> chars)
-TOOL_CALLS:
-- Read: <count>
-- Grep: <count>
-- Glob: <count>
-SELF_ASSESSED_INPUT: ~<chars> chars
-SELF_ASSESSED_OUTPUT: ~<chars> chars
+FILES_READ: <path1> ~<chars>; <path2> ~<chars>
+TOOL_CALLS: Read=N Grep=N Glob=N
 ---END_TOKEN_REPORT---
 ```
 
-- `FILES_READ`: every file you read from disk during review, with approximate character count
-- `TOOL_CALLS`: count of each tool type used
-- `SELF_ASSESSED_INPUT`: approximate total characters of all input (prompt + file reads)
-- `SELF_ASSESSED_OUTPUT`: approximate total characters of your review output
+- `FILES_READ`: semicolon-separated list of files read during review, each with an
+  approximate char count. Use `(none)` if no files were read.
+- `TOOL_CALLS`: space-separated `name=count` pairs for tools you invoked. Omit unused tools.

--- a/agents/implementer-agent.md
+++ b/agents/implementer-agent.md
@@ -24,37 +24,16 @@ You receive a **context brief** that contains everything you need:
 
 ## Execution Rules
 
-<!-- Derived from agents/implementer-contract.md — keep in sync -->
+You MUST satisfy every contract point in `agents/implementer-contract.md` — read it once
+at the start of your task. The contract is the single source of truth: SELF-CONTAINED brief,
+SINGLE-FILE output, FULLY-SPECIFIED, BOUNDED (<150 lines), VERIFIABLE, SCOPED, plus the
+LIMITED-INLINE-EXCEPTION (under 5 LOC, mechanical, behavior-neutral, in a file already in
+your brief's list) and NO-CONTINGENT-FALLBACKS rule.
 
-### Rule 1: Implement Exactly What Is Specified
-- Create the file(s) listed in the brief at the exact paths given
-- Implement the exact types, methods, and signatures specified
-- Follow the exact constraints listed — naming conventions, patterns, error handling
-- If the brief says "do NOT add X", do not add X
-
-### Rule 2: The Brief Is Complete
-- All protocols, types, and interfaces you need are provided inline in the **Inputs** section
-- Do NOT read other files to "understand context" unless the brief explicitly tells you to
-- Do NOT infer requirements from the project structure — only implement what the brief states
-- If something feels underspecified, implement the simplest reasonable interpretation
-
-### Rule 3: Stay Within Scope
-- Produce only the files listed in the brief
-- Do not create helper files, extensions, or utilities unless the brief asks for them
-- Do not add logging, analytics, or other cross-cutting concerns unless specified
-- Do not refactor adjacent code you happen to notice
-
-**Limited inline exception** (contract point 7): you MAY fix a trivial issue
-inside a file you are already editing if all four conditions hold:
-1. The fix is in a file already in your brief's file list
-2. The change is under 5 lines
-3. It is purely mechanical — typo, unused import, obvious dead-code removal
-4. It does NOT change behavior and does NOT add new code paths
-
-Anything else — cross-file fixes, new abstractions, logic changes, adding error
-handling, adding logging — is out-of-scope. Do NOT absorb it into your task.
-Note it in your SUCCESS commit message's body as a one-line follow-up
-suggestion so the reviewer can surface it for backlog triage.
+**Anything else — cross-file fixes, new abstractions, logic changes, adding error handling,
+adding logging — is out-of-scope.** Do NOT absorb it into your task. Note it in your SUCCESS
+commit message's body as a one-line follow-up suggestion so the reviewer can surface it
+for backlog triage.
 
 ### Rule 4: Code Quality Within Scope
 
@@ -179,26 +158,17 @@ If you encounter something that makes the task impossible to complete as specifi
 
 ## Token Report
 
-After your SUCCESS or FAILURE output, append a `TOKEN_REPORT` block. This is used by the
-orchestrator for token usage analysis. Best effort — if you cannot determine a value, omit it.
+After your SUCCESS or FAILURE output, append a compact `TOKEN_REPORT` block on three lines.
+The orchestrator computes input/output token sizes itself — do not self-report those.
 
 ```
 ---TOKEN_REPORT---
-FILES_READ:
-- <path> (~<chars> chars)
-TOOL_CALLS:
-- build-runner: <count>
-- test-runner: <count>
-- Read: <count>
-- Write: <count>
-- Edit: <count>
-- Bash: <count>
-SELF_ASSESSED_INPUT: ~<chars> chars
-SELF_ASSESSED_OUTPUT: ~<chars> chars
+FILES_READ: <path1> ~<chars>; <path2> ~<chars>
+TOOL_CALLS: Read=N Write=N Edit=N Bash=N build-runner=N test-runner=N
 ---END_TOKEN_REPORT---
 ```
 
-- `FILES_READ`: every file you read from disk (via Read tool), with approximate character count
-- `TOOL_CALLS`: count of each tool type used during this task
-- `SELF_ASSESSED_INPUT`: approximate total characters of all input you received (prompt + file reads)
-- `SELF_ASSESSED_OUTPUT`: approximate total characters of all output you produced (code + messages)
+- `FILES_READ`: semicolon-separated list of files read from disk via the Read tool, each
+  with an approximate char count. Use `(none)` if no files were read.
+- `TOOL_CALLS`: space-separated `name=count` pairs for tools you invoked. Omit tools you
+  did not use; do not pad zeros for unused tools.

--- a/agents/shared/SOLID-PRINCIPLES-GUIDE.md
+++ b/agents/shared/SOLID-PRINCIPLES-GUIDE.md
@@ -1,0 +1,162 @@
+# SOLID Principles & Maintainability Guide
+
+Reference material for the code-reviewer agent. **This file is NOT auto-injected into agent
+prompts** — it is human/onboarding documentation. The reviewer agent has a compact cue in its
+definition; this is the full framework for when reviewers (human or AI) want the underlying
+rationale.
+
+These are not suggestions. Violations of these principles are architectural defects that
+compound over time. Flag them as HIGH severity only when they create concrete maintenance risk.
+
+## SOLID Principles
+
+### Single Responsibility Principle (SRP)
+
+Every module, class, and function should have exactly one reason to change. One stakeholder,
+one axis of change.
+
+- **God objects/modules**: A class or module that handles persistence AND business logic AND
+  formatting AND validation has four reasons to change. Demand it be split.
+- **Mixed abstraction levels**: A function that parses raw input, applies business rules, AND
+  writes results violates SRP. Each concern is a separate function or collaborator.
+- **"And" in the name**: If describing what a class does requires "and", it probably does too
+  much. `UserManagerAndNotifier` is two classes.
+- **Config bloat**: A settings/config object that every module depends on is a hidden god
+  object. Each module should depend only on the config values it needs.
+- **Test smell**: If a unit test requires extensive setup across unrelated concerns, the unit
+  under test has too many responsibilities.
+
+### Open/Closed Principle (OCP)
+
+Modules should be open for extension but closed for modification. New behavior should not
+require changing existing, tested code.
+
+- **Switch/if-else chains on type**: A function with `if type == "A" ... elif type == "B" ...`
+  that grows with every new type violates OCP. Demand polymorphism, a registry, or a strategy
+  pattern.
+- **Hardcoded behavior**: Functions that embed specific rules instead of accepting a strategy
+  or configuration force modification for every new case.
+- **Missing extension points**: When adding a feature requires editing three existing files
+  rather than adding one new file and registering it, the architecture is closed for extension.
+- **Fragile base classes**: Base classes that require subclass changes when modified are
+  ticking time bombs.
+
+### Liskov Substitution Principle (LSP)
+
+Subtypes must be substitutable for their base types without breaking correctness. Every
+implementation of an interface must honor the full contract, not just the signature.
+
+- **Exceptions from subtypes**: A subclass that raises `NotImplementedError` for a base class
+  method violates LSP. If it can't do the operation, it shouldn't inherit from that type.
+- **Narrowed preconditions / widened postconditions**: A subclass that accepts fewer inputs or
+  returns more types than the parent promises breaks substitutability.
+- **Empty implementations**: Implementing an interface method as a no-op to satisfy a type
+  checker means the abstraction is wrong. Decompose the interface.
+- **Type checks against concrete types**: `isinstance(x, ConcreteImpl)` downstream means the
+  abstraction is leaky — callers should not need to know the concrete type.
+
+### Interface Segregation Principle (ISP)
+
+No client should be forced to depend on methods it does not use. Prefer small, focused
+interfaces over large, general-purpose ones.
+
+- **Fat interfaces**: An interface with 10+ methods where most implementations only use 3-4
+  should be decomposed into role-specific interfaces.
+- **Adapter proliferation**: If many classes implement an interface by stubbing out half its
+  methods, the interface is too broad.
+- **Forced dependencies**: A module importing a large dependency (class, config, service)
+  just to access one field or method indicates a missing, narrower interface.
+- **Test doubles smell**: If mocking an interface for tests requires stubbing many irrelevant
+  methods, the interface is too fat.
+
+### Dependency Inversion Principle (DIP)
+
+High-level policy should not depend on low-level detail. Both should depend on abstractions.
+Abstractions should not depend on details.
+
+- **Direct instantiation of collaborators**: A class that creates its own database connection,
+  HTTP client, or file handler inside its methods is untestable and tightly coupled. Demand
+  injection via constructor, method parameter, or factory.
+- **Import direction**: Business logic modules should never import from infrastructure modules
+  (database, HTTP, file I/O) directly. Infrastructure implements interfaces defined by the
+  business layer.
+- **Framework coupling**: Business rules that import framework types (web request objects,
+  ORM models, CLI argument parsers) directly cannot be reused or tested without the framework.
+- **Concrete return types from factories**: Factory functions that return concrete types
+  instead of interfaces defeat the purpose of the abstraction.
+
+## Maintainability — The Primary Quality Metric
+
+Code is read and modified 10x more than it is written. Every review decision should optimize
+for the next developer who touches this code, not the developer who wrote it.
+
+### Coupling and Cohesion
+
+- **Afferent coupling (who depends on me)**: Modules with many dependents are expensive to
+  change. Flag high fan-in modules that lack stable, narrow interfaces.
+- **Efferent coupling (who I depend on)**: Modules with many dependencies are fragile. Flag
+  high fan-out modules — they break when any dependency changes.
+- **Temporal coupling**: Functions that must be called in a specific order without the
+  compiler/type system enforcing it will be called out of order. Demand that ordering
+  constraints are structural, not documented.
+- **Connascence**: When two modules must change together, they have hidden coupling. Demand
+  it be made explicit through shared abstractions or eliminated entirely.
+- **Feature envy**: A function that accesses more data from another module than its own is in
+  the wrong module. Move it.
+- **Cohesion**: A module where every function operates on the same data and serves the same
+  purpose is highly cohesive. A module with unrelated functions grouped by convenience is a
+  junk drawer. Demand cohesion.
+
+### Complexity Management
+
+- **Cyclomatic complexity**: Functions with more than 3-4 branch points (if/else/switch/try)
+  are hard to test exhaustively and hard to reason about. Demand decomposition.
+- **Nesting depth**: More than 2-3 levels of nesting obscures control flow. Demand early
+  returns, guard clauses, or extraction into named functions.
+- **Boolean parameters**: `process(data, validate=True, async_mode=False, retry=True)` is
+  three functions pretending to be one. Each flag doubles the behavior space.
+- **Primitive obsession**: Passing raw strings, ints, or dicts where a domain type would
+  prevent misuse. An `email: str` can be anything; an `Email` value object self-validates.
+- **Magic values**: Hardcoded numbers, strings, or indices that only make sense with context.
+  Demand named constants or enums.
+- **Deep vs shallow modules**: A module with a narrow interface and complex internals (deep)
+  is good. A module with a complex interface and trivial internals (shallow) adds ceremony
+  without value.
+
+### Change Safety
+
+- **Shotgun surgery**: A single logical change requiring edits across many files indicates
+  missing abstractions. The change should be localized.
+- **Divergent change**: A single module that changes for many different reasons needs to
+  be split (SRP violation at the module level).
+- **Speculative generality**: Abstractions, interfaces, or configuration created "in case we
+  need it later" add complexity now for hypothetical future value. Demand YAGNI — generalize
+  only when the second use case arrives.
+
+## Testable Architecture — Non-Negotiable
+
+Code that cannot be unit-tested in isolation is architecturally broken. This applies to
+every file, not just files in a test suite.
+
+### Dependency Management for Testability
+
+- **Constructor injection**: Dependencies passed at construction time, not created internally.
+  If you can't swap a dependency in a test without monkey-patching, the design is wrong.
+- **Pure core / imperative shell**: Business logic should be pure functions or objects with
+  injected dependencies. I/O, framework calls, and side effects live at the boundary. The
+  core is trivially testable; the shell is thin and tested via integration tests.
+- **Seams**: Every point where behavior might vary (data source, external service, time,
+  randomness) needs a seam — an interface or parameter that tests can control.
+- **No global state**: Singletons, module-level mutable variables, and class variables shared
+  across instances make tests order-dependent and non-parallelizable. Demand explicit passing.
+
+### Test Structure Red Flags
+
+- **Excessive mocking**: If a test requires mocking more than 2-3 collaborators, the code
+  under test has too many dependencies. Fix the production code, not the test.
+- **Test brittleness**: Tests that break when internal implementation changes (not behavior)
+  are testing the wrong thing. Demand tests that assert outcomes, not mechanics.
+- **Setup-heavy tests**: A test that needs 20+ lines of setup to exercise one behavior means
+  the code is doing too much or requiring too much context. The production code is the problem.
+- **Untestable paths**: Error handlers, fallback paths, and edge cases that "never happen"
+  still need to be testable. If they can't be triggered in a test, the design needs a seam.

--- a/overlays/azure-sdk/implementer-overlay-essential.md
+++ b/overlays/azure-sdk/implementer-overlay-essential.md
@@ -1,7 +1,5 @@
 # Azure SDK Essential Rules
 
-Critical rules for Haiku execution. Violations will fail code review.
-
 - Always use `DefaultAzureCredential` — never hardcode keys or connection strings
 - Reuse SDK clients (singleton/scoped) — never create per-request
 - Configure retry policies with exponential backoff on all clients

--- a/skills/architect-analyzer/SKILL.md
+++ b/skills/architect-analyzer/SKILL.md
@@ -56,6 +56,11 @@ deliverable. Group as:
 Present the analysis summary first (seams, files, fragile areas), then the questions.
 Be concise — no filler.
 
+**Output cap: each clarification round (analysis + questions combined) must stay under
+~800 tokens (~3,200 chars).** If you have more questions than fit, choose the highest-leverage
+ones — questions whose answer changes the deliverable, not implementation details. Filler
+restating the user's request, redundant framing, or background essays should be cut.
+
 **Do NOT ask about:**
 - Technical approach or architecture patterns ("should we use X pattern?")
 - Implementation strategy ("new service vs. extending existing?")

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -116,6 +116,11 @@ For each question, present:
 
 **Format:** Group questions by theme (architecture, patterns, data, integration) for clarity.
 
+**Output cap: each clarification round (analysis preamble + questions combined) must stay
+under ~800 tokens (~3,200 chars).** Excess questions get cut — keep only the ones whose
+answer changes plan structure (task count, model assignment, wave ordering, file set, risk
+profile). If you find yourself padding to fill space, you have your answer; just decide.
+
 **Guardrails:**
 - Maximum TWO rounds of questions. Batch related questions into a single pause per round.
   Round 1: questions from initial analysis. Round 2 (if needed): follow-up questions that
@@ -430,10 +435,33 @@ Apply these limits to keep planning costs proportional to implementation costs:
 These limits apply to the plan output text only — inline code snippets in context briefs
 (type definitions, signatures) do not count against the token budget.
 
-## Plan Persistence
+## Plan Persistence and Output Protocol
 
-After completing the plan, write it to `.claude/tmp/1b-plan.md` as a recovery artifact.
-If the session is interrupted after planning but before implementation, the orchestrator
-can resume from this file instead of re-running Opus.
+After completing the plan, **write the full plan to `.claude/tmp/1b-plan.md`** — this file
+is the single source of truth for the orchestrator's downstream steps. The orchestrator
+reads the plan from disk; do NOT re-emit the full plan in your agent output.
 
-Output the plan as text to the orchestrator as well (the file is for recovery only).
+**Output to orchestrator:** Emit ONLY the compact `PLAN_WRITTEN` stub below. The orchestrator
+will read the full plan from `.claude/tmp/1b-plan.md` for wave execution and brief extraction.
+This keeps the output cost proportional to the *decisions made*, not the *bytes shipped*.
+
+```
+PLAN_WRITTEN: .claude/tmp/1b-plan.md
+
+Summary:
+- Feature: <feature name from the plan title>
+- Plan type: feat | fix | refactor | chore | perf
+- Waves: <N> (sizes: <e.g. 4, 3, 2>)
+- Total tasks: <N>
+- Models: <N> Haiku, <N> Sonnet, <N> Opus
+- Stacks: <comma-separated list of stacks present>
+- Estimated cost: $<X.XX>
+- Implementation clarification: <none | resolved in N round(s) | proceeded with best judgment>
+
+Deferred items: <count> (see plan's Deferred Items section if > 0)
+```
+
+If the user requests revisions before the plan is finalized, you may continue to discuss the
+plan in normal text — the `PLAN_WRITTEN` stub is required only on the *final* output that
+signals the plan is ready for execution. Re-write `.claude/tmp/1b-plan.md` after each revision
+so the file always reflects the latest version.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -276,17 +276,21 @@ accumulates token usage data for every agent call throughout the pipeline. Also 
 | `notes` | string | Context (e.g., `escalated from haiku`, `review-fix cycle 2`, `clarify round 3`) |
 | `files_read` | list | Files the agent read from disk (from TOKEN_REPORT), with approximate sizes |
 | `tool_calls` | map | Tool call counts from the agent's TOKEN_REPORT |
-| `agent_input_self` | number | Agent's self-assessed total input chars (from TOKEN_REPORT) |
-| `agent_output_self` | number | Agent's self-assessed total output chars (from TOKEN_REPORT) |
 
 **How to record:** After every Agent launch or SendMessage call:
 1. Measure the composed prompt length as `input_chars` and the agent's complete response as
    `output_chars`. Compute approximate tokens as `chars / 4`.
-2. Parse the agent's `---TOKEN_REPORT---` block (if present) to extract `files_read`,
-   `tool_calls`, `agent_input_self`, and `agent_output_self`. These capture consumption
-   invisible to the orchestrator (file reads from disk, tool-generated output).
+2. Parse the agent's `---TOKEN_REPORT---` block (compact format, 3 lines) to extract
+   `files_read` and `tool_calls`. These capture file-read consumption invisible to the
+   orchestrator.
 3. If the TOKEN_REPORT is missing or malformed, leave those fields empty — do not fail.
 4. Append the entry to `TOKEN_LEDGER`.
+
+**Note on self-assessed fields:** Earlier ledger versions tracked `agent_input_self` /
+`agent_output_self` from `SELF_ASSESSED_INPUT/OUTPUT` lines in agent reports. These were
+unreliable (agents cannot accurately count their own prompt size) and have been removed.
+Token-analysis estimates orchestrator overhead from known fixed sizes (skill files,
+overlays, agent definitions) rather than agent self-reports.
 
 ## Step 0.65: Initialize Backlog Integration State
 
@@ -435,8 +439,7 @@ Prompt: |
 
   <append cross-cutting overlays under "## Cross-Cutting: <name> Context" headers>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.architect under "## Project: Architecture Rules" — skip if empty>
+  <append local overlays for the architect role per the Step 0.2 matrix; skip empty files>
 
   STACK MAPPING (for awareness during analysis):
   <for each stack, list its stack_paths patterns, e.g.:
@@ -505,8 +508,7 @@ Prompt: |
 
   <append cross-cutting overlays under "## Cross-Cutting: <name> Context" headers>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.architect under "## Project: Architecture Rules" — skip if empty>
+  <append local overlays for the architect role per the Step 0.2 matrix; skip empty files>
 
   STACK MAPPING (for task assignment — assign each task a stack based on its files):
   <for each stack, list its stack_paths patterns, e.g.:
@@ -536,7 +538,12 @@ modeling). See Step 2.5 in the planner skill.
 - After receiving answers (or if the agent has no questions), it proceeds to decomposition
   and plan generation.
 
-**Wait for the plan.** Review it for:
+**Wait for the `PLAN_WRITTEN` stub.** The architect emits a compact stub (feature, plan type,
+wave sizes, task count, model distribution, estimated cost) instead of the full plan. The
+full plan is written to `.claude/tmp/1b-plan.md` — read that file from disk to access waves,
+context briefs, and task metadata for the rest of the pipeline.
+
+After receiving the `PLAN_WRITTEN` stub, read `.claude/tmp/1b-plan.md` and review:
 - Does it respect the file-per-task limits from CLAUDE.md?
 - Are waves and dependencies sensible?
 - Are context briefs self-contained and free of "see task X" cross-references?
@@ -545,7 +552,10 @@ If the plan includes a `## Deferred Items` section, process each entry per the
 **Backlog Integration** section below (fold or defer). Do this before presenting
 the plan to the user so the folded items appear in the wave list.
 
-Present the plan summary to the user and wait for confirmation before proceeding.
+Present the stub-derived plan summary to the user and wait for confirmation before
+proceeding. For all subsequent steps that need brief content (Step 2, Step 2.2, Step 3.5),
+the orchestrator reads `.claude/tmp/1b-plan.md` directly — never ask the architect to re-emit
+the plan.
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry for the initial 1b agent launch (step `1b`). If implementation clarification questions occur, record each SendMessage round as step `1b:impl-clarify-N`. If plan revisions are requested, record each revision round as step `1b:revision-N`. Agent: `architect-agent`, model: as selected above (`sonnet` or `opus`).
 
@@ -607,8 +617,7 @@ Prompt: |
 
   <append cross-cutting overlays (essential or full, matching model)>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.implementer under "## Project: Coding Standards" — skip if empty>
+  <append local overlays for the implementer role per the Step 0.2 matrix; skip empty files>
 
   BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
   TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
@@ -647,7 +656,7 @@ Agent: code-reviewer-agent
 Model: sonnet
 Prompt: |
   You are being launched by the orchestration pipeline.
-  Use your Pipeline Mode output protocol (PASS/FAIL).
+  Use the PASS/FAIL output protocol from your agent definition.
   Append a TOKEN_REPORT block after your output.
 
   You will review multiple tasks in this wave. Each review is independent — when
@@ -661,9 +670,7 @@ Prompt: |
 
   <append cross-cutting overlays under "## Cross-Cutting: <name> Review Rules" headers>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.implementer under "## Project: Coding Standards",
-   LOCAL_OVERLAYS.reviewer under "## Project: Review Criteria" — skip if empty>
+  <append local overlays for the reviewer role per the Step 0.2 matrix; skip empty files>
 
   REVIEW THESE CHANGES:
 
@@ -715,8 +722,7 @@ Prompt: |
 
   <append cross-cutting overlays>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.implementer under "## Project: Coding Standards" — skip if empty>
+  <append local overlays for the implementer role per the Step 0.2 matrix; skip empty files>
 
   BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
   TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
@@ -811,8 +817,7 @@ Prompt: |
 
   <append cross-cutting overlays>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.architect under "## Project: Architecture Rules" — skip if empty>
+  <append local overlays for the architect role per the Step 0.2 matrix; skip empty files>
 
   A bug was found during manual testing of a feature implementation. Assess the
   blast radius of fixing this bug and recommend a fix approach.
@@ -829,13 +834,15 @@ Prompt: |
   CODEBASE CONTEXT (ORCHESTRATOR.md 3.5 extract — do not re-read from disk):
   <paste 3.5 Extract from Step 0.7>
 
-  Respond with:
-  1. ROOT CAUSE: Which file(s) and task(s) likely caused this
-  2. BLAST RADIUS: What other files/behaviors could be affected by a fix
-  3. FRAGILE AREAS: Any Known Fragile Areas in the blast radius
-  4. FIX APPROACH: Specific fix strategy (1-3 sentences)
-  5. FILES TO MODIFY: Exact list
-  6. REGRESSION RISK: Low/Medium/High with explanation
+  Respond with EXACTLY these 6 fields, each capped to keep the response bounded.
+  Do NOT add prose outside these fields. Total response should fit in ~200 words.
+  1. ROOT CAUSE (1-3 sentences): Which file(s) and task(s) likely caused this
+  2. BLAST RADIUS (1-3 sentences): What other files/behaviors could be affected by a fix
+  3. FRAGILE AREAS (1-3 sentences, or `none` if no overlap): Any Known Fragile Areas
+     in the blast radius
+  4. FIX APPROACH (1-3 sentences): Specific fix strategy
+  5. FILES TO MODIFY (bullet list, paths only — no prose)
+  6. REGRESSION RISK (one line): Low/Medium/High with one-sentence justification
 ```
 
 #### 3.5.2: FIX
@@ -862,8 +869,7 @@ Prompt: |
 
   <append cross-cutting overlays>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.implementer under "## Project: Coding Standards" — skip if empty>
+  <append local overlays for the implementer role per the Step 0.2 matrix; skip empty files>
 
   BUILD COMMAND: python3 .claude/scripts/<resolved_stack>/build.py
   TEST COMMAND: python3 .claude/scripts/<resolved_stack>/test.py
@@ -896,7 +902,7 @@ Agent: code-reviewer-agent
 Model: sonnet
 Prompt: |
   You are being launched by the orchestration pipeline.
-  Use your Pipeline Mode output protocol (PASS/FAIL).
+  Use the PASS/FAIL output protocol from your agent definition.
 
   TECH STACK REVIEW RULES:
   <resolve stack from affected files, then paste
@@ -905,9 +911,7 @@ Prompt: |
 
   <append cross-cutting overlays>
 
-  <append local overlays: LOCAL_OVERLAYS.all under "## Project: Local Standards",
-   LOCAL_OVERLAYS.implementer under "## Project: Coding Standards",
-   LOCAL_OVERLAYS.reviewer under "## Project: Review Criteria" — skip if empty>
+  <append local overlays for the reviewer role per the Step 0.2 matrix; skip empty files>
 
   This is a BUG FIX review. In addition to your standard checks, explicitly verify:
   - The fix does not revert or contradict the original implementation's intent

--- a/skills/token-analysis/SKILL.md
+++ b/skills/token-analysis/SKILL.md
@@ -107,8 +107,8 @@ Flag any of these anomalies:
 
 ### 7. Hidden Token Sources
 
-Examine the `files_read` and `agent_input_self` fields from agent TOKEN_REPORTs to assess
-consumption invisible to the orchestrator's prompt-level tracking:
+Examine the `files_read` field from agent TOKEN_REPORTs to assess file-read consumption
+invisible to the orchestrator's prompt-level tracking:
 
 - **Agent definition reads**: If multiple agents of the same type each read their definition
   from disk (e.g., `implementer-agent.md` read 9 times), compute the cumulative cost. This is
@@ -118,13 +118,90 @@ consumption invisible to the orchestrator's prompt-level tracking:
   inline the relevant types into each brief instead.
 - **Large file ingestion**: Any single file read > 5,000 chars by a Haiku agent is suspect —
   Haiku tasks should be self-contained from their brief, not reading large files.
-- **Self-assessed vs orchestrator-tracked delta**: Compare each agent's `agent_input_self` to the
-  orchestrator's `input_chars`. The difference represents hidden consumption (file reads, tool
-  outputs, agent definition ingestion). Compute the total delta across all agents — this is the
-  "blind spot" the orchestrator's prompt-level tracking misses.
+- **Aggregate file-read overhead**: Sum the chars across all `files_read` entries in the
+  ledger. If this exceeds 30% of total orchestrator-tracked input chars, flag as a finding —
+  agents are spending heavily on disk I/O that the planner could potentially inline.
 
-If total hidden consumption exceeds 30% of orchestrator-tracked consumption, flag this as a
-significant finding.
+Note: Earlier versions of this skill compared `agent_input_self` to orchestrator-tracked
+`input_chars` to compute a "hidden consumption delta." Self-assessed agent input was
+unreliable (agents cannot accurately count their prompt size) and that calculation was
+removed. The aggregate file-read overhead above replaces it as the actionable signal.
+
+### 8a. Orchestrator Fixed Overhead
+
+The `TOKEN_LEDGER` records cost per agent invocation, but the orchestrator itself consumes
+tokens that are invisible to per-agent tracking:
+
+- The orchestrate skill file (loaded as part of the orchestrator's working context)
+- ORCHESTRATOR.md extracts pasted into each architect-agent prompt
+- Adapter overlay files loaded for each implementer/reviewer launch
+- Cross-cutting overlay files (when applicable)
+- Local overlay files (`.claude/local/*.md`)
+
+Estimate fixed overhead from known file sizes (these are cheap stat-only operations):
+
+```
+fixed_overhead_chars = 0
+fixed_overhead_chars += filesize(<pipeline_root>/skills/orchestrate/SKILL.md)
+fixed_overhead_chars += sum(filesize(<pipeline_root>/agents/<role>-agent.md) for role in [architect, implementer, code-reviewer])
+fixed_overhead_chars += filesize(.claude/ORCHESTRATOR.md)  # full file as conservative upper bound
+for stack in stacks:
+    for overlay_type in [architect, implementer, implementer_essential, reviewer, test]:
+        fixed_overhead_chars += filesize(<pipeline_root>/adapters/<stack>/<overlay_type>-overlay.md)
+for overlay in overlays:
+    fixed_overhead_chars += sum(filesizes of overlay files)
+for local in [project-overlay, coding-standards, architecture-rules, review-criteria]:
+    if exists(.claude/local/<local>.md):
+        fixed_overhead_chars += filesize
+```
+
+Convert to tokens: `fixed_overhead_tokens = fixed_overhead_chars / 4`.
+
+Report this as a top-level line in the issue body:
+```
+Fixed orchestrator overhead: ~N,NNN tokens (~$X.XX at Sonnet input rates)
+This is loaded ~once per /orchestrate run, separate from per-agent costs.
+```
+
+If `fixed_overhead_tokens > 25,000`, flag as a finding — the orchestrate skill or overlays
+have grown enough that pipeline startup cost is becoming significant. Recommend trimming the
+orchestrate skill (it should target <15K tokens) or splitting overlay content.
+
+### 8. Output Bloat Detection (per-agent-type baselines)
+
+Compare each agent's `output_tokens` to the expected baseline for its protocol output. The
+output protocols are tightly contracted — outputs that significantly exceed the baseline
+indicate the agent is over-explaining, ignoring the "Do NOT deliver" guardrails, or
+emitting Standalone-Mode content when it should emit Pipeline-Mode (PASS/FAIL).
+
+| Agent / output type | Baseline output tokens | Soft cap (flag at) | Hard cap (anomaly) |
+|---|---|---|---|
+| implementer SUCCESS (Haiku) | ~300 | 600 | 1,500 |
+| implementer SUCCESS (Sonnet) | ~400 | 800 | 2,000 |
+| implementer FAILURE | ~250 | 500 | 1,200 |
+| reviewer PASS | ~200 | 400 | 1,000 |
+| reviewer FAIL | ~500 | 1,200 | 3,000 |
+| architect 1a (per round) | ~600 | 800 | 1,500 |
+| architect 1b stub (PLAN_WRITTEN) | ~250 | 500 | 1,000 |
+| architect blast-radius (3.5) | ~400 | 800 | 1,500 |
+
+**Soft cap exceeded:** flag as a minor finding; suggests the agent is verbose. Cumulative
+cost matters more than individual outliers — sum the soft-cap violations across the run.
+If 3+ outputs exceed soft cap, recommend tightening the agent's "do not deliver" rules.
+
+**Hard cap exceeded:** flag as a Section 6 anomaly. Likely causes:
+- Implementer added preamble/commentary before SUCCESS/FAILURE header
+- Reviewer fell back to legacy verbose format (B3 should have removed this — check for
+  CRITICAL ISSUES / SOLID VIOLATIONS / RECOMMENDED REFACTORINGS section headers)
+- Architect emitted full plan in 1b instead of PLAN_WRITTEN stub (B1 regression)
+- Optional improvements section exceeded the 5-entry cap (B2 regression)
+
+To classify by type, parse the agent's first output line:
+- `SUCCESS` / `FAILURE` → implementer
+- `PASS` / `FAIL` → reviewer
+- `PLAN_WRITTEN:` → architect 1b
+- `CLARIFICATION COMPLETE` → architect 1a final
+- Other → architect (analysis or blast-radius) — use the step prefix in the ledger entry
 
 ## Significance Threshold
 
@@ -134,7 +211,9 @@ Only file a GitHub issue if **at least ONE** of these conditions is met:
 - Any anomaly from Section 6 is detected
 - 3 or more prompt efficiency flags from Section 3
 - Review cost ratio > 0.5 from Section 5
-- Hidden consumption exceeds 30% of orchestrator-tracked consumption (Section 7)
+- Aggregate file-read overhead exceeds 30% of orchestrator-tracked input (Section 7)
+- 3+ outputs exceed the soft cap, OR any output exceeds the hard cap (Section 8)
+- Fixed orchestrator overhead exceeds 25,000 tokens (Section 8a)
 
 If none of these thresholds are met, output `FINDINGS: NONE` and stop.
 
@@ -190,6 +269,9 @@ Use this structure for the issue body:
 **Total pipeline cost:** $X.XX (estimated)
 **Total tokens:** X input / X output
 **Agent calls:** X total
+**Fixed orchestrator overhead:** ~N,NNN tokens (~$X.XX) — orchestrate skill, agent
+definitions, adapter overlays, ORCHESTRATOR.md (loaded once per run, separate from
+per-agent costs above)
 
 ## Cost Breakdown by Step
 

--- a/tests/fixtures/implementer-failure.txt
+++ b/tests/fixtures/implementer-failure.txt
@@ -9,16 +9,6 @@ src/calculator.py
 tests/test_calculator.py
 
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~450 chars)
-- src/utils.py (~300 chars)
-TOOL_CALLS:
-- build-runner: 2
-- test-runner: 0
-- Read: 4
-- Write: 1
-- Edit: 3
-- Bash: 0
-SELF_ASSESSED_INPUT: ~9200 chars
-SELF_ASSESSED_OUTPUT: ~800 chars
+FILES_READ: src/calculator.py ~450; src/utils.py ~300
+TOOL_CALLS: build-runner=2 test-runner=0 Read=4 Write=1 Edit=3 Bash=0
 ---END_TOKEN_REPORT---

--- a/tests/fixtures/implementer-success.txt
+++ b/tests/fixtures/implementer-success.txt
@@ -7,16 +7,6 @@ feat(calculator): add multiply function to calculator module
 - Add comprehensive unit tests achieving 94% coverage
 
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~450 chars)
-- tests/test_calculator.py (~820 chars)
-TOOL_CALLS:
-- build-runner: 1
-- test-runner: 2
-- Read: 3
-- Write: 1
-- Edit: 2
-- Bash: 0
-SELF_ASSESSED_INPUT: ~8500 chars
-SELF_ASSESSED_OUTPUT: ~1200 chars
+FILES_READ: src/calculator.py ~450; tests/test_calculator.py ~820
+TOOL_CALLS: build-runner=1 test-runner=2 Read=3 Write=1 Edit=2 Bash=0
 ---END_TOKEN_REPORT---

--- a/tests/fixtures/plan-stub.txt
+++ b/tests/fixtures/plan-stub.txt
@@ -1,0 +1,13 @@
+PLAN_WRITTEN: .claude/tmp/1b-plan.md
+
+Summary:
+- Feature: Add JWT refresh token rotation
+- Plan type: feat
+- Waves: 3 (sizes: 4, 3, 2)
+- Total tasks: 9
+- Models: 7 Haiku, 2 Sonnet, 0 Opus
+- Stacks: python, react
+- Estimated cost: $0.18
+- Implementation clarification: resolved in 1 round
+
+Deferred items: 2

--- a/tests/fixtures/reviewer-fail.txt
+++ b/tests/fixtures/reviewer-fail.txt
@@ -16,14 +16,6 @@ Consider extracting validation helpers to reduce duplication across arithmetic f
 The error messages could include the actual values that caused the failure for debugging
 
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~520 chars)
-- tests/test_calculator.py (~1100 chars)
-- src/types.py (~200 chars)
-TOOL_CALLS:
-- Read: 5
-- Grep: 3
-- Glob: 1
-SELF_ASSESSED_INPUT: ~7200 chars
-SELF_ASSESSED_OUTPUT: ~900 chars
+FILES_READ: src/calculator.py ~520; tests/test_calculator.py ~1100; src/types.py ~200
+TOOL_CALLS: Read=5 Grep=3 Glob=1
 ---END_TOKEN_REPORT---

--- a/tests/fixtures/reviewer-pass-with-optional-tagged.txt
+++ b/tests/fixtures/reviewer-pass-with-optional-tagged.txt
@@ -3,12 +3,6 @@ PASS
 [nice-to-have] Error messages could include the offending value for easier debugging
 
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~520 chars)
-- tests/test_calculator.py (~1100 chars)
-TOOL_CALLS:
-- Read: 3
-- Grep: 1
-SELF_ASSESSED_INPUT: ~4200 chars
-SELF_ASSESSED_OUTPUT: ~300 chars
+FILES_READ: src/calculator.py ~520; tests/test_calculator.py ~1100
+TOOL_CALLS: Read=3 Grep=1
 ---END_TOKEN_REPORT---

--- a/tests/fixtures/reviewer-pass.txt
+++ b/tests/fixtures/reviewer-pass.txt
@@ -3,13 +3,6 @@ Minor: consider using math.isclose() for float comparisons in test assertions
 Minor: multiply docstring could mention overflow behavior
 
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~520 chars)
-- tests/test_calculator.py (~1100 chars)
-TOOL_CALLS:
-- Read: 4
-- Grep: 2
-- Glob: 1
-SELF_ASSESSED_INPUT: ~6800 chars
-SELF_ASSESSED_OUTPUT: ~350 chars
+FILES_READ: src/calculator.py ~520; tests/test_calculator.py ~1100
+TOOL_CALLS: Read=4 Grep=2 Glob=1
 ---END_TOKEN_REPORT---

--- a/tests/fixtures/token-report.txt
+++ b/tests/fixtures/token-report.txt
@@ -1,18 +1,4 @@
 ---TOKEN_REPORT---
-FILES_READ:
-- src/calculator.py (~450 chars)
-- src/utils.py (~300 chars)
-- tests/test_calculator.py (~820 chars)
-- .claude/ORCHESTRATOR.md (~3200 chars)
-TOOL_CALLS:
-- build-runner: 1
-- test-runner: 2
-- Read: 6
-- Write: 2
-- Edit: 3
-- Grep: 1
-- Glob: 0
-- Bash: 1
-SELF_ASSESSED_INPUT: ~12500 chars
-SELF_ASSESSED_OUTPUT: ~2100 chars
+FILES_READ: src/calculator.py ~450; src/utils.py ~300; tests/test_calculator.py ~820; .claude/ORCHESTRATOR.md ~3200
+TOOL_CALLS: build-runner=1 test-runner=2 Read=6 Write=2 Edit=3 Grep=1 Glob=0 Bash=1
 ---END_TOKEN_REPORT---

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -137,7 +137,16 @@ def parse_reviewer_result(output: str) -> dict:
 
 
 def parse_token_report(output: str) -> dict | None:
-    """Extract TOKEN_REPORT block from any agent output."""
+    """Extract TOKEN_REPORT block from any agent output.
+
+    Compact single-line-per-field format:
+        ---TOKEN_REPORT---
+        FILES_READ: <path1> ~Nchars; <path2> ~Nchars
+        TOOL_CALLS: Read=N Write=N Edit=N build-runner=N
+        ---END_TOKEN_REPORT---
+
+    `FILES_READ` may be `(none)` when no files were read; `TOOL_CALLS` is required.
+    """
     start_marker = "---TOKEN_REPORT---"
     end_marker = "---END_TOKEN_REPORT---"
 
@@ -152,25 +161,22 @@ def parse_token_report(output: str) -> dict | None:
     block = output[start_idx + len(start_marker):end_idx].strip()
     report: dict = {"files_read": [], "tool_calls": {}}
 
-    section = None
     for line in block.split("\n"):
         stripped = line.strip()
-        if stripped == "FILES_READ:":
-            section = "files"
-        elif stripped == "TOOL_CALLS:":
-            section = "tools"
-        elif stripped.startswith("SELF_ASSESSED_INPUT:"):
-            report["self_assessed_input"] = stripped.split(":", 1)[1].strip()
-            section = None
-        elif stripped.startswith("SELF_ASSESSED_OUTPUT:"):
-            report["self_assessed_output"] = stripped.split(":", 1)[1].strip()
-            section = None
-        elif section == "files" and stripped.startswith("- "):
-            report["files_read"].append(stripped[2:])
-        elif section == "tools" and stripped.startswith("- "):
-            parts = stripped[2:].split(":", 1)
-            if len(parts) == 2:
-                report["tool_calls"][parts[0].strip()] = parts[1].strip()
+        if stripped.startswith("FILES_READ:"):
+            payload = stripped.split(":", 1)[1].strip()
+            if payload and payload.lower() != "(none)":
+                report["files_read"] = [
+                    entry.strip()
+                    for entry in payload.split(";")
+                    if entry.strip()
+                ]
+        elif stripped.startswith("TOOL_CALLS:"):
+            payload = stripped.split(":", 1)[1].strip()
+            for token in payload.split():
+                if "=" in token:
+                    name, count = token.split("=", 1)
+                    report["tool_calls"][name.strip()] = count.strip()
 
     return report
 
@@ -233,6 +239,78 @@ def parse_open_pr_result(output: str) -> dict:
             result["number"] = line.split(":", 1)[1].strip()
         elif line.startswith("PR_URL:"):
             result["url"] = line.split(":", 1)[1].strip()
+    return result
+
+
+def parse_plan_stub(output: str) -> dict | None:
+    """Parse the architect-planner's PLAN_WRITTEN stub.
+
+    Expected format (emitted by 1b agent on final plan output):
+        PLAN_WRITTEN: .claude/tmp/1b-plan.md
+
+        Summary:
+        - Feature: <name>
+        - Plan type: feat
+        - Waves: 3 (sizes: 4, 3, 2)
+        - Total tasks: 9
+        - Models: 7 Haiku, 2 Sonnet, 0 Opus
+        - Stacks: react, python
+        - Estimated cost: $0.18
+        - Implementation clarification: none
+
+        Deferred items: 0
+    """
+    if "PLAN_WRITTEN:" not in output:
+        return None
+
+    result: dict = {"path": "", "deferred_items": 0}
+    for line in output.strip().split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("PLAN_WRITTEN:"):
+            result["path"] = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("- Feature:"):
+            result["feature"] = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("- Plan type:"):
+            result["plan_type"] = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("- Total tasks:"):
+            try:
+                result["total_tasks"] = int(stripped.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif stripped.startswith("- Waves:"):
+            payload = stripped.split(":", 1)[1].strip()
+            # "3 (sizes: 4, 3, 2)" -> waves=3, wave_sizes=[4,3,2]
+            count_match = re.match(r"(\d+)", payload)
+            if count_match:
+                result["waves"] = int(count_match.group(1))
+            sizes_match = re.search(r"sizes:\s*([\d,\s]+)", payload)
+            if sizes_match:
+                result["wave_sizes"] = [
+                    int(s.strip()) for s in sizes_match.group(1).split(",")
+                    if s.strip().isdigit()
+                ]
+        elif stripped.startswith("- Models:"):
+            payload = stripped.split(":", 1)[1].strip()
+            counts = {}
+            for match in re.finditer(r"(\d+)\s+(Haiku|Sonnet|Opus)", payload):
+                counts[match.group(2).lower()] = int(match.group(1))
+            result["models"] = counts
+        elif stripped.startswith("- Stacks:"):
+            payload = stripped.split(":", 1)[1].strip()
+            result["stacks"] = [s.strip() for s in payload.split(",") if s.strip()]
+        elif stripped.startswith("- Estimated cost:"):
+            payload = stripped.split(":", 1)[1].strip().lstrip("$")
+            try:
+                result["estimated_cost"] = float(payload)
+            except ValueError:
+                pass
+        elif stripped.startswith("Deferred items:"):
+            payload = stripped.split(":", 1)[1].strip()
+            try:
+                result["deferred_items"] = int(payload)
+            except ValueError:
+                pass
+
     return result
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -31,6 +31,7 @@ from parsers import (
     parse_drift_check_output,
     parse_implementer_result,
     parse_open_pr_result,
+    parse_plan_stub,
     parse_reviewer_result,
     parse_security_scan_output,
     parse_test_output,
@@ -66,8 +67,11 @@ class TestImplementerProtocol(unittest.TestCase):
         self.assertIsNotNone(report)
         self.assertIn("files_read", report)
         self.assertIn("tool_calls", report)
-        self.assertIn("self_assessed_input", report)
-        self.assertIn("self_assessed_output", report)
+        self.assertGreater(len(report["files_read"]), 0)
+        self.assertGreater(len(report["tool_calls"]), 0)
+        # Self-assessed fields removed in compact format — orchestrator computes these.
+        self.assertNotIn("self_assessed_input", report)
+        self.assertNotIn("self_assessed_output", report)
 
     def test_failure_has_token_report(self) -> None:
         fixture = (FIXTURES_DIR / "implementer-failure.txt").read_text()
@@ -197,19 +201,58 @@ class TestTokenReport(unittest.TestCase):
         self.assertIsNotNone(report)
         self.assertTrue(len(report["files_read"]) > 0)
         self.assertTrue(len(report["tool_calls"]) > 0)
-        self.assertIn("self_assessed_input", report)
-        self.assertIn("self_assessed_output", report)
+        # Compact format drops self-assessed input/output.
+        self.assertNotIn("self_assessed_input", report)
+        self.assertNotIn("self_assessed_output", report)
 
     def test_missing_report_returns_none(self) -> None:
         output = "SUCCESS\n\nfeat(core): add thing"
         report = parse_token_report(output)
         self.assertIsNone(report)
 
-    def test_malformed_report_returns_partial(self) -> None:
-        output = "PASS\n---TOKEN_REPORT---\nFILES_READ:\n- src/app.py (~1200 chars)\n---END_TOKEN_REPORT---"
+    def test_compact_format_parses(self) -> None:
+        """Compact format: single-line FILES_READ and TOOL_CALLS."""
+        output = (
+            "PASS\n"
+            "---TOKEN_REPORT---\n"
+            "FILES_READ: src/app.py ~1200; src/util.py ~400\n"
+            "TOOL_CALLS: Read=3 Grep=1\n"
+            "---END_TOKEN_REPORT---"
+        )
         report = parse_token_report(output)
         self.assertIsNotNone(report)
-        self.assertEqual(len(report["files_read"]), 1)
+        self.assertEqual(len(report["files_read"]), 2)
+        self.assertEqual(report["tool_calls"]["Read"], "3")
+        self.assertEqual(report["tool_calls"]["Grep"], "1")
+
+    def test_files_read_none_handled(self) -> None:
+        """FILES_READ may be (none) when no files were read."""
+        output = (
+            "SUCCESS\n\nfix(core): tweak\n"
+            "---TOKEN_REPORT---\n"
+            "FILES_READ: (none)\n"
+            "TOOL_CALLS: Edit=1\n"
+            "---END_TOKEN_REPORT---"
+        )
+        report = parse_token_report(output)
+        self.assertIsNotNone(report)
+        self.assertEqual(report["files_read"], [])
+        self.assertEqual(report["tool_calls"]["Edit"], "1")
+
+    def test_no_self_assessed_fields_in_output(self) -> None:
+        """Regression: SELF_ASSESSED_* fields should not appear in compact output."""
+        for fixture_name in [
+            "implementer-success.txt",
+            "implementer-failure.txt",
+            "reviewer-pass.txt",
+            "reviewer-fail.txt",
+            "token-report.txt",
+        ]:
+            content = (FIXTURES_DIR / fixture_name).read_text()
+            self.assertNotIn("SELF_ASSESSED_INPUT", content,
+                             f"{fixture_name} still has SELF_ASSESSED_INPUT")
+            self.assertNotIn("SELF_ASSESSED_OUTPUT", content,
+                             f"{fixture_name} still has SELF_ASSESSED_OUTPUT")
 
 
 class TestTokenAnalysisResult(unittest.TestCase):
@@ -231,6 +274,37 @@ class TestOpenPRResult(unittest.TestCase):
         self.assertEqual(result["branch"], "feat/add-feature")
         self.assertEqual(result["number"], "42")
         self.assertIn("github.com", result["url"])
+
+
+class TestPlanStub(unittest.TestCase):
+    def test_plan_stub_full_parse(self) -> None:
+        fixture = (FIXTURES_DIR / "plan-stub.txt").read_text()
+        result = parse_plan_stub(fixture)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["path"], ".claude/tmp/1b-plan.md")
+        self.assertEqual(result["feature"], "Add JWT refresh token rotation")
+        self.assertEqual(result["plan_type"], "feat")
+        self.assertEqual(result["waves"], 3)
+        self.assertEqual(result["wave_sizes"], [4, 3, 2])
+        self.assertEqual(result["total_tasks"], 9)
+        self.assertEqual(result["models"]["haiku"], 7)
+        self.assertEqual(result["models"]["sonnet"], 2)
+        self.assertEqual(result["models"]["opus"], 0)
+        self.assertEqual(result["stacks"], ["python", "react"])
+        self.assertAlmostEqual(result["estimated_cost"], 0.18)
+        self.assertEqual(result["deferred_items"], 2)
+
+    def test_plan_stub_missing_returns_none(self) -> None:
+        result = parse_plan_stub("Some random text without the marker")
+        self.assertIsNone(result)
+
+    def test_plan_stub_minimal(self) -> None:
+        """A minimal stub should parse without optional fields."""
+        output = "PLAN_WRITTEN: .claude/tmp/1b-plan.md\n\nSummary:\n- Total tasks: 3"
+        result = parse_plan_stub(output)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["path"], ".claude/tmp/1b-plan.md")
+        self.assertEqual(result["total_tasks"], 3)
 
 
 class TestEdgeCases(unittest.TestCase):

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -262,6 +262,38 @@ def check_essential_overlay_size(result: ValidationResult) -> None:
             )
 
 
+def check_essential_overlay_no_pipeline_protocol_rules(result: ValidationResult) -> None:
+    """Essential overlays must not duplicate pipeline-protocol rules from agent definitions (C1).
+
+    The 'Never run git commit/git push' rule lives in implementer-agent.md (always loaded
+    as system prompt). Repeating it in adapter essentials is pure duplication — Haiku tasks
+    that read the agent definition + essential see the same rule twice.
+    """
+    overlay_paths = []
+    for adapter in ADAPTERS:
+        overlay_paths.append(PIPELINE_ROOT / "adapters" / adapter / "implementer-overlay-essential.md")
+    for overlay in OVERLAYS:
+        overlay_paths.append(PIPELINE_ROOT / "overlays" / overlay / "implementer-overlay-essential.md")
+
+    for path in overlay_paths:
+        if not path.exists():
+            continue
+        rel = path.relative_to(PIPELINE_ROOT)
+        content = path.read_text()
+        if "git commit" in content and "orchestrator commits" in content:
+            result.fail(
+                f"{rel}: still contains 'git commit' pipeline-protocol rule "
+                f"(C1 regression — that rule belongs in implementer-agent.md)"
+            )
+        elif "Critical rules for Haiku execution. Violations will fail code review" in content:
+            result.fail(
+                f"{rel}: still contains boilerplate disclaimer "
+                f"(C1 — remove this filler line, the rules speak for themselves)"
+            )
+        else:
+            result.ok(f"{rel}: free of pipeline-protocol duplication")
+
+
 def check_agent_markers(result: ValidationResult) -> None:
     """Agents must have the correct injection markers."""
     for agent_file, markers in AGENT_MARKERS.items():
@@ -293,7 +325,12 @@ def check_agent_protocols(result: ValidationResult) -> None:
 
 
 def check_token_report_consistency(result: ValidationResult) -> None:
-    """All agents that should emit TOKEN_REPORT must document the format."""
+    """All agents that should emit TOKEN_REPORT must document the compact format.
+
+    The compact format drops SELF_ASSESSED_* fields (unreliable self-reports) and
+    consolidates FILES_READ/TOOL_CALLS to single-line entries. Agents must NOT
+    re-introduce the verbose multi-line format.
+    """
     token_report_agents = ["implementer-agent.md", "code-reviewer-agent.md", "architect-agent.md"]
     for agent_file in token_report_agents:
         path = PIPELINE_ROOT / "agents" / agent_file
@@ -304,24 +341,36 @@ def check_token_report_consistency(result: ValidationResult) -> None:
         has_start = "---TOKEN_REPORT---" in content
         has_end = "---END_TOKEN_REPORT---" in content
         has_files_read = "FILES_READ:" in content
-        has_self_input = "SELF_ASSESSED_INPUT:" in content
-        has_self_output = "SELF_ASSESSED_OUTPUT:" in content
+        has_tool_calls = "TOOL_CALLS:" in content
+        # Compact format: SELF_ASSESSED_* must be absent
+        has_self_input = "SELF_ASSESSED_INPUT" in content
+        has_self_output = "SELF_ASSESSED_OUTPUT" in content
 
-        if all([has_start, has_end, has_files_read, has_self_input, has_self_output]):
-            result.ok(f"Agent {agent_file}: TOKEN_REPORT format complete")
+        missing = []
+        if not has_start:
+            missing.append("---TOKEN_REPORT---")
+        if not has_end:
+            missing.append("---END_TOKEN_REPORT---")
+        if not has_files_read:
+            missing.append("FILES_READ:")
+        if not has_tool_calls:
+            missing.append("TOOL_CALLS:")
+
+        bloat = []
+        if has_self_input:
+            bloat.append("SELF_ASSESSED_INPUT (compact format dropped this)")
+        if has_self_output:
+            bloat.append("SELF_ASSESSED_OUTPUT (compact format dropped this)")
+
+        if not missing and not bloat:
+            result.ok(f"Agent {agent_file}: TOKEN_REPORT compact format complete")
         else:
-            missing = []
-            if not has_start:
-                missing.append("---TOKEN_REPORT---")
-            if not has_end:
-                missing.append("---END_TOKEN_REPORT---")
-            if not has_files_read:
-                missing.append("FILES_READ:")
-            if not has_self_input:
-                missing.append("SELF_ASSESSED_INPUT:")
-            if not has_self_output:
-                missing.append("SELF_ASSESSED_OUTPUT:")
-            result.fail(f"Agent {agent_file}: TOKEN_REPORT missing: {', '.join(missing)}")
+            details = []
+            if missing:
+                details.append(f"missing: {', '.join(missing)}")
+            if bloat:
+                details.append(f"bloat: {', '.join(bloat)}")
+            result.fail(f"Agent {agent_file}: TOKEN_REPORT — {' | '.join(details)}")
 
 
 def check_implementer_contract_references(result: ValidationResult) -> None:
@@ -392,6 +441,158 @@ def check_extract_profile_headers(result: ValidationResult) -> None:
                 result.fail(f"Extract {profile_name}: header '## {header}' not found in template")
 
 
+def check_token_analysis_output_baselines(result: ValidationResult) -> None:
+    """Token-analysis skill must document per-agent-type output baselines (E1)."""
+    path = PIPELINE_ROOT / "skills" / "token-analysis" / "SKILL.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+    required_markers = [
+        "Output Bloat Detection",
+        "Soft cap exceeded",
+        "Hard cap exceeded",
+        "PLAN_WRITTEN",
+        "implementer SUCCESS",
+        "reviewer PASS",
+    ]
+    missing = [m for m in required_markers if m not in content]
+    if missing:
+        result.fail(f"token-analysis missing E1 baselines: {', '.join(missing)}")
+    else:
+        result.ok("token-analysis documents per-agent output baselines (E1)")
+
+
+def check_token_analysis_fixed_overhead(result: ValidationResult) -> None:
+    """Token-analysis skill must document fixed orchestrator overhead estimation (E2)."""
+    path = PIPELINE_ROOT / "skills" / "token-analysis" / "SKILL.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+    required_markers = [
+        "Orchestrator Fixed Overhead",
+        "fixed_overhead_chars",
+        "Fixed orchestrator overhead",
+        "25,000 tokens",
+    ]
+    missing = [m for m in required_markers if m not in content]
+    if missing:
+        result.fail(f"token-analysis missing E2 fixed-overhead docs: {', '.join(missing)}")
+    else:
+        result.ok("token-analysis documents fixed orchestrator overhead (E2)")
+
+
+def check_clarification_round_caps(result: ValidationResult) -> None:
+    """Architect skills must cap clarification round output to bound input bloat (B5)."""
+    for skill_path in [
+        PIPELINE_ROOT / "skills" / "architect-analyzer" / "SKILL.md",
+        PIPELINE_ROOT / "skills" / "architect-planner" / "SKILL.md",
+    ]:
+        if not skill_path.exists():
+            continue
+        content = skill_path.read_text()
+        rel_path = skill_path.relative_to(PIPELINE_ROOT)
+        if "800 tokens" in content or "800 token" in content:
+            result.ok(f"{rel_path}: documents 800-token clarification cap")
+        else:
+            result.fail(f"{rel_path}: missing clarification round output cap (B5)")
+
+
+def check_reviewer_no_standalone_mode(result: ValidationResult) -> None:
+    """Code-reviewer must not document a separate Standalone Mode (B3).
+
+    The reviewer historically had a verbose 7-section format for non-orchestrator
+    invocations. That format invited output bloat when prompts didn't crisply
+    signal Pipeline Mode. The PASS/FAIL protocol is now the only supported format.
+    """
+    path = PIPELINE_ROOT / "agents" / "code-reviewer-agent.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+    forbidden_markers = [
+        "## CRITICAL ISSUES",
+        "## SOLID / MAINTAINABILITY VIOLATIONS",
+        "## PERFORMANCE KILLERS",
+        "## RECOMMENDED REFACTORINGS",
+        "Standalone Mode (launched directly by user)",
+    ]
+    found = [m for m in forbidden_markers if m in content]
+    if found:
+        result.fail(
+            f"Code-reviewer still documents Standalone Mode (B3 regression): {', '.join(found)}"
+        )
+    else:
+        result.ok("Code-reviewer does not document Standalone Mode")
+
+    # Must still document the protocol guard
+    if "Protocol Guard" in content or "If your first line is not" in content:
+        result.ok("Code-reviewer documents protocol guard")
+    else:
+        result.fail("Code-reviewer missing protocol guard (PASS/FAIL header enforcement)")
+
+
+def check_reviewer_optional_cap(result: ValidationResult) -> None:
+    """Code-reviewer must document a cap on OPTIONAL IMPROVEMENTS to bound output."""
+    path = PIPELINE_ROOT / "agents" / "code-reviewer-agent.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+    if "maximum 5 entries" in content.lower() or "max 5 entries" in content.lower() or "Cap: maximum 5" in content:
+        result.ok("Code-reviewer documents OPTIONAL IMPROVEMENTS cap")
+    else:
+        result.fail("Code-reviewer missing OPTIONAL IMPROVEMENTS cap (B2)")
+
+    if "(N more not shown)" in content or "more not shown" in content:
+        result.ok("Code-reviewer documents overflow indicator")
+    else:
+        result.fail("Code-reviewer missing overflow indicator for capped entries (B2)")
+
+
+def check_planner_plan_stub(result: ValidationResult) -> None:
+    """Planner must emit PLAN_WRITTEN stub instead of the full plan."""
+    planner_path = PIPELINE_ROOT / "skills" / "architect-planner" / "SKILL.md"
+    if not planner_path.exists():
+        result.fail("architect-planner skill exists")
+        return
+
+    content = planner_path.read_text()
+    if "PLAN_WRITTEN:" in content:
+        result.ok("Planner documents PLAN_WRITTEN stub format")
+    else:
+        result.fail("Planner missing PLAN_WRITTEN stub documentation")
+
+    # Regression guard: planner must NOT instruct the agent to re-emit the full plan.
+    if "Output the plan as text to the orchestrator" in content:
+        result.fail(
+            "Planner still instructs agent to re-emit the full plan to orchestrator "
+            "(B1 regression — should write to disk only and emit PLAN_WRITTEN stub)"
+        )
+    else:
+        result.ok("Planner does not instruct double-pay full-plan emission")
+
+
+def check_orchestrate_reads_plan_from_disk(result: ValidationResult) -> None:
+    """Orchestrate must read 1b-plan.md from disk, not from agent output."""
+    orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
+    if not orchestrate_path.exists():
+        return
+
+    content = orchestrate_path.read_text()
+
+    if "PLAN_WRITTEN" in content:
+        result.ok("Orchestrate references PLAN_WRITTEN stub")
+    else:
+        result.fail("Orchestrate missing PLAN_WRITTEN stub reference")
+
+    if "read .claude/tmp/1b-plan.md" in content.lower() or "read `.claude/tmp/1b-plan.md`" in content.lower():
+        result.ok("Orchestrate documents reading 1b-plan.md from disk")
+    else:
+        result.fail("Orchestrate missing 'read 1b-plan.md from disk' instruction")
+
+
 def check_orchestrate_overlay_selection(result: ValidationResult) -> None:
     """Orchestrate must document Haiku vs full overlay selection logic."""
     orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
@@ -422,7 +623,6 @@ def check_orchestrate_token_ledger(result: ValidationResult) -> None:
     required_fields = [
         "step", "agent", "model", "input_chars", "output_chars",
         "is_retry", "is_escalation", "files_read", "tool_calls",
-        "agent_input_self", "agent_output_self",
     ]
 
     for field in required_fields:
@@ -852,10 +1052,18 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Required files", check_required_files),
         ("Adapter completeness", check_adapter_completeness),
         ("Essential overlay size", check_essential_overlay_size),
+        ("Essential overlay no pipeline-protocol rules", check_essential_overlay_no_pipeline_protocol_rules),
         ("Agent injection markers", check_agent_markers),
         ("Agent output protocols", check_agent_protocols),
         ("TOKEN_REPORT consistency", check_token_report_consistency),
         ("Implementer contract references", check_implementer_contract_references),
+        ("Reviewer no Standalone Mode", check_reviewer_no_standalone_mode),
+        ("Reviewer OPTIONAL IMPROVEMENTS cap", check_reviewer_optional_cap),
+        ("Clarification round caps", check_clarification_round_caps),
+        ("Token-analysis output baselines", check_token_analysis_output_baselines),
+        ("Token-analysis fixed overhead", check_token_analysis_fixed_overhead),
+        ("Planner PLAN_WRITTEN stub", check_planner_plan_stub),
+        ("Orchestrate reads plan from disk", check_orchestrate_reads_plan_from_disk),
         ("ORCHESTRATOR.md template sections", check_orchestrator_template_sections),
         ("Extract profile headers", check_extract_profile_headers),
         ("Overlay selection logic", check_orchestrate_overlay_selection),


### PR DESCRIPTION
## Summary

End-to-end token optimization across agents, skills, and overlays. Cuts an estimated **~8–12K tokens per `/orchestrate` run** — mostly OUTPUT, which is 5× more expensive than input at Sonnet rates.

This started as an analysis pass; the analysis surfaced 13 actionable opportunities, which were then implemented cluster-by-cluster with regression guards added in lockstep.

## Cluster A — Agent definition slimming

- **A1** Extract the SOLID/Maintainability treatise (~155 lines) from `code-reviewer-agent.md` to `agents/shared/SOLID-PRINCIPLES-GUIDE.md`. The agent keeps a compact ~15-line priority cue. Saves ~2,000 tokens per wave-reviewer launch (the largest single per-call saving).
- **A2** Replace `implementer-agent.md` Rules 1-3 with a reference to `implementer-contract.md`. Eliminates dual-source-of-truth (the file even had a `<!-- keep in sync -->` comment acknowledging the risk).
- **A3** Compact 3-line `TOKEN_REPORT` format. Dropped `SELF_ASSESSED_INPUT/OUTPUT` (unreliable — agents can't accurately count their own prompt size; the orchestrator already measures these itself). Saves ~150 tokens per agent output.

## Cluster B — Output discipline

- **B1** Architect 1b now emits a compact `PLAN_WRITTEN` stub instead of returning the full plan as agent output. Orchestrator reads the plan from `.claude/tmp/1b-plan.md` for downstream steps. Saves ~3–4K **OUTPUT** tokens per run (single largest output saving).
- **B2** Cap reviewer `OPTIONAL IMPROVEMENTS` at 5 entries with `(N more not shown)` overflow indicator.
- **B3** Delete reviewer Standalone Mode (the verbose 7-section format). Pipeline Mode `PASS`/`FAIL` is the only output protocol in either invocation context. Adds an explicit protocol guard.
- **B4** Per-field caps (1-3 sentences each) on blast-radius response fields.
- **B5** Cap architect clarification round outputs at 800 tokens (architect-analyzer + architect-planner).

## Cluster C — Adapter overlay deduplication

- **C1** Remove the `Never run git commit/git push` pipeline-protocol rule from 7 adapter essentials. That rule already lives in `implementer-agent.md`'s Output Protocol section (always loaded as system prompt) — repeating it in essentials was pure duplication. Also strips the boilerplate `Critical rules for Haiku execution. Violations will fail code review.` disclaimer.

## Cluster D — Orchestrate skill consolidation

- **D1** Consolidate 8 verbose `LOCAL_OVERLAYS` injection blocks (each 2-3 lines) into single-line references to the Step 0.2 matrix.

## Cluster E — Token-analysis improvements

- **E1** New Section 8 in `token-analysis` skill: per-agent-type output baselines (implementer SUCCESS ~300 tok, reviewer PASS ~200 tok, architect 1b stub ~250 tok, etc.) with soft/hard caps for bloat detection.
- **E2** New Section 8a: fixed orchestrator overhead estimation (orchestrate skill + agent definitions + adapter overlays + ORCHESTRATOR.md) — measures the per-run startup cost that's invisible to per-agent ledger tracking.

## File changes

| Layer | Files | Notes |
|---|---|---|
| Agents | 3 modified, 1 new (`agents/shared/SOLID-PRINCIPLES-GUIDE.md`) | code-reviewer-agent.md: 349 → 187 lines |
| Skills | 4 modified | orchestrate, token-analysis, architect-planner, architect-analyzer |
| Adapter overlays | 7 essentials | All under 1000-char target after dedup |
| Tests | 3 modified, 1 new fixture | parsers.py + 17 new validators + 5 new contract tests |

## Test plan

- [x] `python3 tests/validate_structure.py` — **330 → 347** passed (+17 regression-guard checks)
- [x] `python3 tests/test_contracts.py` — **73 → 78** passed (+5 tests including PLAN_WRITTEN parser & compact TOKEN_REPORT format)
- [x] `python3 tests/smoke/run_smoke.py` — **36/36** unchanged
- [ ] Run a full `/orchestrate` cycle on a consumer project to verify the new PLAN_WRITTEN stub flow end-to-end (next manual step)
- [ ] Review the `agents/shared/SOLID-PRINCIPLES-GUIDE.md` extract for content fidelity (no editorial loss vs. the prior in-agent treatise)

## Regression guards

Each new behavior has a `validate_structure.py` check that fails if the change is reverted. Reverting any of A1, A2, A3, B1, B2, B3, B5, C1, E1, or E2 would cause structural validation to fail, so this PR is its own ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)