### PR TITLE
docs(mermaid): widen wrappingWidth so labels stop wrapping mid-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The pipeline is **tech-stack-agnostic**. The core workflow is identical whether 
 ## Pipeline at a Glance
 
 ```mermaid
+%%{init: {'flowchart': {'wrappingWidth': 300}}}%%
 flowchart TD
     User([User describes feature]) --> S1a
     S1a["<b>Step 1a</b>: Clarify<br/>Sonnet · scope &amp; behavior Q&amp;A"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,7 @@ For each agent launch:
 The composition is layered — pipeline-wide content first, then project-specific overrides:
 
 ```mermaid
+%%{init: {'flowchart': {'wrappingWidth': 320}}}%%
 flowchart LR
     subgraph PipelineRepo["From pipeline repo"]
         Adapter["Adapter overlay<br/>per stack, per agent role<br/>e.g. adapters/react/reviewer-overlay.md"]

--- a/docs/backlog-integration.md
+++ b/docs/backlog-integration.md
@@ -5,6 +5,7 @@ Backlog integration captures out-of-scope work surfaced during `/orchestrate` ru
 ## Fold vs. defer at a glance
 
 ```mermaid
+%%{init: {'flowchart': {'wrappingWidth': 280}}}%%
 flowchart TD
     Source["Out-of-scope item surfaced by:<br/>• Reviewer (OPTIONAL IMPROVEMENTS, tagged)<br/>• Planner (Deferred Items)<br/>• Implementer (Follow-up suggestion)<br/>• Token analysis (always defers)"]
     Source --> Classify{Haiku-tier?<br/>single-file<br/>mechanical<br/>fully-specified}


### PR DESCRIPTION
## Summary
- GitHub's default Mermaid `wrappingWidth` (~200px) was breaking longer node labels mid-phrase. Examples seen in the rendered diagrams: `Sonnet default, Opus if / novel`, `adapters/react/reviewer- / overlay.md`, `• Reviewer (OPTIONAL / IMPROVEMENTS, tagged)`.
- Adds a one-line `%%{init: {'flowchart': {'wrappingWidth': N}}}%%` directive to each of the three Mermaid diagrams (`README.md`, `docs/architecture.md`, `docs/backlog-integration.md`) — 300 / 320 / 280 — so each `<br/>`-separated line renders intact.
- No text content changed.

## Test plan
- [ ] Open `README.md` on GitHub and confirm the Step 1b / Step 2.1 / Step 3.5 labels render on single lines (no mid-phrase breaks).
- [ ] Open `docs/architecture.md` and confirm the Adapter / Cross-cutting overlay file-path examples render on single lines.
- [ ] Open `docs/backlog-integration.md` and confirm each bullet in the top "Out-of-scope item surfaced by:" box renders on its own single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)