### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MILL5
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds a top-level `LICENSE` file with the standard MIT license text. No prior LICENSE existed in the repo.

## Decisions made

- **License:** MIT (per the request)
- **Copyright holder:** `MILL5` — taken from the GitHub org name (`MILL5/claude-code-pipeline`)
- **Year:** 2026

If the copyright holder should be a different legal entity (e.g. `MILL5 LLC`, `Mill5 Inc.`, an individual), say the word and I'll amend before merge.

## Test plan

- [x] LICENSE file present at repo root
- [x] Standard MIT text (matches GitHub's MIT license picker output)
- [ ] Confirm copyright holder is correct as `MILL5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)