### PR TITLE
chore(planner): add small-edit brief mode targeting ~4K chars (part of #59)

### DIFF
--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -176,18 +176,30 @@ A context brief includes:
    - **Target line range**: `lines N–M` so the implementer can use `Read(offset=N, limit=5)`
      instead of ingesting the full file to locate the target. Without this, Haiku reads the
      entire file — a 27K-char test file costs ~7K tokens just to find a 3-line edit target.
-   - **TRUST THE BRIEF note** (append at the end of the brief):
-     > "The before/after strings above were copied directly from the file at HEAD — do not
-     > re-read the file to verify. If you need surrounding context, use
-     > `Read(offset=N, limit=10)` scoped to the line range above."
+   - **TRUST THE BRIEF note** (append at the end of the brief, exactly one sentence):
+     > "Strings copied from HEAD; do not re-read to verify. For surrounding context use `Read(offset=N, limit=10)` scoped to the line range above."
 
-   This addresses the triple-read pattern: 1a reads the file to draft the strings, 1b reads
-   it to confirm them, and the implementer reads it again to locate them. The line range
-   makes the implementer's read a 10-line targeted fetch instead of a full-file ingest.
+   This addresses the triple-read pattern (1a → 1b → implementer all reading the same file).
+   The line range makes the implementer's read a 10-line targeted fetch instead of a
+   full-file ingest.
 
 **Critical rule**: A context brief must be *self-contained*. Haiku should never need to read another task's brief to execute this one. If task B depends on task A's output, task B's brief must include the relevant interface/contract inline, not "see task A."
 
 **Why FORBIDDEN goes near the top**: Haiku tends to cargo-cult "solutions" it has seen in training and quietly ignore prohibitions buried at the bottom of a long brief. Stating them as `FORBIDDEN in this task:` right after the file list — before the agent has loaded up on output-spec momentum — materially improves adherence. Reserve this section for task-specific prohibitions only; generic stack rules belong in the implementer overlay.
+
+#### Small-edit brief mode (target ~4K chars)
+
+For tasks that change fewer than ~20 lines in a single file, OR create a single file with fewer than ~50 lines of generated content, write a compact brief that fits in ~4,000 characters (~1K tokens). Verbose briefs on small tasks waste 5-7x the implementer's input token budget — a 53K-token prompt for a 50-line YAML edit is the failure mode tracked in issue #59.
+
+For these tasks:
+
+- **Inline diffs over verbatim blocks.** When editing existing files, show only the changed lines plus 2-3 lines of surrounding context, not the full before/after of large sections. The implementer can `Read(offset=N, limit=10)` for more context if needed (combined with the line-range hint in #8 above).
+- **Skeleton-with-comments over full templates.** When creating a new file, write a 10-line skeleton with inline comments describing each section, not the full target file content. Haiku is good at expanding skeletons; pasting the full target turns the brief into a copy-paste exercise.
+- **FORBIDDEN cap of 2.** Keep to two task-specific risks. If you're tempted to list more, the rest belong in the implementer overlay (general stack rules) rather than the brief.
+- **One-sentence TRUST THE BRIEF.** For exact-string edits, use the condensed format from #8 above — never expand it back to a multi-line block.
+- **Skip background prose.** Do not explain why the change is part of a larger feature. The implementer does not need to choose between code paths based on motivation; if it does, the brief is under-specified for Haiku and should be split or escalated.
+
+The general Brief size gate (Decomposition Quality Checks below) flags briefs over 3K tokens for Haiku. Small-edit mode targets ~1K tokens, comfortably under the gate.
 
 ### Step 5: Assign Models, Stacks, and Estimate
 

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -670,6 +670,41 @@ def check_planner_exact_string_brief_hints(result: ValidationResult) -> None:
         result.fail("Planner missing TRUST THE BRIEF note for exact-string edit briefs")
 
 
+def check_planner_small_edit_brief_mode(result: ValidationResult) -> None:
+    """Planner must document small-edit brief mode targeting ~4K chars (#59 Finding 1).
+
+    Issue #59 traced 38-53K-token implementer prompts to verbose briefs on small edits.
+    The fix is a documented "Small-edit brief mode" with a ~4K-char target, inline-diff
+    guidance for edits, skeleton-with-comments for creates, and a 2-item FORBIDDEN cap.
+    This check ensures those guardrails stay in the planner.
+    """
+    path = PIPELINE_ROOT / "skills" / "architect-planner" / "SKILL.md"
+    if not path.exists():
+        return
+
+    content = path.read_text()
+
+    if "Small-edit brief mode" in content:
+        result.ok("Planner documents small-edit brief mode")
+    else:
+        result.fail("Planner missing small-edit brief mode section (#59 Finding 1)")
+
+    if "4,000 character" in content or "~4K chars" in content or "4K characters" in content:
+        result.ok("Planner documents ~4K-char target for small-edit briefs")
+    else:
+        result.fail("Planner missing ~4K-char target for small-edit briefs (#59)")
+
+    if "nline diff" in content:  # matches "Inline diffs"/"inline diffs"
+        result.ok("Planner documents inline-diff guidance for small edits")
+    else:
+        result.fail("Planner missing inline-diff guidance for small edits (#59)")
+
+    if "Skeleton-with-comments" in content or "skeleton-with-comments" in content or "skeleton with comments" in content.lower():
+        result.ok("Planner documents skeleton-with-comments guidance for new-file creates")
+    else:
+        result.fail("Planner missing skeleton-with-comments guidance for new-file creates (#59)")
+
+
 def check_orchestrate_reads_plan_from_disk(result: ValidationResult) -> None:
     """Orchestrate must read 1b-plan.md from disk, not from agent output."""
     orchestrate_path = PIPELINE_ROOT / "skills" / "orchestrate" / "SKILL.md"
@@ -1310,6 +1345,7 @@ def run_all_checks(verbose: bool = False) -> ValidationResult:
         ("Token-analysis small-plan gates", check_token_analysis_small_plan_gates),
         ("Planner PLAN_WRITTEN stub", check_planner_plan_stub),
         ("Planner exact-string brief hints", check_planner_exact_string_brief_hints),
+        ("Planner small-edit brief mode (#59)", check_planner_small_edit_brief_mode),
         ("Orchestrate reads plan from disk", check_orchestrate_reads_plan_from_disk),
         ("ORCHESTRATOR.md template sections", check_orchestrator_template_sections),
         ("Extract profile headers", check_extract_profile_headers),


### PR DESCRIPTION
## Summary

Issue #59 Finding 1 reported implementer prompts at 38-53K tokens (5-7x over the 8K threshold), driven by verbose context briefs on small-edit tasks. The brief format guidance in `skills/architect-planner/SKILL.md` had no special case for single-file edits or small file creates, so the planner reused the same brief shape regardless of task scope (verbatim before/after blocks, multi-line FORBIDDEN, multi-line TRUST THE BRIEF).

This PR adds a **Small-edit brief mode** subsection prescribing:
- **Inline diffs** over verbatim before/after blocks for <20-line edits
- **Skeleton-with-comments** over full-file paste for <50-line creates
- **FORBIDDEN cap of 2 items** (down from generic 1-3)
- **One-sentence TRUST THE BRIEF** (referenced from #8 above)
- **Skip background prose** — implementer doesn't need to know feature motivation
- **Target ~4K chars (~1K tokens)** per brief — comfortably under the existing 3K-token Haiku Brief size gate

Also condenses the existing TRUST THE BRIEF note example in Step 4 #8 from a 3-line block to one sentence — the verbose version was being copied verbatim into every exact-string-edit brief, compounding the bloat.

## Drift guard

Adds `tests/validate_structure.py:check_planner_small_edit_brief_mode` enforcing that the guidance stays in the planner. 4 new checks:
- Section "Small-edit brief mode" exists
- 4K-char target is documented
- Inline-diff guidance present
- Skeleton-with-comments guidance present

If a future edit removes any of these, the validator fails with a clear `(#59)` source pointer.

## Why this doesn't close #59

#59 has two findings; this PR addresses Finding 1 only. Finding 2 (orchestrate SKILL.md overhead) is in #61. Both PRs together address the issue. After both merge, #59 should close.

## Forward-looking note

The actual brief-size reduction depends on future planner runs. This PR only changes guidance; existing pipelines won't replay differently. The next /orchestrate run that produces small-edit tasks should produce briefs that fit the 4K target.

## Test plan

- [x] `python3 tests/validate_structure.py` — 386 checks pass (4 new from the new drift guard)
- [x] `python3 tests/test_contracts.py` — 80 tests pass
- [x] Negative spot-check: removing "Small-edit brief mode" header from the planner causes the new check to fail with the expected message (manually verified pattern; identical guard pattern as #52's drift guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)