### PR TITLE
feat(pipeline): add [simplify] tag to reviewer protocol (closes #44)

### DIFF
--- a/adapters/android/reviewer-overlay.md
+++ b/adapters/android/reviewer-overlay.md
@@ -88,11 +88,6 @@ You are a senior Android engineer with deep expertise in Kotlin, Jetpack Compose
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - POJO-style class with `equals`/`hashCode`/`toString` overrides → `data class`
 - Manual configuration of an object via setters in sequence → `apply { }`
 - Side-effecting use of an object that returns it → `also { }`

--- a/adapters/android/reviewer-overlay.md
+++ b/adapters/android/reviewer-overlay.md
@@ -85,3 +85,24 @@ You are a senior Android engineer with deep expertise in Kotlin, Jetpack Compose
 - Platform types from Java interop not explicitly typed (null safety hole)
 - `lateinit` used for nullable state (should be nullable type + null check)
 - Missing KDoc on public API
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- POJO-style class with `equals`/`hashCode`/`toString` overrides → `data class`
+- Manual configuration of an object via setters in sequence → `apply { }`
+- Side-effecting use of an object that returns it → `also { }`
+- Local transformation of a single value → `let { }` (only when it removes
+  a temporary variable)
+- `when` over a boolean / closed type with `else` branch that can never
+  fire → sealed class / sealed interface for exhaustive matching
+- `if (x != null) x.method()` → `x?.method()`
+- `?: throw IllegalStateException(...)` repeated boilerplate →
+  `requireNotNull(x)` / `checkNotNull(x)`
+- `mutableListOf<T>().apply { addAll(...) }` → `buildList { addAll(...) }`
+- Java-interop call returning platform type used immediately → explicit
+  type annotation at the call site (clarity, not just preference)

--- a/adapters/bicep/reviewer-overlay.md
+++ b/adapters/bicep/reviewer-overlay.md
@@ -85,3 +85,27 @@
 - Clean module boundaries with typed interfaces
 - Comprehensive tagging on all resources
 - Security-first: managed identity, Key Vault, private endpoints, encryption
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. The build (`bicep build`), `what-if`
+plan, and structural tests are the enforcement gate; reviewer judgment is
+the trigger.
+
+- Hand-rolled `for` loop building a derived array → `map()` / `filter()` /
+  `reduce()` ARM functions
+- Multiple parameters that are always passed together → consolidated
+  parameter object with typed properties
+- Inline resource definition repeated 2+ times with parameter variation →
+  module reuse
+- `concat('a', 'b', 'c')` of literals → string interpolation `'abc'` (or
+  `'${var}suffix'`)
+- `if (condition) { resource1 } else { resource2 }` where only one shared
+  property differs → single resource with conditional property
+- `length(array) == 0` → `empty(array)`
+- `dependsOn` listing resources Bicep can already infer from references →
+  drop the explicit list
+- Output that is a literal of an input parameter → drop the output (caller
+  already has the value)

--- a/adapters/bicep/reviewer-overlay.md
+++ b/adapters/bicep/reviewer-overlay.md
@@ -88,12 +88,6 @@
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. The build (`bicep build`), `what-if`
-plan, and structural tests are the enforcement gate; reviewer judgment is
-the trigger.
-
 - Hand-rolled `for` loop building a derived array → `map()` / `filter()` /
   `reduce()` ARM functions
 - Multiple parameters that are always passed together → consolidated

--- a/adapters/flutter/reviewer-overlay.md
+++ b/adapters/flutter/reviewer-overlay.md
@@ -80,11 +80,6 @@ You are a senior Flutter engineer with deep expertise in Dart, the Flutter frame
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - Stateless widget with no lifecycle/state → `const` constructor (when all
   child widgets are also `const`-eligible)
 - Builder boilerplate that always returns the same widget given input →

--- a/adapters/flutter/reviewer-overlay.md
+++ b/adapters/flutter/reviewer-overlay.md
@@ -77,3 +77,25 @@ You are a senior Flutter engineer with deep expertise in Dart, the Flutter frame
 - Missing `rethrow` — caught exception re-thrown with `throw` loses stack trace
 - `var` where `final` is appropriate (value never reassigned)
 - Package imports where relative imports should be used (within same package)
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- Stateless widget with no lifecycle/state → `const` constructor (when all
+  child widgets are also `const`-eligible)
+- Builder boilerplate that always returns the same widget given input →
+  hoist to a `const` widget instance
+- `Container` with only one decoration property → the more specific widget
+  (`Padding`, `Center`, `SizedBox`)
+- `Column`/`Row` with one child → drop the wrapper
+- `if (x) return Widget1; return Widget2;` builder → ternary
+- Repeated `Key` allocation across rebuilds for a stable identity → hoisted
+  `static const` key
+- `.toList()` on an iterable already typed `List<T>` (e.g., spread of
+  `[a, b, c].toList()`) → drop
+- Manual `setState` wrapping a single field assign that's already inside a
+  `setState` block → drop the inner wrapper

--- a/adapters/python/reviewer-overlay.md
+++ b/adapters/python/reviewer-overlay.md
@@ -90,3 +90,24 @@
 - Clean, maintainable, well-typed code
 - Testable architecture with dependency injection
 - Simple, focused solutions (no over-engineering)
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- `list(map(f, xs))` / `list(filter(p, xs))` → list/dict/set comprehension
+- Class that's just typed fields with `__init__` → `@dataclass`
+- `"text " + str(x) + " more"` / `"text {}".format(x)` → f-string
+- Manual file open/close around `try/finally` → `with open(...) as f:`
+- Walrus operator (`:=`) when it removes a duplicated read or pre-binding
+  line in a comprehension/while
+- `for k in d.keys():` → `for k in d:`
+- `if x in [a, b, c]:` (small literal set) → `if x in {a, b, c}:`
+- Manual `dict.get(k, default)` then `is None` check → just `dict.get(k, default)`
+  when the default is the desired value
+- `len(seq) == 0` → `not seq` (when truthiness semantics match)
+- Hand-rolled `@property` returning a stored attribute with no logic →
+  plain attribute

--- a/adapters/python/reviewer-overlay.md
+++ b/adapters/python/reviewer-overlay.md
@@ -93,11 +93,6 @@
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - `list(map(f, xs))` / `list(filter(p, xs))` → list/dict/set comprehension
 - Class that's just typed fields with `__init__` → `@dataclass`
 - `"text " + str(x) + " more"` / `"text {}".format(x)` → f-string

--- a/adapters/react/reviewer-overlay.md
+++ b/adapters/react/reviewer-overlay.md
@@ -85,3 +85,27 @@
 - Clean, maintainable, well-documented code
 - Testable architecture (dependency injection via props/context)
 - Simple, focused solutions (no over-engineering)
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- Same `useEffect` body in 2+ components with identical deps → custom hook
+- Re-derived value computed every render → `useMemo` (only when dep stability
+  is obvious; otherwise leave alone)
+- `<React.Fragment>` with no key → `<>` shorthand
+- `<div>` wrapping a single child only to satisfy a single-root rule →
+  fragment
+- Manual prop forwarding of every prop → `{...props}` spread when the
+  component is genuinely a wrapper
+- `useState(false)` + setter for a derived boolean → derive from existing
+  state inline
+- `array.map(x => x)` identity → `array` directly
+- Conditional className built from `+` concatenation with spaces →
+  template literal
+- Inline arrow function in render that doesn't capture render-scoped state
+  → defined outside the component (only when stability matters for memoized
+  children)

--- a/adapters/react/reviewer-overlay.md
+++ b/adapters/react/reviewer-overlay.md
@@ -88,11 +88,6 @@
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - Same `useEffect` body in 2+ components with identical deps → custom hook
 - Re-derived value computed every render → `useMemo` (only when dep stability
   is obvious; otherwise leave alone)

--- a/adapters/swift-ios/reviewer-overlay.md
+++ b/adapters/swift-ios/reviewer-overlay.md
@@ -72,11 +72,6 @@
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - Closure-arg call → trailing closure when it improves readability
 - `guard let x = x else { return }` → optional chaining (`x?.method()`) when no
   control flow other than early return depends on the unwrap

--- a/adapters/swift-ios/reviewer-overlay.md
+++ b/adapters/swift-ios/reviewer-overlay.md
@@ -69,3 +69,22 @@
 - Clean, maintainable, well-documented code
 - Testable architecture (dependency injection where possible)
 - Simple, focused solutions (no over-engineering)
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- Closure-arg call → trailing closure when it improves readability
+- `guard let x = x else { return }` → optional chaining (`x?.method()`) when no
+  control flow other than early return depends on the unwrap
+- `for` loop building a new collection → `.map` / `.compactMap` / `.filter`
+- Stored property with custom getter only → computed property
+- `if let _ = optional` discarding the bound value → `if optional != nil`
+- `array.count == 0` → `array.isEmpty`
+- `String` interpolation of `String(describing:)` on a known type →
+  direct interpolation
+- Manual `Result<T, Error>` plumbing through `do/try/catch` that just
+  re-throws → `try` directly

--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -107,20 +107,22 @@ FIX: <one-line description of required fix>
 Only include CRITICAL and HIGH issues in the FAIL output.
 Medium/low issues go after a `--- OPTIONAL IMPROVEMENTS ---` divider.
 
-Within OPTIONAL IMPROVEMENTS, prefix EACH entry with exactly one of two tags:
+Within OPTIONAL IMPROVEMENTS, prefix EACH entry with exactly one of three tags:
 
 ```
 --- OPTIONAL IMPROVEMENTS ---
 [should-fix] <one-line issue>: <why it matters>
 [nice-to-have] <one-line issue>: <why it matters>
+[simplify] <file>:<line> — <current pattern> → <preferred pattern>: <why it preserves behavior>
 ```
 
-**Cap: maximum 5 entries combined** across `[should-fix]` and `[nice-to-have]`. If you
-identify more than 5, choose the 5 most impactful and end the section with a single line:
-`(N more not shown)` where N is the count of entries you suppressed. This keeps review
-output bounded and forces explicit prioritization. Pure-PASS reviews with zero structural
-issues should typically have 0-2 entries; reviews with FAIL plus optional improvements
-should typically have 1-3 entries to keep the orchestrator's classification work tractable.
+**Cap: maximum 5 entries combined** across `[should-fix]`, `[nice-to-have]`, and
+`[simplify]`. If you identify more than 5, choose the 5 most impactful and end the
+section with a single line: `(N more not shown)` where N is the count of entries you
+suppressed. This keeps review output bounded and forces explicit prioritization.
+Pure-PASS reviews with zero structural issues should typically have 0-2 entries;
+reviews with FAIL plus optional improvements should typically have 1-3 entries to
+keep the orchestrator's classification work tractable.
 
 **`[should-fix]`** — a real improvement with concrete value, but not a blocker.
 Typically medium-severity: a tight duplication, a missing abstraction that
@@ -130,10 +132,19 @@ tripping on. These are the things you'd raise again in the next review.
 **`[nice-to-have]`** — genuinely optional: style polish, speculative refactors,
 defensive programming for unlikely cases, ideas for the future. Safe to ignore.
 
-The tags control fold-vs-defer behavior downstream: `[should-fix]` items are
-candidates to fold into the current run (subject to the run's fold cap);
-`[nice-to-have]` items default to deferral to the backlog. The classification
-is yours to make — when in doubt, choose `[nice-to-have]`.
+**`[simplify]`** — a behavior-preserving rewrite for clarity, idiom, or
+concision. Targets stack-idiom violations, redundancy, unnecessary indirection,
+dead branches, awkward control flow. You MUST be confident the rewrite is
+observably equivalent — if unsure, use `[should-fix]` instead. Use the
+single-line format above (file:line — current → preferred: why) so the
+downstream Haiku implementer has everything needed for a one-shot rewrite.
+Stack-specific candidate patterns are listed in your tech-stack overlay's
+`Simplification Heuristics` section.
+
+The tags control fold-vs-defer behavior downstream: `[should-fix]` and
+`[simplify]` entries are candidates to fold into the current run (subject to the
+run's fold cap); `[nice-to-have]` entries default to deferral to the backlog.
+The classification is yours to make — when in doubt, choose `[nice-to-have]`.
 
 ### Backlog Filing
 

--- a/overlays/azure-sdk/reviewer-overlay.md
+++ b/overlays/azure-sdk/reviewer-overlay.md
@@ -75,11 +75,6 @@
 
 ## Simplification Heuristics
 
-Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
-`[simplify]` when you are confident it preserves observable behavior — when
-in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
-gate; reviewer judgment is the trigger.
-
 - Hand-built credential chain (env var → MSI → CLI fallback) →
   `DefaultAzureCredential()` (when chain order matches the SDK default)
 - Connection string from app settings → `ManagedIdentityCredential` /

--- a/overlays/azure-sdk/reviewer-overlay.md
+++ b/overlays/azure-sdk/reviewer-overlay.md
@@ -72,3 +72,25 @@
 - Correlation IDs propagated across all cross-service operations
 - Structured logging with Azure Monitor/Application Insights — no secrets in logs
 - Resource tagging on all programmatically created resources
+
+## Simplification Heuristics
+
+Use these patterns for `[simplify]` tag entries. Only flag a rewrite as
+`[simplify]` when you are confident it preserves observable behavior — when
+in doubt, use `[should-fix]` instead. Tests and the build are the enforcement
+gate; reviewer judgment is the trigger.
+
+- Hand-built credential chain (env var → MSI → CLI fallback) →
+  `DefaultAzureCredential()` (when chain order matches the SDK default)
+- Connection string from app settings → `ManagedIdentityCredential` /
+  `DefaultAzureCredential` (only when the resource supports AAD auth)
+- Hand-rolled retry loop with sleeps → SDK's built-in retry policy
+  configuration
+- Manual correlation-ID header injection → SDK's distributed tracing
+  configuration (when supported)
+- Per-request client construction in a hot path → singleton/scoped client
+- Manual paging loop concatenating pages → SDK's `AsyncPageable` /
+  `Pageable` iteration helpers
+- `KeyVaultClient.getSecret(name).value` repeated reads → cached secret
+  with TTL respecting Key Vault's recommended refresh cadence (only when
+  rotation cadence is documented)

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -702,10 +702,10 @@ agent for tasks 9+. This prevents context window saturation from accumulated rev
 - If `FAIL`: proceed to Step 2.2 (fix)
 
 **Backlog classification:** after handling PASS/FAIL, parse the
-`--- OPTIONAL IMPROVEMENTS ---` section. Each entry is tagged `[should-fix]` or
-`[nice-to-have]`. For each, apply the fold-vs-defer rule in the Backlog
-Integration section below. This happens after the pass/fail handshake — do not
-let it block the review cycle.
+`--- OPTIONAL IMPROVEMENTS ---` section. Each entry is tagged `[should-fix]`,
+`[nice-to-have]`, or `[simplify]`. For each, apply the fold-vs-defer rule in
+the Backlog Integration section below. This happens after the pass/fail
+handshake — do not let it block the review cycle.
 
 **Token tracking:** Record a `TOKEN_LEDGER` entry for each review (step `2.1:<task_id>`). Agent: `code-reviewer-agent`, model: `sonnet` or `haiku` per the micro-plan rule above. For SendMessage reviews, `input_chars` is the SendMessage content (not the full accumulated context).
 
@@ -1129,8 +1129,29 @@ Use the planner's existing Haiku/Sonnet classification rubric
 - **Sonnet/Opus-tier** — design decisions, multi-file, moderate-to-high reasoning
   → **defer** (file to backlog).
 
-Reviewer guidance: `[should-fix]` entries with Haiku-tier fix are fold
-candidates; `[nice-to-have]` entries default-defer regardless of tier.
+Reviewer guidance:
+- `[should-fix]` entries with Haiku-tier fix are fold candidates.
+- `[nice-to-have]` entries default-defer regardless of tier.
+- `[simplify]` entries are fold candidates by definition (Haiku-tier,
+  single-file, behavior-preserving). The reviewer self-attests behavior
+  preservation; the **build + test gate is the enforcement**. Two safety
+  guards apply:
+  1. **Haiku-reviewer guard:** if the reviewer that emitted the entry was
+     Haiku (micro-plan reviewer per the M3 cost-proportional rule), force
+     the entry to **defer** instead of fold. Haiku judgment on behavior
+     preservation is not yet trusted enough to auto-apply in-run.
+  2. **Abandon-on-failure:** when the spawned simplify implementer
+     returns `FAILURE` (build or test failed), do **NOT** enter the
+     standard Step 2.2 fix loop. Discard the simplify worktree, log
+     `action: simplify_abandoned` with reasoning `"tests/build failed —
+     original code retained"`, and continue. The premise of `[simplify]`
+     is behavior preservation; if tests fail, the rewrite is wrong, and
+     the original code is correct by construction.
+
+`[simplify]` empty-diff path: if the implementer cannot find a
+behavior-preserving rewrite, it returns `SUCCESS` with no diff and a
+one-line note. Skip the empty commit and log
+`action: simplify_no_change`.
 
 ### Run-Level Fold Cap
 
@@ -1184,7 +1205,7 @@ backlog_decisions:
   - phase: reviewer              # planner | reviewer | implementer | token-analysis
     title: "Extract common Grok error mapper"
     classification: sonnet       # haiku | sonnet | opus | trivial
-    action: deferred             # folded | deferred | skipped | failed
+    action: deferred             # folded | deferred | skipped | failed | simplify_abandoned | simplify_no_change
     issue_url: "https://github.com/.../issues/42"   # present when action=deferred
     issue_number: 42
     reasoning: "Cross-cuts 4 files, adds new abstraction — Sonnet-tier"
@@ -1215,8 +1236,11 @@ PR). If no folds occurred, omit the section entirely.
 
 - **Step 1b (planner)**: planner outputs a `Deferred Items` section. Orchestrator
   iterates each, classifies, folds or files per the rule above.
-- **Step 2.1 (reviewer)**: each `[should-fix]` / `[nice-to-have]` entry in
-  OPTIONAL IMPROVEMENTS is classified. Orchestrator folds or files.
+- **Step 2.1 (reviewer)**: each `[should-fix]` / `[nice-to-have]` /
+  `[simplify]` entry in OPTIONAL IMPROVEMENTS is classified. Orchestrator
+  folds or files. `[simplify]` entries from a Haiku reviewer always defer
+  (option B safety guard); folded `[simplify]` tasks abandon on test
+  failure rather than entering the fix loop.
 - **Step 2 (implementer)**: implementer's SUCCESS commit message may include a
   "Follow-up" suggestion line — surface to reviewer, who classifies it with the
   rest.

--- a/tests/fixtures/reviewer-pass-with-all-three-tags.txt
+++ b/tests/fixtures/reviewer-pass-with-all-three-tags.txt
@@ -1,0 +1,9 @@
+PASS
+[should-fix] Duplicated validation logic across divide() and modulo() — extract a shared guard helper
+[nice-to-have] Error messages could include the offending value for easier debugging
+[simplify] src/calculator.py:42 — manual loop summing list → sum(values): builtin matches loop semantics for numeric iterables
+
+---TOKEN_REPORT---
+FILES_READ: src/calculator.py ~520; tests/test_calculator.py ~1100
+TOOL_CALLS: Read=3 Grep=1
+---END_TOKEN_REPORT---

--- a/tests/fixtures/reviewer-pass-with-simplify-tagged.txt
+++ b/tests/fixtures/reviewer-pass-with-simplify-tagged.txt
@@ -1,0 +1,7 @@
+PASS
+[simplify] src/calculator.py:42 — manual loop summing list → sum(values): builtin matches loop semantics for numeric iterables
+
+---TOKEN_REPORT---
+FILES_READ: src/calculator.py ~520; tests/test_calculator.py ~1100
+TOOL_CALLS: Read=3 Grep=1
+---END_TOKEN_REPORT---

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -64,13 +64,13 @@ def parse_implementer_result(output: str) -> dict:
 
 
 def _parse_optional_entry(raw: str) -> dict:
-    """Split a `[should-fix] ...` / `[nice-to-have] ...` prefix from free text.
+    """Split a `[should-fix] ...` / `[nice-to-have] ...` / `[simplify] ...` prefix from free text.
 
-    Returns {"text": str, "tag": "should-fix"|"nice-to-have"|None}. Entries
-    without a known tag get tag=None for backward compatibility.
+    Returns {"text": str, "tag": "should-fix"|"nice-to-have"|"simplify"|None}.
+    Entries without a known tag get tag=None for backward compatibility.
     """
     s = raw.strip()
-    for tag in ("should-fix", "nice-to-have"):
+    for tag in ("should-fix", "nice-to-have", "simplify"):
         prefix = f"[{tag}]"
         if s.startswith(prefix):
             return {"text": s[len(prefix):].strip(), "tag": tag}

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -124,6 +124,28 @@ class TestReviewerProtocol(unittest.TestCase):
             self.assertTrue(s["text"])
             self.assertFalse(s["text"].startswith("["))
 
+    def test_simplify_tag_recognized(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-pass-with-simplify-tagged.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["status"], "PASS")
+        suggestions = result["suggestions"]
+        self.assertEqual(len(suggestions), 1)
+        self.assertEqual(suggestions[0]["tag"], "simplify")
+        self.assertTrue(suggestions[0]["text"])
+        self.assertFalse(suggestions[0]["text"].startswith("["))
+
+    def test_all_three_tags_coexist(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-pass-with-all-three-tags.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["status"], "PASS")
+        suggestions = result["suggestions"]
+        self.assertEqual(len(suggestions), 3)
+        tags = {s["tag"] for s in suggestions}
+        self.assertEqual(tags, {"should-fix", "nice-to-have", "simplify"})
+        for s in suggestions:
+            self.assertTrue(s["text"])
+            self.assertFalse(s["text"].startswith("["))
+
     def test_untagged_entries_preserve_null_tag(self) -> None:
         fixture = (FIXTURES_DIR / "reviewer-fail.txt").read_text()
         result = parse_reviewer_result(fixture)

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -1075,6 +1075,28 @@ def check_fix_defects_skill(result: ValidationResult) -> None:
         result.fail("fix-defects missing PR comment reply mechanism")
 
 
+def check_reviewer_simplification_heuristics(result: ValidationResult) -> None:
+    """Each adapter and cross-cutting overlay reviewer-overlay.md must document
+    the Simplification Heuristics section that backs the [simplify] tag."""
+    marker = "## Simplification Heuristics"
+    targets = [
+        ("adapters", a) for a in ADAPTERS
+    ] + [
+        ("overlays", o) for o in OVERLAYS
+    ]
+    for kind, name in targets:
+        path = PIPELINE_ROOT / kind / name / "reviewer-overlay.md"
+        if not path.exists():
+            continue  # already caught by completeness check
+        if marker in path.read_text():
+            result.ok(f"{kind}/{name}: reviewer-overlay.md has Simplification Heuristics section")
+        else:
+            result.fail(
+                f"{kind}/{name}: reviewer-overlay.md missing '{marker}' section "
+                f"(required for the [simplify] tag — see agents/code-reviewer-agent.md)"
+            )
+
+
 def check_overlay_completeness(result: ValidationResult) -> None:
     """Check each overlay has all required files."""
     for overlay in OVERLAYS:
@@ -1243,6 +1265,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Implementer contract references", check_implementer_contract_references),
         ("Reviewer no Standalone Mode", check_reviewer_no_standalone_mode),
         ("Reviewer OPTIONAL IMPROVEMENTS cap", check_reviewer_optional_cap),
+        ("Reviewer Simplification Heuristics sections", check_reviewer_simplification_heuristics),
         ("Clarification round caps", check_clarification_round_caps),
         ("Token-analysis output baselines", check_token_analysis_output_baselines),
         ("Token-analysis fixed overhead", check_token_analysis_fixed_overhead),


### PR DESCRIPTION
## Summary

Adds the `[simplify]` tag as the third entry type in the reviewer's `OPTIONAL IMPROVEMENTS` taxonomy, wired through the existing fold-vs-defer machinery. Zero new agents, zero new skills, zero new orchestrate steps — exactly per the design in #44.

## Two safety guards

| Guard | What it does | Why |
|---|---|---|
| **Haiku-reviewer guard (option B)** | `[simplify]` entries from a Haiku reviewer always **defer** instead of fold | M3 cost-proportional rule means micro-plan reviewers can be Haiku; Haiku judgment on behavior preservation isn't trusted enough yet for in-run auto-apply. Confirmed with the user. |
| **Abandon-on-failure** | When a folded `[simplify]` implementer returns `FAILURE`, **don't** enter the standard 2.2 fix loop — discard the worktree, log `simplify_abandoned` | The premise of `[simplify]` is behavior preservation; if tests fail, the rewrite is wrong and the original code is correct by construction. The fix loop tries to make broken code work, which is the wrong response here. |

**Tests-passing remains the sole behavioral-preservation gate** (implementer Rule 7 — coverage ≥90%, all tests pass). Confirmed with the user as the desired model.

## Commits

| Commit | Scope |
|---|---|
| `0fe3b7b` feat(pipeline): add [simplify] tag to reviewer protocol | reviewer agent + parser + 2 fixtures + 2 contract tests + orchestrate fold rule (3 sites) + run-log schema |
| `ec30c5d` feat(pipeline): add Simplification Heuristics to all reviewer overlays | 6 adapter overlays + 1 cross-cutting overlay + validate_structure check |

Both commits pass all three test layers individually.

## Test plan

- [x] `python3 tests/validate_structure.py` — 376 checks pass (was 361, added 7 simplification + reviewer cap update)
- [x] `python3 tests/test_contracts.py` — 80 tests pass (was 78, added `test_simplify_tag_recognized` + `test_all_three_tags_coexist`)
- [x] `python3 tests/smoke/run_smoke.py` — 36 checks pass
- [x] Existing `[should-fix]` / `[nice-to-have]` regression — both old fixtures and the existing `test_tagged_optional_suggestions` test pass unmodified
- [ ] Run `/orchestrate` on a small consumer change post-merge that the reviewer flags `[simplify]` and confirm: Sonnet-reviewer entry folds and tests pass; Haiku-reviewer entry defers as backlog issue
- [ ] Confirm a deliberate abandon path (synthetic test failure) hits `simplify_abandoned` and the original code is retained

## Out of scope (future)

- Examples paired with each rule — deferred to #46's research-seeded refresh tooling, where a research subagent drafts Bad/Good pairs for human curation
- `simplify_strict=true` config that elevates `[simplify]` to FAIL severity (#44 lists this as out-of-scope future)
- Smoke test extension for end-to-end `[simplify]` flow (#44 marks optional)

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)