### PR TITLE
chore(react): lift act() and container.querySelector cargo-cult rules (closes #52)

### DIFF
--- a/adapters/react/implementer-overlay-essential.md
+++ b/adapters/react/implementer-overlay-essential.md
@@ -10,4 +10,4 @@
 - Stable, unique `key` props in lists — never array index for dynamic lists
 - Handle loading, error, and empty states explicitly in data-fetching components
 - `const` by default, `let` only for reassignment, never `var`
-- Do NOT import or call `cleanup()` in test files — `@testing-library/react` registers it automatically via `afterEach`
+- RTL tests (`@testing-library/react` auto-handles cleanup + `act()`): no `cleanup()`, no `act()` around RTL helpers, no `container.querySelector` — use `getByRole`/`getByLabelText`

--- a/adapters/react/implementer-overlay.md
+++ b/adapters/react/implementer-overlay.md
@@ -56,7 +56,11 @@ Within the boundaries of what the brief asks for, write clean React/TypeScript:
 
 ## Testing
 
-- Do NOT import or call `cleanup()` in test files — `@testing-library/react` registers it automatically via `afterEach`. Manual calls are dead code that the reviewer will reject.
+When writing tests with `@testing-library/react` (RTL), the library already handles common test-setup mechanics. Manual duplication is dead code that the reviewer will reject:
+
+- Do NOT import or call `cleanup()` in test files — RTL registers it automatically via `afterEach`.
+- Do NOT wrap RTL helpers (`render`, `userEvent`, `fireEvent`, `waitFor`, `findBy*`) in `act()` — they already wrap it internally. Manual `act()` is only needed for direct state mutations outside RTL.
+- Do NOT use `container.querySelector` to find elements — use RTL queries: `getByRole`, `getByLabelText`, `getByPlaceholderText`, `getByText`, falling back to `getByTestId` only when no accessible query works.
 
 ## Project Conventions
 

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -263,6 +263,43 @@ def check_essential_overlay_size(result: ValidationResult) -> None:
             )
 
 
+# Rules that have been lifted from test-overlay.md into implementer overlays
+# to prevent Haiku cargo-culting library-auto-handled patterns. Each entry
+# asserts that the distinctive identifier still appears in the implementer
+# essential overlay AND the full overlay for the named adapter. See issue #52.
+#
+# Format: (adapter, identifier, source-issue, description)
+LIFTED_RULES: list[tuple[str, str, str, str]] = [
+    ("react", "`cleanup()`", "#50/#51", "RTL auto-registers afterEach(cleanup)"),
+    ("react", "`act()`", "#52", "RTL helpers already wrap act() internally"),
+    ("react", "container.querySelector", "#52", "Use RTL accessibility queries instead"),
+]
+
+
+def check_lifted_rules_present(result: ValidationResult) -> None:
+    """Rules lifted into implementer overlays must remain there (drift guard).
+
+    Once a cargo-cult-prevention rule is lifted from test-overlay.md into the
+    implementer overlay, removing it would silently re-create the gap where the
+    test-architect sees the rule but the implementer that writes the test code
+    does not. This check enforces persistence in BOTH the essential variant
+    (Haiku reads it) and the full variant (Sonnet/Opus reads it). See issue #52.
+    """
+    for adapter, identifier, source, description in LIFTED_RULES:
+        for variant in ("implementer-overlay-essential.md", "implementer-overlay.md"):
+            path = PIPELINE_ROOT / "adapters" / adapter / variant
+            if not path.exists():
+                continue  # caught by completeness check
+            content = path.read_text()
+            if identifier in content:
+                result.ok(f"Adapter {adapter}: lifted rule '{identifier}' present in {variant}")
+            else:
+                result.fail(
+                    f"Adapter {adapter}: lifted rule '{identifier}' missing from {variant} "
+                    f"(source: {source} — {description}; do not silently revert lifts)"
+                )
+
+
 def check_essential_overlay_no_pipeline_protocol_rules(result: ValidationResult) -> None:
     """Essential overlays must not duplicate pipeline-protocol rules from agent definitions (C1).
 
@@ -1259,6 +1296,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Adapter completeness", check_adapter_completeness),
         ("Essential overlay size", check_essential_overlay_size),
         ("Essential overlay no pipeline-protocol rules", check_essential_overlay_no_pipeline_protocol_rules),
+        ("Lifted rules drift guard (#52)", check_lifted_rules_present),
         ("Agent injection markers", check_agent_markers),
         ("Agent output protocols", check_agent_protocols),
         ("TOKEN_REPORT consistency", check_token_report_consistency),


### PR DESCRIPTION
## Summary

- Lifts two RTL cargo-cult rules from `adapters/react/test-overlay.md` into both variants of the implementer overlay so Haiku sees them when writing test code (not just the test-architect that plans tests).
- Adds a drift guard in `tests/validate_structure.py`: a `LIFTED_RULES` registry asserts that each lifted rule's distinctive identifier remains present in both `implementer-overlay-essential.md` and `implementer-overlay.md`. Catches silent regressions where someone moves a rule back to test-overlay-only and re-opens the gap that motivated #50.

## Acceptance criteria from #52

- [x] **Each known RTL suspect decided**:
  - `cleanup()` — already lifted in #51
  - `act()` wrapping when RTL handles it — **lifted** (universal cargo-cult shape)
  - `container.querySelector` — **lifted** (universal cargo-cult shape)
  - `fireEvent` over `userEvent` — **kept in test-overlay only** (test-design preference, not a "library auto-handles" pattern)
  - Snapshotting entire page components — **kept in test-overlay only** (test-architect's call, not implementer)
- [x] **Fast pass over python and swift-ios** — no candidates found (see below)
- [x] **Single follow-up PR** implements the lifts (this PR)
- [x] **Essential overlay under 1000-char cap** — react went 932 → 994 chars
- [x] **Drift guard** added in `tests/validate_structure.py:check_lifted_rules_present`, registered as `Lifted rules drift guard (#52)`. Negative-tested: removing any lifted identifier from either overlay causes a clear failure naming the adapter, rule, source issue, and which file is missing it.

## No candidates found — python and swift-ios

The issue body listed speculative candidates for python (manual `try/finally` vs context managers, `loop.close()` vs `asyncio.run`, hand-rolled retry loops, manual `__enter__/__exit__`) and swift-ios (`[weak self]` inside `@MainActor`, `DispatchQueue.main.async` inside actor-isolated code, manual NotificationCenter cleanup). Reviewed each:

- The patterns most likely to cause cargo-cult (context manager use, type system idioms, actor isolation) are already covered by existing essential rules — `with` for resources is on python essential line 5, `@MainActor` for UI code is on swift-ios essential line 3.
- The remaining speculative items have no incident data backing them. Lifting rules without confirmed incidents inflates the essential overlay against its 1000-char cap with no proven payoff.

Recommendation: revisit per-adapter when concrete incidents accrue (the same trigger that drove #50 → #51 → this PR).

## Test plan

- [x] `python3 tests/validate_structure.py` — passes (382 checks, +6 new from the drift guard registry)
- [x] `python3 tests/test_contracts.py` — passes (80 tests)
- [x] Drift guard negative-tested: temporarily removed each rule from the essential overlay and confirmed the validator fails with the expected message
- [x] Essential overlay size verified at 994 chars, under the 1000-char cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)