### PR TITLE
docs: add per-stack adoption guides (closes #55 partially)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,18 @@ Then use any of these to trigger the pipeline:
 
 ## Available Adapters
 
-| Adapter | Auto-Detects | Build Tool | Test Framework | Coverage |
-|---------|-------------|------------|----------------|----------|
-| `swift-ios` | `*.xcodeproj`, `*.xcworkspace`, `Package.swift` | Xcode / Swift PM | XCTest | xccov |
-| `react` | `package.json` with `react` dependency | npm/yarn/pnpm/bun + tsc | Jest / Vitest | istanbul / v8 |
-| `python` | `pyproject.toml`, `setup.py`, `requirements.txt` | mypy + ruff | pytest | pytest-cov |
-| `flutter` | `pubspec.yaml` with `flutter:` | flutter analyze + dart format | flutter test (unit/widget/golden/integration) | lcov |
-| `android` | `build.gradle.kts`, `build.gradle` | Gradle (AGP) + Android lint | JUnit 4 + Robolectric / Espresso / Compose Testing | JaCoCo |
-| `bicep` | `*.bicep`, `bicepconfig.json` | bicep build + az bicep lint | ARM-TTK / PSRule / what-if | Resource validation coverage |
+| Adapter | Auto-Detects | Build Tool | Test Framework | Coverage | Adoption Guide |
+|---------|-------------|------------|----------------|----------|----------------|
+| `swift-ios` | `*.xcodeproj`, `*.xcworkspace`, `Package.swift` | Xcode / Swift PM | XCTest | xccov | [swift-ios.md](docs/adoption/swift-ios.md) |
+| `react` | `package.json` with `react` dependency | npm/yarn/pnpm/bun + tsc | Jest / Vitest | istanbul / v8 | [react.md](docs/adoption/react.md) |
+| `python` | `pyproject.toml`, `setup.py`, `requirements.txt` | mypy + ruff | pytest | pytest-cov | [python.md](docs/adoption/python.md) |
+| `flutter` | `pubspec.yaml` with `flutter:` | flutter analyze + dart format | flutter test (unit/widget/golden/integration) | lcov | [flutter.md](docs/adoption/flutter.md) |
+| `android` | `build.gradle.kts`, `build.gradle` | Gradle (AGP) + Android lint | JUnit 4 + Robolectric / Espresso / Compose Testing | JaCoCo | [android.md](docs/adoption/android.md) |
+| `bicep` | `*.bicep`, `bicepconfig.json` | bicep build + az bicep lint | ARM-TTK / PSRule / what-if | Resource validation coverage | [bicep.md](docs/adoption/bicep.md) |
 
-**Deploying to Azure?** See the **[Azure Deployment Guide](docs/azure-guide.md)** for Bicep adapter setup, Azure SDK overlay, authentication, and the 7 Azure-specific skills.
+Each adoption guide covers detection, required tools, bootstrap output, project layout assumptions, build/test commands, common pitfalls, and a worked first-`/orchestrate`-run example for that stack.
+
+**Deploying to Azure?** See the **[Azure Deployment Guide](docs/azure-guide.md)** for the full Bicep + Azure SDK overlay + authentication + skills walkthrough (more detailed than the bicep adoption guide).
 
 ### What Each Adapter Provides
 
@@ -444,7 +446,14 @@ claude-code-pipeline/
 |
 |-- docs/                                # Guides and documentation
 |   |-- azure-guide.md                  # Azure deployment guide (Bicep, SDK, auth, skills)
-|   +-- testing-guide.md                # Manual testing & defect reporting guide
+|   |-- testing-guide.md                # Manual testing & defect reporting guide
+|   +-- adoption/                       # Per-stack adoption guides (linked from README adapter table)
+|       |-- swift-ios.md
+|       |-- react.md
+|       |-- python.md
+|       |-- flutter.md
+|       |-- android.md
+|       +-- bicep.md
 |
 +-- templates/                           # Project file templates
     |-- CLAUDE.md.template               # Starting point for project CLAUDE.md

--- a/docs/adoption/android.md
+++ b/docs/adoption/android.md
@@ -1,0 +1,123 @@
+# Adopting the Android / Kotlin Adapter
+
+This adapter activates for native Android projects (Gradle-based, Kotlin or Java sources). The pipeline runs Gradle with the AGP build tool + Android lint for build, and JUnit 4 (Robolectric / Espresso / Compose Testing) for tests with JaCoCo for coverage.
+
+## Detection
+
+`init.sh` activates this adapter when any of these exist at the project root:
+
+- `build.gradle.kts`
+- `build.gradle`
+- `app/build.gradle.kts`
+- `app/build.gradle`
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Android SDK | Build target platforms | Install via Android Studio or sdkmanager |
+| Gradle wrapper (`gradlew`) | Bundled with project | Don't install Gradle globally |
+| JDK 11+ | Required for AGP 8+ | JDK 17 recommended |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+The Gradle wrapper handles AGP, Kotlin, and JaCoCo plugin versions. No extra installs needed beyond the wrapper.
+
+## Bootstrap
+
+```bash
+cd your-android-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: android
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/android -> .claude/pipeline/adapters/android/scripts
+Wrote .claude/pipeline.config (stacks=android)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+## Project layout assumed
+
+Default `stack_paths`:
+
+- `app/src/main/`, `app/src/test/`, `app/src/androidTest/`, `android/`
+
+Plus fallback globs for `**/*.kt`, `**/*.java`, `**/build.gradle.kts`, `**/build.gradle`, `**/AndroidManifest.xml`, and `gradle/libs.versions.toml`.
+
+This matches the standard single-module Android Studio layout. For multi-module projects (`feature/`, `core/`, `data/` modules), add patterns to `pipeline.config`:
+
+```ini
+stack_paths.android=feature/*/src/**,core/*/src/**,data/*/src/**,app/src/**
+```
+
+## Build & test commands
+
+```bash
+python3 .claude/scripts/android/build.py
+python3 .claude/scripts/android/test.py
+```
+
+`build.py` runs `./gradlew assembleDebug lint` and emits the pipeline's contract line (`BUILD SUCCEEDED | N warning(s)` / `BUILD FAILED | ...`). `test.py` runs `./gradlew testDebugUnitTest jacocoTestReport`, parses JUnit XML output and JaCoCo XML reports, and emits `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%`.
+
+Raw `./gradlew test`, `./gradlew assemble`, and `./gradlew lint` are blocked by `hooks.json`.
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/orchestrate
+```
+
+Then describe a small change: *"Add a 'Dark mode' preference to the settings screen and persist via DataStore"*. The pipeline will:
+
+1. Ask 1-2 feature-clarifying questions (default state, system-following behavior)
+2. Generate a Haiku-tier plan (likely 2-3 tasks: composable + ViewModel + DataStore key)
+3. Open a draft PR
+4. Run pre-flight build (Gradle assemble + lint)
+5. Implement, review (with Android reviewer overlay watching for lifecycle, concurrency, security)
+6. Run unit tests with JaCoCo coverage
+7. Ask you to manually test on emulator or device
+8. File a token-analysis report
+
+For a small Compose feature, expect ~$0.20-0.50 and 10-20 minutes wall-clock (Gradle builds dominate).
+
+## Common pitfalls
+
+### Cold-cache Gradle builds
+
+The first `./gradlew assembleDebug` after a clone or `./gradlew clean` downloads the AGP, Kotlin, and dependency JARs. Pre-flight build can take 5-10 minutes from cold. Consider running a manual build once before `/orchestrate` to warm the cache — pre-flight will then complete in seconds.
+
+### `lateinit` on nullable state
+
+The Android implementer overlay forbids `lateinit var` for nullable state (use a nullable type + null check instead). Haiku occasionally misuses `lateinit` on initially-null view bindings. The reviewer catches this; if you see `lateinit` warnings flagged, it's the overlay doing its job.
+
+### Robolectric vs. instrumented tests
+
+The pipeline's `test.py` runs `testDebugUnitTest` only — that's JUnit + Robolectric. It does NOT run `connectedDebugAndroidTest` (instrumented tests on a device/emulator) because that requires a running emulator and significantly longer wall-clock. If your project relies on instrumented tests for coverage, either move logic into Robolectric-friendly tests or invoke the instrumented suite manually outside the pipeline.
+
+### `!!` non-null assertion
+
+Kotlin's `!!` operator is forbidden in production code per the Android implementer overlay. Use `?.`, `?:`, `requireNotNull()`, or `checkNotNull()`. If your existing codebase has `!!` instances, the reviewer flags them as `[should-fix]` rather than `FAIL` to avoid blocking unrelated work.
+
+### Multi-module: where does a task land?
+
+For multi-module projects, the orchestrator resolves task → stack via `stack_paths`. If a task touches `feature/profile/src/main/...`, the Android adapter handles it. If a task touches `build-logic/src/main/...` (Gradle convention plugins), it still routes to Android. Cross-module refactors get the architect's union view.
+
+### Compose vs. View system
+
+The Android implementer overlay assumes Jetpack Compose first, View system as legacy. If your project is mostly XML/Views, document the preference in `.claude/local/coding-standards.md` to override the default. The reviewer overlay watches for Compose anti-patterns (recomposition, state hoisting) but doesn't block Views-based code.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `android` in the title.

--- a/docs/adoption/bicep.md
+++ b/docs/adoption/bicep.md
@@ -1,0 +1,134 @@
+# Adopting the Bicep (Azure IaC) Adapter
+
+This adapter activates for Azure infrastructure-as-code projects using Bicep. The pipeline runs `bicep build` + lint for build and ARM-TTK / PSRule / `what-if` for tests. The Bicep adapter also auto-implies the cross-cutting `azure-sdk` overlay (for projects that mix IaC with SDK code) and adds the `azure-auth` capability that triggers an Azure login pre-flight before deploy/what-if operations.
+
+> **Comprehensive guide:** for the full Azure adoption story (Bicep + Azure SDK overlay + auth + the seven Azure-specific skills), see [docs/azure-guide.md](../azure-guide.md). This document is a quick-start summary that points there for depth.
+
+## Detection
+
+`init.sh` activates this adapter when any of these exist at the project root:
+
+- `*.bicep` files (anywhere)
+- `infra/*.bicep`, `infrastructure/*.bicep`, `deploy/*.bicep`, `modules/*.bicep`
+- `bicepconfig.json`
+
+When detected, the `azure-auth` capability and `azure-sdk` overlay activate automatically (see `manifest.json`).
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Azure CLI (`az`) | Bicep build + deployment | `az upgrade` if installed; `az bicep install` |
+| Bicep CLI | Build + lint | Bundled with `az` (`az bicep version`) |
+| PowerShell 7+ (`pwsh`) | PSRule + ARM-TTK | Optional but recommended for full coverage |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+## Bootstrap
+
+```bash
+cd your-bicep-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: bicep
+Active overlays: azure-sdk
+Active capabilities: azure-auth
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/bicep -> .claude/pipeline/adapters/bicep/scripts
+Wrote .claude/pipeline.config (stacks=bicep, overlays=azure-sdk)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+After bootstrap, run `/azure-login` once to verify Azure auth, subscription context, and RBAC permissions.
+
+## Project layout assumed
+
+Default `stack_paths`:
+
+- `infra/`, `infrastructure/`, `deploy/`
+
+Plus fallback globs for `**/*.bicep`, `**/*.bicepparam`, and `bicepconfig.json`.
+
+If your modules live elsewhere (e.g., `modules/`), they're picked up by the fallback globs. For non-standard layouts, add patterns to `pipeline.config` explicitly.
+
+## Build & test commands
+
+```bash
+python3 .claude/scripts/bicep/build.py
+python3 .claude/scripts/bicep/test.py
+```
+
+`build.py` runs `bicep build` + `az bicep lint` and emits the pipeline's contract line. `test.py` orchestrates ARM-TTK, PSRule, and (optionally) `what-if` against a target subscription, parsing each tool's output into the unified `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%` line.
+
+Raw `bicep build`, `az deployment ... create`, and PSRule invocations are blocked by `hooks.json`. Use the Azure-specific skills:
+
+- `/validate-bicep` — lint + build + optional what-if
+- `/deploy-bicep` — deploy with mandatory confirmation gate
+- `/azure-cost-estimate` — monthly cost projection
+- `/security-scan` — PSRule + Checkov
+- `/infra-test-runner` — ARM-TTK + Pester
+- `/azure-drift-check` — compare deployed state to templates
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/azure-login          # one-time, verifies auth
+/orchestrate
+```
+
+Then describe a small change: *"Add a private endpoint to the Storage account in modules/storage.bicep"*. The pipeline will:
+
+1. Ask 1-2 clarifying questions (subnet to attach to, DNS zone integration)
+2. Generate a Haiku-tier plan (likely 1-2 tasks)
+3. Open a draft PR
+4. Run pre-flight build (`bicep build` + lint)
+5. Implement, review (with Bicep reviewer overlay watching for security, cost, reliability)
+6. Run ARM-TTK + PSRule
+7. Optionally run `what-if` against a target subscription (configured via `/validate-bicep`)
+8. Ask you to manually approve before any deploy
+9. File a token-analysis report
+
+For a small infra change, expect ~$0.10-0.30 and 5-10 minutes wall-clock.
+
+## Common pitfalls
+
+### Authentication scope
+
+`az login` may default to a different tenant or subscription than the one you're targeting. The `/azure-login` skill validates this explicitly. If `what-if` or deploy fails with permission errors, re-run `/azure-login` and confirm the subscription context.
+
+### `dependsOn` over-specification
+
+Bicep can infer `dependsOn` from references in most cases. The reviewer flags explicit `dependsOn` lists that duplicate inferable dependencies as `[simplify]`. If you see deps removed during fix cycles, that's behavior-preserving cleanup.
+
+### What-if vs. deploy
+
+The pipeline never deploys without explicit user confirmation (`/deploy-bicep` requires a confirmation gate). What-if is a non-mutating preview. For PR validation, prefer what-if to deploy — what-if catches most issues and doesn't risk drift.
+
+### Module reuse
+
+The Bicep reviewer overlay encourages module reuse over inlining. Haiku tends to inline resources for clarity. Reviewer flags 2+ near-duplicate resource definitions as candidates for module extraction (`[should-fix]`).
+
+### Multi-stack: Bicep + an SDK language
+
+If your repo has Bicep templates AND application code in another language (Python with Azure SDK, .NET/Node calling Azure services), bootstrap both stacks. The `azure-sdk` overlay activates automatically and applies to whichever language stack you bootstrap with — the overlay teaches both Python and Bicep the same auth/retry/Key Vault discipline.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `bicep` or `azure` in the title.
+
+## See also
+
+- [Azure Deployment Guide](../azure-guide.md) — full Azure adoption walkthrough
+- [Testing Guide](../testing-guide.md) — manual testing and defect reporting

--- a/docs/adoption/flutter.md
+++ b/docs/adoption/flutter.md
@@ -1,0 +1,122 @@
+# Adopting the Flutter / Dart Adapter
+
+This adapter activates for Flutter apps and pure-Dart packages. The pipeline runs `flutter analyze` + `dart format` for build, and `flutter test` (unit, widget, golden, integration) for tests. Coverage flows through `lcov`.
+
+## Detection
+
+`init.sh` activates this adapter when:
+
+- `pubspec.yaml` exists and contains the string `flutter:` (i.e., it's a Flutter app, not a pure-Dart package)
+
+Pure-Dart packages without `flutter:` in the manifest aren't auto-detected. Pass `--stack=flutter` explicitly if you want Dart conventions (the overlays still apply).
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Flutter SDK 3.16+ | Build + test toolchain | Or use FVM (Flutter Version Management) |
+| Dart SDK | Bundled with Flutter | Don't install separately |
+| `lcov` | Coverage post-processing | `brew install lcov` on macOS |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+If you target iOS or Android natively, also install those platforms' tooling — but for adoption, you can start with Flutter-only and add native adapters later.
+
+## Bootstrap
+
+```bash
+cd your-flutter-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: flutter
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/flutter -> .claude/pipeline/adapters/flutter/scripts
+Wrote .claude/pipeline.config (stacks=flutter)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+For Flutter apps with native code (Swift in `ios/`, Kotlin in `android/`), bootstrap with all three adapters:
+
+```bash
+bash .claude/pipeline/init.sh . --stack=flutter --stack=swift-ios --stack=android
+```
+
+The orchestrator routes Dart files to Flutter overlays, Swift files to swift-ios overlays, and Kotlin files to Android overlays based on `stack_paths`.
+
+## Project layout assumed
+
+Default `stack_paths` for Flutter:
+
+- `lib/`, `test/`, `integration_test/`
+
+Plus fallback globs for `**/*.dart`, `pubspec.yaml`, `analysis_options.yaml`, `l10n.yaml`, and ARB files in `lib/l10n/`.
+
+This matches the standard `flutter create` layout. If you've reorganized into a multi-package monorepo (e.g., `packages/<name>/lib/`), update `stack_paths.flutter` in `pipeline.config` accordingly.
+
+## Build & test commands
+
+```bash
+python3 .claude/scripts/flutter/build.py
+python3 .claude/scripts/flutter/test.py
+```
+
+`build.py` runs `flutter analyze` + `dart format --set-exit-if-changed` and emits the pipeline's contract line. `test.py` runs `flutter test --machine --coverage`, parses the streaming JSON, post-processes `coverage/lcov.info`, and emits `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%`.
+
+Raw `flutter test`, `flutter build`, and `flutter analyze` are blocked by `hooks.json`.
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/orchestrate
+```
+
+Then describe a small change: *"Add a pull-to-refresh on the feed screen"*. The pipeline will:
+
+1. Ask 1-2 feature-clarifying questions (where the refresh state lives, error handling)
+2. Generate a Haiku-tier plan (likely 1-2 widget tasks)
+3. Open a draft PR
+4. Run pre-flight build (`flutter analyze`)
+5. Implement, review (with Flutter reviewer overlay watching for widget rebuilds, lifecycle, l10n, accessibility)
+6. Run unit + widget tests
+7. Ask you to manually test
+8. File a token-analysis report
+
+For a small widget addition, expect ~$0.10-0.30 and 5-10 minutes wall-clock.
+
+## Common pitfalls
+
+### `const` constructors
+
+The Flutter implementer overlay encourages `const` constructors where eligible. Haiku tends to apply this aggressively, sometimes adding `const` where a parameter prevents it. The reviewer catches mismatches. If you see `const` removed during fix cycles, that's why.
+
+### Golden test snapshot drift
+
+Golden tests (`testWidgets` with `matchesGoldenFile`) are sensitive to renderer / font / OS version. If your CI environment differs from your local environment, golden tests fail intermittently. The pipeline doesn't auto-update goldens — it surfaces failures and asks you to triage. To regenerate locally, run `flutter test --update-goldens` and commit the deltas explicitly.
+
+### `flutter pub get` not in pre-flight
+
+The pipeline's pre-flight build runs `flutter analyze` but does NOT run `flutter pub get` first. If your `pubspec.lock` is out of date or you've just pulled new deps, run `flutter pub get` manually before `/orchestrate`. (This will be folded into pre-flight in a future iteration.)
+
+### Multi-platform: native code review
+
+When you bootstrap with `--stack=flutter --stack=swift-ios --stack=android`, native code edits go through the corresponding native adapter's reviewer (e.g., Swift edits get the swift-ios reviewer overlay's retain-cycle and force-unwrap rules). The Flutter reviewer doesn't second-guess native code.
+
+### State management library not assumed
+
+The Flutter implementer overlay is opinion-light on state management — it doesn't pre-assume Riverpod, Bloc, Provider, or vanilla setState. Whatever your project uses, document the convention in `.claude/local/coding-standards.md` so the implementer follows it.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `flutter` in the title.

