### PR TITLE
fix(react): forbid manual cleanup() in test files (closes #50)

### DIFF
--- a/adapters/react/implementer-overlay-essential.md
+++ b/adapters/react/implementer-overlay-essential.md
@@ -10,3 +10,4 @@
 - Stable, unique `key` props in lists — never array index for dynamic lists
 - Handle loading, error, and empty states explicitly in data-fetching components
 - `const` by default, `let` only for reassignment, never `var`
+- Do NOT import or call `cleanup()` in test files — `@testing-library/react` registers it automatically via `afterEach`

--- a/adapters/react/implementer-overlay.md
+++ b/adapters/react/implementer-overlay.md
@@ -54,6 +54,10 @@ Within the boundaries of what the brief asks for, write clean React/TypeScript:
 - Lazy load heavy components with `React.lazy` and `Suspense`
 - Avoid unnecessary re-renders by lifting state to the appropriate level
 
+## Testing
+
+- Do NOT import or call `cleanup()` in test files — `@testing-library/react` registers it automatically via `afterEach`. Manual calls are dead code that the reviewer will reject.
+
 ## Project Conventions
 
 Key conventions for React/TypeScript projects (the context brief overrides these if different):


### PR DESCRIPTION
## Summary

Haiku cargo-culted a manual `cleanup()` import + `afterEach(() => cleanup())` into a React test file because the React implementer overlay never told it not to. The reviewer flagged it FAIL → Sonnet escalation → **28.5% of total run spend on a 1-task chore**.

`@testing-library/react` has auto-registered `cleanup()` via its own `afterEach` since v9, so the manual call is dead code.

## Fix

Add a single-line prohibition to `adapters/react/implementer-overlay-essential.md` (which Haiku reads unconditionally on every React task):

> `- Do NOT import or call `cleanup()` in test files — `@testing-library/react` registers it automatically via `afterEach``

Mirror in `adapters/react/implementer-overlay.md` under a new minimal `## Testing` section so the full overlay stays consistent.

## Why the essential overlay (not per-task FORBIDDEN)

`skills/architect-planner/SKILL.md:190` says:

> Reserve [the FORBIDDEN section] for task-specific prohibitions only; generic stack rules belong in the implementer overlay.

This rule applies to every React test edit, not a single task — so the implementer overlay is the correct location. The planner doesn't have to recognize "this task touches a test file" — Haiku just has the rule by default.

## Cost / size

- Essential overlay: 810 → 932 chars (still under the 1000-char structural cap)
- Per-Haiku-React-task token cost: ~30 extra tokens (one bullet)
- Avoided cost: a single Sonnet escalation in the original incident burned ~$0.35 — first prevented escalation pays for ~10 years of the added context cost

## Test plan

- [x] `python3 tests/validate_structure.py` — 376 checks pass (essential overlay size cap not breached)
- [x] `python3 tests/test_contracts.py` — 80 tests pass
- [x] `python3 tests/smoke/run_smoke.py` — 36 checks pass
- [ ] Watch the next `/orchestrate` run that touches a React test file — confirm Haiku does not import `cleanup()` and the implementer's first pass is accepted by the reviewer

## Out of scope

This fix targets one specific cargo-cult. The broader pattern (Haiku reaches for "library best-practices" the library already auto-handles) may also affect other RTL conventions like manual `act()` wrapping or `container.querySelector`. Those are documented as anti-patterns in `adapters/react/test-overlay.md` but the implementer agent doesn't read that overlay. A future PR could decide whether to lift them into the implementer overlays too — leaving as a follow-up to avoid scope creep on this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)