### PR TITLE
chore(planner,token-analysis): structural-overhead suppression and coverage-test classification (closes #63)

### DIFF
--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -223,6 +223,19 @@ implementer receives.
 | Requires design decisions OR multi-file consistency OR moderate reasoning | **Sonnet** | ~$0.03-0.15 |
 | Irreducibly complex: novel algorithm, concurrent correctness, architectural decisions | **Opus** | ~$0.10-0.50 |
 
+**Coverage-test tasks default to Haiku.** Test-writing tasks (adding `*.test.*` files for an
+existing component, hook, or function) qualify as "fully specified, single file" by default.
+Escalate to Sonnet only when one of these signals applies:
+
+- More than 3 mocked dependencies (mocked modules, hooks, or services in a single test file)
+- Async or concurrent behavior under test (timers, race conditions, ordering invariants)
+- Test output expected to exceed 300 lines (rough proxy: more than ~25 cases or >5 setup helpers)
+- Tests asserting cross-component or cross-module state (integration-style tests)
+
+A 16-test component file with two event-handler mocks is Haiku. A 40-test file with six mocked
+modules is Sonnet. When in doubt, prefer Haiku and let the reviewer flag if the brief was
+under-specified.
+
 **Cost check**: After assignment, compute the estimated total cost. Compare against "what if we ran everything on Sonnet" and "what if we ran everything on Opus." The mixed strategy should be meaningfully cheaper.
 
 ### Step 6: Define Execution Order
@@ -434,6 +447,8 @@ Sometimes the planner can't fully specify a task because it depends on runtime d
 | Signal | Model | Why |
 |--------|-------|-----|
 | Clear, self-contained spec | **Haiku** | Cheapest, fast, reliable |
+| Coverage test for existing code, ≤3 mocks, no async, <25 cases | **Haiku** | Default for test-writing tasks |
+| Coverage test with >3 mocks, async behavior, or integration scope | **Sonnet** | Mock orchestration / cross-module reasoning |
 | Multi-file changes needing consistency | **Sonnet** | Cross-file coherence |
 | >3 interacting edge cases or >300 lines output | **Sonnet** | Haiku drops edge cases / drifts |
 | Design decisions constraining downstream tasks | **Sonnet** | Requires judgment |

--- a/skills/token-analysis/SKILL.md
+++ b/skills/token-analysis/SKILL.md
@@ -71,6 +71,18 @@ Gates suppressed for small plans (< 4 tasks):
   **not** suppressed)
 - **Section 7** — aggregate file-read overhead > 30% gate
 
+**Structural-overhead adjustment:** Even on plans with ≥4 implementation tasks, fixed
+Sonnet-tier overhead can structurally dominate when the 1b plan or wave reviewer is expensive.
+When `(step_1a_cost + step_1b_cost + reviewer_cost) / total_cost > 0.25`, the Sonnet target
+of 20% is mathematically unreachable regardless of planner quality (overhead alone exceeds
+the target ceiling). In this case, suppress the model-distribution 15pp-deviation gate and
+emit a one-line note: *"Structural overhead dominates (1a+1b+reviewer = X% of total):
+model-distribution gate suppressed — overhead alone exceeds Sonnet target."*
+
+Apply only the model-distribution suppression here, not the broader small-plan suppression.
+Other gates (review-ratio, step-anomalies, file-read overhead) remain in force because they
+target distinct failure modes.
+
 Continue to compute and report all distributions and ratios for visibility; the suppression
 only prevents these from tripping the filing threshold and generating findings.
 
@@ -182,9 +194,12 @@ Fixed orchestrator overhead: ~N,NNN tokens (~$X.XX at Sonnet input rates)
 This is loaded ~once per /orchestrate run, separate from per-agent costs.
 ```
 
-If `fixed_overhead_tokens > 25,000`, flag as a finding — the orchestrate skill or overlays
-have grown enough that pipeline startup cost is becoming significant. Recommend trimming the
-orchestrate skill (it should target <15K tokens) or splitting overlay content.
+If `fixed_overhead_tokens > 35,000`, flag as a finding — overhead has grown beyond the
+post-trim structural floor (~35K for a two-stack project after #59 trim work). Recommend
+splitting overlay content or lazy-loading on-demand sections of orchestrate/SKILL.md. Do
+not flag for being merely above the older 25K target — that target is structurally
+unreachable without a larger restructure (split orchestrate, lazy-load overlays per task),
+and recurring findings against an unactionable floor are noise.
 
 ### 8. Output Bloat Detection (per-agent-type baselines)
 


### PR DESCRIPTION
## Summary

Resolves #63. Three small edits across two skill files:

1. **`skills/token-analysis/SKILL.md` Section 2** — adds a structural-overhead suppression gate. When `(step_1a + step_1b + reviewer_cost) / total > 25%`, the 20% Sonnet target is mathematically unreachable (overhead alone exceeds the target ceiling). Suppresses the model-distribution 15pp-deviation finding with a one-line note instead of filing noise.
2. **`skills/architect-planner/SKILL.md` Step 5 + Quick Reference** — adds explicit coverage-test classification: default Haiku, escalate to Sonnet only on specific signals (>3 mocks, async behavior, >300 lines, integration scope). Closes the gap where #63's wave-1 (3 coverage tests, all Sonnet at $1.62) should have been a Haiku/Sonnet mix.
3. **`skills/token-analysis/SKILL.md` Section 8a** — raises fixed-overhead gate from 25K to 35K tokens, anchored on the measured post-#59 structural floor. The old 25K target is unreachable without a larger restructure (split orchestrate, lazy-load overlays per task), so recurring findings against an unactionable floor were noise.

## Why

#63 reported Sonnet at 94.6% of spend (target: 20%) on a coverage chore plan, with two layered root causes:

- **Layer 1 (structural):** fixed Sonnet overhead from 1a + 1b + reviewer = $0.90, which is 28% of total spend on this run — already above the 20% Sonnet ceiling regardless of planner quality. Edit (1) catches this case.
- **Layer 2 (planner):** the wave-1 test-writing tasks (App.test 6 mocks, useApi.test 9 hooks, CoinRow.test 2 mocks) were all Sonnet. CoinRow.test should have been Haiku. Edit (2) adds the explicit rubric.

The third edit is bookkeeping: #63 also re-flagged Finding 2 from #59 (orchestrate overhead 36K, over the 25K gate). #59's trim PR landed 4 minutes after #63's run started, but even post-trim the aggregate is ~35K and the 25K gate is structurally unreachable. Raising to 35K stops the false-positive recurrence while still catching genuine regression.

## Verification

- `python3 tests/validate_structure.py` — 386/386 pass
- `python3 tests/test_contracts.py` — 80/80 pass
- Diff: +33 / -3 lines across 2 files

## Test plan

- [x] Structural validator passes
- [x] Contract tests pass
- [ ] Next /orchestrate run on a coverage-chore plan exercises the new structural-overhead suppression
- [ ] Next /orchestrate run with coverage-test tasks exercises the planner's new classification rubric

🤖 Generated with [Claude Code](https://claude.com/claude-code)