### PR TITLE
feat(pipeline): add automated browser UI test step (chrome-ui-test)

### DIFF
--- a/adapters/react/manifest.json
+++ b/adapters/react/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "react",
   "display_name": "React / TypeScript",
-  "capabilities": [],
+  "capabilities": ["browser-ui"],
   "implies_overlays": [],
   "detection": [
     { "type": "file_contains", "path": "package.json", "pattern": "\"react\"" }

--- a/skills/chrome-ui-test/SKILL.md
+++ b/skills/chrome-ui-test/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: chrome-ui-test
+description: >
+  Automated browser-based UI smoke test for browser-hostable implementations.
+  Drives the dev server in Chrome via the claude-in-chrome MCP tools to exercise
+  the golden path, two to three edge cases, and a regression spot-check on
+  adjacent UI. Invoked by /orchestrate when --chrome is authorized AND at least
+  one active stack declares the `browser-ui` capability. Returns PASS/FAIL with
+  a short findings block.
+---
+
+# Chrome UI Test Skill
+
+You are a browser-driving test agent. You exercise the just-shipped UI in a real
+Chrome tab via the `claude-in-chrome` MCP tools and report PASS or FAIL. You do
+NOT modify code. You do NOT replace unit/integration tests — those already ran
+in Step 2. This is a **wired-up smoke test**: real DOM, real network, real
+runtime errors.
+
+## Required MCP Tools
+
+Before calling any browser tool, load it with `ToolSearch` (the claude-in-chrome
+tools are deferred):
+
+```
+ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__get_page_text,mcp__claude-in-chrome__find,mcp__claude-in-chrome__form_input,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__read_console_messages,mcp__claude-in-chrome__read_network_requests,mcp__claude-in-chrome__javascript_tool"
+```
+
+If any tool fails to load, abort with `FAIL` and report the missing tool — do
+NOT skip the test silently.
+
+## Inputs (provided by the orchestrator)
+
+| Field | Description |
+|-------|-------------|
+| `IMPLEMENTATION_SUMMARY` | One paragraph describing what shipped this run (from the plan + commits) |
+| `FILES_MODIFIED` | List of files touched by all waves |
+| `TASK_BRIEFS` | Original context briefs for browser-ui tasks, so you know acceptance criteria |
+| `DEV_SERVER_HINT` | URL or start command the project uses (e.g., `npm run dev`, default `http://localhost:5173`) |
+
+## Procedure
+
+### Step 1: Bring up the dev server
+
+1. Read `package.json` (or the active stack's equivalent) to find the dev script.
+   Common scripts: `dev`, `start`, `serve`. Prefer `dev` for Vite/Next, `start`
+   for Create React App.
+2. Run the dev server with `Bash(run_in_background: true)`:
+   ```
+   npm run dev
+   ```
+   Capture the background shell ID. Do NOT block on it.
+3. Poll for readiness with `curl -s http://localhost:<port> -o /dev/null -w "%{http_code}"`
+   inside an `until` loop (use `Monitor` if available; otherwise short Bash polls).
+   Timeout after 60 s — if the server never responds, abort with `FAIL`.
+
+If a dev server is already running on the expected port (curl returns `200`
+before you start one), reuse it and skip the boot step.
+
+### Step 2: Open Chrome and read tab context
+
+1. Call `mcp__claude-in-chrome__tabs_context_mcp` first — never reuse stale tab
+   IDs from prior sessions.
+2. Create a fresh tab with `mcp__claude-in-chrome__tabs_create_mcp` pointing at
+   the dev server URL.
+3. Wait for navigation to settle (`mcp__claude-in-chrome__read_page` returning a
+   non-empty body).
+
+### Step 3: Golden-path exercise
+
+For the primary user-visible feature in `IMPLEMENTATION_SUMMARY`:
+
+1. Identify the entry point (route, button, form) from the task briefs.
+2. Use `mcp__claude-in-chrome__find` to locate the element by accessible name.
+   Prefer roles + names (e.g., button "Submit"); fall back to text only if needed.
+3. Drive the interaction with `mcp__claude-in-chrome__form_input` (for inputs)
+   or `mcp__claude-in-chrome__computer` (for clicks the find-tool can target).
+4. Verify the expected post-condition by reading the page text or DOM
+   (`mcp__claude-in-chrome__get_page_text`).
+5. After every interaction, call `mcp__claude-in-chrome__read_console_messages`
+   with `pattern: "error|warning|uncaught"` to catch runtime errors. Any
+   uncaught exception is a `FAIL`.
+
+### Step 4: Edge cases (2-3 max)
+
+Pick edge cases from the task brief's acceptance criteria — NOT invented ones.
+Typical UI edge cases worth one click each:
+
+- Empty submit / required-field validation
+- Network failure surface (use `mcp__claude-in-chrome__read_network_requests`
+  to confirm error handling renders rather than crashes)
+- Long input / boundary value (if the brief specifies a length or range)
+
+Skip edge cases that the brief did not call out — this is a smoke test, not a
+QA pass.
+
+### Step 5: Regression spot-check
+
+Navigate to ONE adjacent unrelated screen (the home route is fine if no other
+obvious neighbor exists). Confirm:
+
+- Page renders without console errors
+- A primary interactive element (nav link, button) is visible and clickable
+
+This is a 30-second sanity check — do not exhaustively retest the app.
+
+### Step 6: Optional GIF capture
+
+If the orchestrator passed `RECORD_GIF: true`, wrap the golden-path interaction
+with `mcp__claude-in-chrome__gif_creator` and save to
+`.claude/tmp/chrome-ui-test-<run-id>.gif`. Mention the file in your output so
+the orchestrator can attach it to the PR comment.
+
+### Step 7: Tear down
+
+1. Close the tab you created (do NOT close tabs the user already had open).
+2. Stop the background dev server only if YOU started it (do not kill a server
+   the user was already running). Read the background shell's exit-or-still-running
+   status and `kill <pid>` only if it matches your captured shell ID.
+
+## Output Protocol
+
+Emit ONE of these blocks, then a `TOKEN_REPORT`.
+
+### PASS
+
+```
+PASS
+
+Golden path: <one-line description, e.g., "Login form accepts valid credentials and navigates to /dashboard">
+Edge cases checked:
+- <case 1>: ok
+- <case 2>: ok
+Regression spot-check: <route>: ok
+Console errors: none
+GIF: <path or "not recorded">
+```
+
+### FAIL
+
+```
+FAIL
+
+Failing scenario: <one-line: which step in which case>
+Symptom: <what happened — DOM content, console message, network failure>
+Reproduction:
+1. <step>
+2. <step>
+Suspected file(s): <best guess from FILES_MODIFIED, or "unknown — needs triage">
+Console excerpt:
+  <last 5 relevant console lines>
+GIF: <path or "not recorded">
+```
+
+A FAIL routes back to the orchestrator, which feeds it into the same Step 3.5
+bug-fix cycle (assess → fix → review → re-test). The chrome agent does NOT fix
+bugs.
+
+### TOKEN_REPORT
+
+Append a 3-line compact token report so the orchestrator can record it in
+TOKEN_LEDGER:
+
+```
+---TOKEN_REPORT---
+files_read: <comma-separated paths with approx sizes, e.g., "package.json (~2KB)">
+tool_calls: navigate=N, read_page=N, find=N, form_input=N, console=N, network=N, gif=N
+---END_TOKEN_REPORT---
+```
+
+## Refusal Conditions
+
+Abort with `FAIL` and a clear reason if:
+
+- Required claude-in-chrome MCP tools cannot be loaded
+- Dev server fails to start within 60 s
+- A modal `alert`/`confirm`/`prompt` dialog appears (locks the extension —
+  warn the user to dismiss it manually)
+- 3 consecutive browser tool calls error out (see "Avoid rabbit holes" in the
+  global system instructions)
+
+Do NOT loop indefinitely retrying the same failing interaction. If a step fails
+twice with the same symptom, treat it as a real bug and emit FAIL with the
+reproduction recipe.
+
+## What This Skill Does NOT Do
+
+- Does not run unit tests (Step 2's `python3 .claude/scripts/<stack>/test.py` does)
+- Does not replace the user's manual test loop in Step 3.5 — it runs BEFORE it
+- Does not modify code (the orchestrator routes any FAIL into the bug-fix flow)
+- Does not perform visual-regression diffs (out of scope; needs a baseline store)
+- Does not test mobile/native UIs (those stacks do not declare `browser-ui`)

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -395,6 +395,12 @@ Step 3: COMMIT + PUSH (orchestrator commits per agent, pushes to PR branch)
     |  Uses the SUCCESS message verbatim as the git commit message
     |  Record test baseline (total passing count) after all waves complete
     v
+Step 3.4: AUTOMATED BROWSER UI TEST (chrome-ui-test skill, conditional)
+    |  Auto-fires when ACTIVE_CAPABILITIES includes `browser-ui`, this run touched
+    |    browser-ui files, AND the claude-in-chrome MCP tools are loadable
+    |  Drives the dev server in Chrome via claude-in-chrome MCP tools
+    |  Returns PASS or FAIL — FAIL feeds the same bug-fix cycle as Step 3.5
+    v
 Step 3.5: MANUAL TEST (user tests PR branch)
     |  User reports bugs OR says "tests pass"
     |  Each bug: assess blast radius -> fix (Sonnet) -> review -> full test suite -> commit
@@ -764,6 +770,82 @@ Pushing after each commit keeps the draft PR up to date so progress is visible.
 
 **Record test baseline:** After committing all waves, run the full test suite and record
 the total passing test count. This is the regression baseline for Step 3.5.
+
+### Step 3.4: AUTOMATED BROWSER UI TEST (conditional)
+
+**Gating rule:** Evaluate these checks in order. Skip Step 3.4 silently at the
+first one that fails — do not run later checks (each is more expensive than
+the last).
+
+1. **Capability check** — `ACTIVE_CAPABILITIES` includes `browser-ui` (at
+   least one active stack's `manifest.json` declares this capability — `react`
+   does by default). Fast in-memory lookup.
+2. **Wave-relevance check** — at least one file in `FILES_MODIFIED` (across
+   all waves this run) resolves via `resolve_stack()` to a stack with the
+   `browser-ui` capability. Pure backend-only runs skip Step 3.4.
+3. **Tool availability check** — probe whether the `claude-in-chrome` MCP
+   tools are authorized in the current session:
+   ```
+   ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp"
+   ```
+   If the result contains a `<function>` schema for that tool, chrome is
+   authorized. If the result is "No matching deferred tools found" (or
+   equivalent empty result), the MCP server is not configured for this
+   session — skip Step 3.4 silently. No flag, no warning: the user simply
+   has not opted into chrome for this session.
+
+The probe in check 3 is the source of truth for "is chrome authorized?" —
+mirroring how `ACTIVE_CAPABILITIES` drives `azure-auth`. There is no
+`--chrome` flag because the MCP tool list is itself the authorization signal:
+if the user added `claude-in-chrome` to their MCP config and approved it,
+the tools are loadable; if they did not, they are not.
+
+**Invocation:**
+
+```
+Skill: chrome-ui-test
+Prompt: |
+  Read `.claude/skills/chrome-ui-test/SKILL.md` for your instructions.
+
+  IMPLEMENTATION_SUMMARY:
+  <one paragraph from the plan + commit messages, focused on user-visible behavior>
+
+  FILES_MODIFIED:
+  <list of files touched across all waves, filtered to browser-ui stacks>
+
+  TASK_BRIEFS:
+  <paste the original context briefs for tasks whose stack has browser-ui capability>
+
+  DEV_SERVER_HINT:
+  <if the project has a `dev` script in package.json, paste the script line and
+   default port; otherwise the skill will inspect package.json itself>
+
+  RECORD_GIF: <true if the user explicitly asked for a recording in their request, else false>
+```
+
+**Outcome handling:**
+
+- **PASS** — record the result in TOKEN_LEDGER and proceed to Step 3.5. The
+  user-facing prompt for manual test should mention the automated smoke
+  passed: "Automated browser smoke test passed (golden path + N edge cases).
+  Please test the branch and report any bugs..."
+- **FAIL** — treat the failure as a bug report and route it through the
+  existing Step 3.5.1 (ASSESS) → 3.5.2 (FIX) → 3.5.3 (REVIEW) → 3.5.4
+  (COMMIT) → 3.5.5 (RE-TEST) cycle. Use the skill's "Reproduction" block as
+  the bug report. After the fix is committed, re-run Step 3.4 once before
+  handing back to the user. If Step 3.4 fails twice on the same scenario,
+  stop and present the findings — do NOT loop.
+
+**Token tracking:** Record a `TOKEN_LEDGER` entry for the chrome-ui-test
+invocation (step `3.4`). Agent: `orchestrator` (skill, not an Agent launch),
+model: `sonnet` (the orchestrator's own model). If a re-run occurs after a
+fix, record it as `3.4:retry-N`.
+
+**Why this runs before Step 3.5 rather than replacing it:** The automated
+smoke catches obvious wiring failures (uncaught exceptions, missing imports,
+broken routes) before bothering the user, but it cannot judge UX, copy,
+visual correctness, or business-rule edge cases. The user's manual test
+remains authoritative.
 
 ### Step 3.5: MANUAL TEST
 
@@ -1203,6 +1285,9 @@ PR). If no folds occurred, omit the section entirely.
 | Bug fix fails review twice | Launch architect blast-radius analysis, present to user |
 | 3+ bug-fix cycles in one manual test round | Stop, report all outstanding issues for manual triage |
 | Token analysis skill fails | Log warning, report to user, do not block pipeline completion |
+| chrome-ui-test FAIL | Route into Step 3.5.1-3.5.5 bug-fix cycle using its reproduction recipe as the bug report |
+| chrome-ui-test FAIL twice on same scenario after fix | Stop Step 3.4 retries, present findings, hand to user manual test |
+| claude-in-chrome MCP tools not loadable | Skip Step 3.4 silently — user has not authorized chrome for this session |
 | `gh issue create` fails (missing label, auth, etc.) | Retry without `--label`, report failure if still errors |
 | Pipeline repo has no GitHub remote | Skip issue filing, report token summary to user directly |
 | Backlog sentinel absent | Phase classifications still recorded in run-log; no `gh` calls; emit one-line hint on first skip |

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -86,6 +86,7 @@ REQUIRED_SKILLS = [
     "azure-login/SKILL.md",
     "update-pipeline/SKILL.md",
     "bootstrap-backlog/SKILL.md",
+    "chrome-ui-test/SKILL.md",
 ]
 
 REQUIRED_BACKLOG_TEMPLATES = [


### PR DESCRIPTION
## Summary
- New `chrome-ui-test` skill drives the dev server in Chrome via the `claude-in-chrome` MCP tools — runs a golden-path exercise, 2-3 edge cases from the task brief, and a regression spot-check on an adjacent screen. Returns PASS/FAIL with a reproduction recipe.
- New orchestrate **Step 3.4** auto-fires between commit/push and manual test when (a) an active stack declares the `browser-ui` capability, (b) the run actually touched browser-ui files, and (c) the `claude-in-chrome` MCP tools are loadable via `ToolSearch`. No `--chrome` flag — capability + tool availability is the gate (mirrors the `azure-auth` pattern).
- React adapter declares `"capabilities": ["browser-ui"]`. Other browser-hostable stacks can opt in by adding the same capability.
- FAIL routes the reproduction recipe into the existing Step 3.5 bug-fix cycle (assess → fix → review → re-test). Re-runs once after a fix; a second failure on the same scenario hands back to the user.

## Test plan
- [x] `python3 tests/validate_structure.py` — 350/350 pass
- [x] `python3 tests/test_contracts.py` — 78/78 pass
- [ ] In a react project with the `claude-in-chrome` MCP server configured, `/orchestrate "add login form"` runs Step 3.4 after commit and reports PASS or routes failure into 3.5.x
- [ ] In a react project WITHOUT the MCP server configured, Step 3.4 skips silently (no warning, no flag mismatch)
- [ ] In a non-browser-ui project (e.g., pure python adapter), Step 3.4 skips silently
- [ ] Mixed-stack run where this wave only touched backend files — Step 3.4 skips even with the MCP server configured (wave-relevance check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)