--- a/docs/adoption/python.md
+++ b/docs/adoption/python.md
@@ -1,0 +1,132 @@
+# Adopting the Python Adapter
+
+This adapter activates when the pipeline detects Python project metadata. It covers libraries, services (Django, FastAPI, Flask), and async/await codebases. The pipeline uses `mypy` + `ruff` for build, `pytest` + `pytest-cov` for tests.
+
+## Detection
+
+`init.sh` activates this adapter when any of these exist at the project root:
+
+- `pyproject.toml`
+- `setup.py`
+- `setup.cfg`
+- `requirements.txt`
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Python 3.9+ | Runtime | Earlier versions may work but type-hints assume 3.9+ |
+| `pip` / `poetry` / `uv` | Package manager | Detected from your lockfile |
+| `mypy` | Type checking | Used by `build.py` |
+| `ruff` | Lint + format | Used by `build.py` |
+| `pytest` + `pytest-cov` | Test runner + coverage | Used by `test.py` |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+Install pipeline-required tools: `pip install mypy ruff pytest pytest-cov`
+
+## Bootstrap
+
+```bash
+cd your-python-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: python
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/python -> .claude/pipeline/adapters/python/scripts
+Wrote .claude/pipeline.config (stacks=python)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+If `pyproject.toml` declares Azure SDK packages (e.g., `azure-identity`, `azure-storage-blob`), `init.sh` also activates the cross-cutting `azure-sdk` overlay automatically.
+
+## Project layout assumed
+
+Default `stack_paths` expect code in:
+
+- `src/backend/`, `backend/`, `server/`, or `api/`
+
+Plus a fallback to any `**/*.py` file.
+
+For src-layout packages (`src/<package_name>/`), this works as-is. For flat-layout packages (`<package_name>/` at root), consider adding the path explicitly to `pipeline.config`:
+
+```ini
+stack_paths.python=mypackage/**,tests/**
+```
+
+## Build & test commands
+
+```bash
+python3 .claude/scripts/python/build.py
+python3 .claude/scripts/python/test.py
+```
+
+The build runner runs `ruff check` + `mypy` and emits `BUILD SUCCEEDED | N warning(s)` or `BUILD FAILED | ...`. The test runner runs `pytest --cov` and emits the `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%` contract line.
+
+Raw `pytest`, `mypy`, and `ruff` invocations are blocked by `hooks.json`. Use the skills instead.
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/orchestrate
+```
+
+Then describe a small change: *"Add a `/healthz` endpoint that returns the current schema version"*. The pipeline will:
+
+1. Ask 1-2 feature-clarifying questions (likely about response shape and authentication)
+2. Generate a Haiku-tier plan
+3. Open a draft PR
+4. Run pre-flight build (`mypy` + `ruff`)
+5. Implement, review (with the Python reviewer overlay enforcing GIL, security, resource management), commit
+6. Run tests (must hit ≥90% coverage)
+7. Ask you to manually test
+8. File a token-analysis report
+
+For a small endpoint addition, expect ~$0.10-0.30 and 5-8 minutes wall-clock.
+
+## Common pitfalls
+
+### Mutable default arguments
+
+The Python implementer overlay forbids `def f(items=[])` (a classic Python footgun). Haiku-emitted code uses `None` sentinel + `if items is None: items = []`. If you have legacy code with mutable defaults, the reviewer flags it as a `[should-fix]`.
+
+### Test discovery on flat-layout packages
+
+`pytest` defaults to discovering tests under `tests/` or any `test_*.py` file. If your tests live elsewhere, set `[tool.pytest.ini_options].testpaths` in `pyproject.toml`. The pipeline trusts your project's `pytest` config — it does not pass extra `--rootdir` flags.
+
+### Coverage gate at 90%
+
+The implementer's Rule 7 enforces ≥90% coverage. On a fresh project with low coverage, the first feature run may fail this gate. Two paths:
+
+1. Lower the gate temporarily via the brief's "Verification" override (state explicitly that this run has a coverage exception; the test-architect agent will not generate extra tests beyond the brief)
+2. Run the test-architect agent first to bring overall coverage up to 90% before triggering `/orchestrate`
+
+### Async test gotchas
+
+If your project uses `pytest-asyncio`, configure `asyncio_mode = "auto"` in `pyproject.toml` so the implementer doesn't have to mark every test `@pytest.mark.asyncio`. The Python implementer overlay assumes auto mode.
+
+### Multi-stack repos with React + Python
+
+A common shape: React in `frontend/`, Python in `backend/`. Bootstrap both:
+
+```bash
+bash .claude/pipeline/init.sh . --stack=react --stack=python
+```
+
+Use explicit `stack_paths` in `pipeline.config` to keep the boundary clean. The orchestrator routes each task to the correct adapter; the reviewer agent for a wave loads the union of stacks present in that wave's tasks.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `python` in the title.

--- a/docs/adoption/react.md
+++ b/docs/adoption/react.md
@@ -1,0 +1,122 @@
+# Adopting the React / TypeScript Adapter
+
+This adapter activates when the pipeline detects React in your `package.json`. It covers React + TypeScript projects using Jest or Vitest for tests.
+
+## Detection
+
+`init.sh` activates this adapter when:
+
+- `package.json` exists and contains the string `"react"` (in any dependency field)
+
+If `package.json` exists but no other adapter matched, this adapter activates as a fallback (covers plain TypeScript/JavaScript projects).
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Node.js 18+ | Runtime for npm/yarn/pnpm/bun | Use whatever your `package.json` engines field requires |
+| `npm` / `yarn` / `pnpm` / `bun` | Package manager | Detected from your lockfile |
+| `tsc` | Type checking during build | Provided by `typescript` devDep |
+| Jest or Vitest | Test runner | Detected from `package.json` test script |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+## Bootstrap
+
+```bash
+cd your-react-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: react
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/react -> .claude/pipeline/adapters/react/scripts
+Wrote .claude/pipeline.config (stacks=react)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+After bootstrap, edit `.claude/ORCHESTRATOR.md` to describe your architecture (component layout, state management, data flow). The architect agent reads this on every run.
+
+## Project layout assumed
+
+Default `stack_paths` for React expect code in:
+
+- `src/frontend/`, `frontend/`, `client/`, or `app/`
+
+Plus a fallback to any `**/*.tsx`, `**/*.jsx`, `**/*.ts`, `**/*.js` file.
+
+If your project uses a non-standard path (e.g., `web/` or `apps/<name>/`), edit `.claude/pipeline.config` after bootstrap:
+
+```ini
+stack_paths.react=web/**,apps/*/src/**
+```
+
+## Build & test commands
+
+The pipeline calls these via the `build-runner` and `test-runner` skills:
+
+```bash
+python3 .claude/scripts/react/build.py
+python3 .claude/scripts/react/test.py
+```
+
+The build runner shells out to `tsc --noEmit` for type checking and your project's build script (auto-detected from `package.json`). The test runner runs Jest/Vitest with coverage and emits the pipeline's `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%` contract line.
+
+Raw `npm test` and `npx jest` are blocked by `hooks.json` to force pipeline usage and avoid coverage drift. Override the block by running through the skill instead.
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/orchestrate
+```
+
+Then describe a small feature: *"Add a loading spinner to the homepage data fetch"*. The pipeline will:
+
+1. Ask 1-2 feature-clarifying questions
+2. Generate a Haiku-tier plan (likely 1-2 tasks for a small change)
+3. Open a draft PR
+4. Run pre-flight build to catch any pre-existing TS errors before launching tasks
+5. Implement, review, commit
+6. Ask you to manually test the PR branch
+7. File a token-analysis report
+
+For a 1-2 task change, expect ~$0.05–0.20 in API costs and 3-5 minutes wall-clock.
+
+## Common pitfalls
+
+### `cleanup()` cargo-cult in tests
+
+Haiku used to add `import { cleanup } from '@testing-library/react'` and `afterEach(() => cleanup())` because RTL docs from older versions show this pattern. RTL v9+ auto-registers cleanup. The implementer overlay now explicitly forbids manual `cleanup()` (PR #51), so this should not happen in fresh runs. If you see it, the React adapter overlay may need an update — file an issue.
+
+### Pre-existing TS errors block Haiku
+
+If `tsc --noEmit` fails on the unmodified base, Haiku tasks will hit the same errors and fail. The pre-flight build at Step 1.4 catches this and pauses with three options: abort, continue anyway, or inject a Wave 0 fix. Recommend **inject Wave 0 fix** — let the pipeline handle the blocker before scheduling the real work.
+
+### Multi-stack repos with React + Python
+
+If your repo has both a React frontend and a Python backend, bootstrap both adapters:
+
+```bash
+bash .claude/pipeline/init.sh . --stack=react --stack=python
+```
+
+The orchestrator routes each task to the correct adapter using `stack_paths`. Use explicit `stack_paths` in `pipeline.config` to avoid ambiguity at the boundary (e.g., a config file used by both).
+
+### `package.json` without React still activates this adapter
+
+The React adapter has a fallback rule that triggers for any `package.json` if no other adapter matched. If you're on a plain Node.js (non-React) project and want a different setup, add `--stack=` flags explicitly to override auto-detection.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `react` in the title.

--- a/docs/adoption/swift-ios.md
+++ b/docs/adoption/swift-ios.md
@@ -1,0 +1,118 @@
+# Adopting the Swift / iOS Adapter
+
+This adapter activates for Apple-ecosystem projects: iOS, watchOS, macOS, tvOS, and Swift Packages. The pipeline uses Xcode for build and XCTest for tests, with `xccov` for coverage.
+
+## Detection
+
+`init.sh` activates this adapter when any of these exist at the project root:
+
+- `*.xcodeproj` directory
+- `*.xcworkspace` directory
+- `Package.swift`
+
+## Tools you'll need
+
+| Tool | Why | Notes |
+|---|---|---|
+| Xcode 15+ | Build + test toolchain | Install via App Store; accept the EULA after install |
+| `xcrun` | Sub-tool resolution | Provided by Xcode |
+| iOS / watchOS simulators | Test runtime | Install via Xcode > Settings > Platforms |
+| `gh` CLI | PR creation by the pipeline | `gh auth status` must exit 0 |
+
+For watchOS apps, the watch-side build/test scheme needs both iPhone + Watch destinations. The adapter's `scripts/build.py` figures this out from your scheme list, but you'll get clearer errors if the scheme is configured properly.
+
+## Bootstrap
+
+```bash
+cd your-ios-project
+git submodule add https://github.com/MILL5/claude-code-pipeline.git .claude/pipeline
+bash .claude/pipeline/init.sh .
+```
+
+Expected output:
+
+```
+Detected stacks: swift-ios
+Symlinks created:
+  .claude/agents -> .claude/pipeline/agents
+  .claude/skills/* -> .claude/pipeline/skills/*
+  .claude/scripts/swift-ios -> .claude/pipeline/adapters/swift-ios/scripts
+Wrote .claude/pipeline.config (stacks=swift-ios)
+Merged hooks into .claude/settings.json
+Generated .claude/CLAUDE.md and .claude/ORCHESTRATOR.md (edit these next)
+Generated .claude/local/ overlay templates
+```
+
+After bootstrap, edit `.claude/ORCHESTRATOR.md` to capture your scheme names, build targets (e.g., iOS app + Watch app + widgets), and any Apple-specific architecture notes (MVVM, observation, persistence layer).
+
+## Project layout assumed
+
+The adapter has no enforced directory layout — it relies on the `**/*.swift` fallback glob. Both flat (everything in `Sources/`) and target-segregated (multi-target Xcode project) layouts work.
+
+If you have multiple platforms in one repo (e.g., iOS app + watchOS app), the pipeline launches separate build/test invocations per scheme based on what your project declares.
+
+## Build & test commands
+
+```bash
+python3 .claude/scripts/swift-ios/build.py
+python3 .claude/scripts/swift-ios/test.py
+```
+
+`build.py` shells out to `xcodebuild` per active scheme and emits the pipeline's contract line (`BUILD SUCCEEDED | N warning(s)` / `BUILD FAILED | ...`). `test.py` runs `xcodebuild test` with code coverage enabled, parses `.xcresult`, and emits `Summary: Total: N, Passed: N, Failed: N | Coverage: X.X%`.
+
+Raw `xcodebuild build`, `xcodebuild test`, `swift build`, and `swift test` invocations are blocked by `hooks.json`. Use the skills.
+
+## First `/orchestrate` run
+
+Inside Claude Code:
+
+```
+/orchestrate
+```
+
+Then describe a small UI change: *"Add a settings toggle to enable haptic feedback on the timer screen"*. The pipeline will:
+
+1. Ask 1-2 feature-clarifying questions (UI placement, persistence, default state)
+2. Generate a Haiku-tier plan (likely 2-3 tasks: model + view + settings persistence)
+3. Open a draft PR
+4. Run pre-flight build (catches existing scheme/destination issues)
+5. Implement, review (with Swift reviewer overlay watching for retain cycles, force-unwraps, MainActor violations), commit
+6. Run XCTest with coverage
+7. Ask you to manually test on a simulator or device
+8. File a token-analysis report
+
+For a small UI feature, expect ~$0.15-0.40 and 8-15 minutes wall-clock (Xcode builds dominate wall-clock cost).
+
+## Common pitfalls
+
+### Simulator availability
+
+`xcodebuild test` needs a destination. If no simulator is installed for the deployment target, tests fail with cryptic errors. Pre-install simulators for your deployment targets in Xcode > Settings > Platforms before running the pipeline.
+
+### Multi-scheme repos (iOS + Watch + Widgets)
+
+Each scheme has its own destination. The default `scripts/test.py` runs all schemes. If you only want to run the iOS app's scheme, pass `--scheme=YourApp` through the test-runner skill — but the implementer agent will run all schemes by default to enforce the regression guard across targets.
+
+### `[weak self]` patterns Haiku may miss
+
+The Swift implementer overlay enforces `[weak self]` in escaping closures. Haiku occasionally cargo-cults `[weak self]` even when not needed (e.g., inside a `Task { @MainActor in ... }` whose lifecycle is already bounded). The reviewer typically catches over-application. If you see false-positive `[weak self]` in implementations, file a docs issue — the implementer overlay may need a refinement.
+
+### Force-unwraps in test code
+
+The Swift reviewer overlay flags force-unwraps in production code as `[should-fix]` or `FAIL`. Tests are exempted by convention (using `try!` or `XCTUnwrap` is fine in tests). The reviewer knows the difference, but it's worth noting if a Haiku implementer over-applies the rule.
+
+### Multi-stack: Flutter app with native Swift modules
+
+If you're embedding native Swift code in a Flutter app, bootstrap both adapters:
+
+```bash
+bash .claude/pipeline/init.sh . --stack=flutter --stack=swift-ios
+```
+
+The orchestrator routes Dart tasks to Flutter overlays and Swift tasks to Swift overlays. Cross-stack work (e.g., Dart calling into a Swift platform channel) gets the architect's union view of both.
+
+## Where to file issues
+
+Pipeline behavior issues: https://github.com/MILL5/claude-code-pipeline/issues
+
+Adoption pain specific to this stack: same repo, label `type: docs` with `swift-ios` in the title.


### PR DESCRIPTION
## Summary

Adds `docs/adoption/<stack>.md` for all six adapters (swift-ios, react, python, flutter, android, bicep). Each guide follows the same structure so adopters get a predictable shape regardless of stack.

## Scope (per the issue acceptance criteria)

- [x] One `docs/adoption/<stack>.md` per active adapter (6 files)
- [x] Each links from the README's \"Available Adapters\" row (new \"Adoption Guide\" column)
- [x] Each includes a worked example of a successful first `/orchestrate` run
- [x] Each documents 3-5 common pitfalls (drawn from manifest detection rules, overlay rules, and recent token-analysis incidents)
- [x] `python3 tests/validate_structure.py` passes (376 checks)

## Guide structure (consistent across all six)

1. Detection — what triggers auto-detection (from each manifest.json)
2. Tools you'll need — required tooling and notes
3. Bootstrap — expected `init.sh` output
4. Project layout assumed — default `stack_paths` and how to override
5. Build & test commands — how the pipeline invokes them
6. First `/orchestrate` run — a stack-appropriate worked example
7. Common pitfalls — 3-5 gotchas per stack
8. Where to file issues

## Notable content choices

- **Bicep guide** is a thin wrapper that points to the more comprehensive `docs/azure-guide.md` rather than duplicating that ~1000-line walkthrough.
- **React guide** documents the `cleanup()` cargo-cult pitfall and the fix from #50/#51 — real adoption pain.
- **Multi-stack notes** in every guide cover the common combos (React + Python; Flutter + swift-ios + Android; Bicep + an SDK language).
- **Pitfalls drawn from real signal where possible** (React's `cleanup()`, Python's mutable-default ban, Bicep's `dependsOn` over-specification flagged by `[simplify]`). Stacks without recent incident data have pitfalls inferred from the implementer/reviewer overlays.

## What's still open in #55

The remaining bullet — \"Link LICENSE in the README's License section\" — depends on #53 merging. After #53 lands, it's a one-line edit (`MIT` -> `MIT — see [LICENSE](LICENSE).`). I left #55 open for that, with a checkbox noting the dependency.

## Test plan

- [x] All 6 guide files exist under `docs/adoption/`
- [x] README adapter table links resolve to the new files
- [x] README project-structure tree lists the new docs
- [x] `python3 tests/validate_structure.py` — 376 checks pass
- [ ] Spot-check one guide on a fresh repo of that stack to confirm bootstrap output matches reality (recommended before this PR merges)
- [ ] Read end-to-end as a new adopter for one stack — confirm the path from \"clone\" to \"first feature merged\" is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)