### PR TITLE
feat(pipeline): line-range + TRUST THE BRIEF hints for exact-string edit briefs

### DIFF
--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -171,6 +171,19 @@ A context brief includes:
 5. **Output specification**: Exact public API, method signatures, expected behavior
 6. **Constraints**: Naming conventions, patterns to follow, error handling approach. For Haiku tasks, embed the 1-2 most relevant rules from the adapter's `implementer-overlay-essential.md` that apply to this specific task (e.g., "Cleanup all effects in useEffect return function" for a component with side effects, or "Use `raise ... from e` to preserve exception chains" for error handling code). This makes the brief self-contained and targeted — the implementer does not need to scan the full overlay.
 7. **Verification**: How to know the task is done correctly — use the stack-specific build and test commands: `python3 .claude/scripts/<stack>/build.py` and `python3 .claude/scripts/<stack>/test.py`
+8. **For exact-string edit tasks** (mechanical tasks where you are supplying exact before/after
+   strings at character level): include two additional items in the brief:
+   - **Target line range**: `lines N–M` so the implementer can use `Read(offset=N, limit=5)`
+     instead of ingesting the full file to locate the target. Without this, Haiku reads the
+     entire file — a 27K-char test file costs ~7K tokens just to find a 3-line edit target.
+   - **TRUST THE BRIEF note** (append at the end of the brief):
+     > "The before/after strings above were copied directly from the file at HEAD — do not
+     > re-read the file to verify. If you need surrounding context, use
+     > `Read(offset=N, limit=10)` scoped to the line range above."
+
+   This addresses the triple-read pattern: 1a reads the file to draft the strings, 1b reads
+   it to confirm them, and the implementer reads it again to locate them. The line range
+   makes the implementer's read a 10-line targeted fetch instead of a full-file ingest.
 
 **Critical rule**: A context brief must be *self-contained*. Haiku should never need to read another task's brief to execute this one. If task B depends on task A's output, task B's brief must include the relevant interface/contract inline, not "see task A."
 

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -575,6 +575,30 @@ def check_planner_plan_stub(result: ValidationResult) -> None:
         result.ok("Planner does not instruct double-pay full-plan emission")
 
 
+def check_planner_exact_string_brief_hints(result: ValidationResult) -> None:
+    """Planner must document line-range and TRUST THE BRIEF hints for exact-string edit tasks."""
+    path = PIPELINE_ROOT / "skills" / "architect-planner" / "SKILL.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+
+    if "exact-string edit" in content.lower() or "exact string edit" in content.lower():
+        result.ok("Planner documents exact-string edit task brief requirements")
+    else:
+        result.fail("Planner missing exact-string edit task brief requirements")
+
+    if "line range" in content.lower() or "line N" in content or "lines N" in content:
+        result.ok("Planner documents line range hint to scope implementer file reads")
+    else:
+        result.fail("Planner missing line range hint for exact-string edit briefs")
+
+    if "do not re-read" in content.lower() or "trust the brief" in content.lower():
+        result.ok("Planner documents TRUST THE BRIEF / do-not-re-read note for exact-string briefs")
+    else:
+        result.fail("Planner missing TRUST THE BRIEF note for exact-string edit briefs")
+
+
 def check_orchestrate_reads_plan_from_disk(result: ValidationResult) -> None:
     """Orchestrate must read 1b-plan.md from disk, not from agent output."""
     orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
@@ -1064,6 +1088,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Token-analysis output baselines", check_token_analysis_output_baselines),
         ("Token-analysis fixed overhead", check_token_analysis_fixed_overhead),
         ("Planner PLAN_WRITTEN stub", check_planner_plan_stub),
+        ("Planner exact-string brief hints", check_planner_exact_string_brief_hints),
         ("Orchestrate reads plan from disk", check_orchestrate_reads_plan_from_disk),
         ("ORCHESTRATOR.md template sections", check_orchestrator_template_sections),
         ("Extract profile headers", check_extract_profile_headers),


### PR DESCRIPTION
## Summary
Addresses issue #41 (triple-read of `tests/test_scheduler.py` — 96K chars, ~24K redundant tokens, ~\$0.07–0.09 per micro-task occurrence).

Adds **brief item 8** to `architect-planner/SKILL.md` for exact-string edit tasks: when the planner supplies exact before/after strings at character level, the brief must also include:
- **Target line range** (`lines N–M`) so the implementer calls `Read(offset=N, limit=5)` instead of ingesting the full file to locate the target
- **TRUST THE BRIEF note** appended at the end: *"The before/after strings above were copied directly from the file at HEAD — do not re-read the file to verify. Use `Read(offset=N, limit=10)` scoped to the line range above."*

The root cause: without a line range, Haiku reads the entire file to find the edit target — a 27K-char test file becomes ~7K tokens of hidden consumption just to find a 3-line diff. 1a and 1b also each read the file independently for string extraction, making the triple-read pattern structural on fully-specified micro-tasks.

## Test plan
- [x] `python3 tests/validate_structure.py` — 353/353 pass (350 → 353, 3 new checks in `check_planner_exact_string_brief_hints`)
- [x] `python3 tests/test_contracts.py` — 78/78 pass
- [ ] Run `/orchestrate` on a 1-task chore with a fully-specified edit → planner brief includes `lines N–M` and TRUST THE BRIEF note → implementer uses targeted `Read(offset=N, limit=10)` instead of full-file ingest

## Related
- Closes #41
- The Finding 2 in #41 (1a > Step 2 token anomaly) is covered by PR #40 (small-plan gate suppression) — no action needed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)