### PR TITLE
chore(orchestrate,planner): bundle 1 cost reductions for #66

### DIFF
--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -292,9 +292,16 @@ The plan MUST be output as a structured document following this exact format:
 | Haiku | X         | ~X,000            | ~X,000            | $X.XX     |
 | Sonnet| X         | ~X,000            | ~X,000            | $X.XX     |
 | Opus  | X         | ~X,000            | ~X,000            | $X.XX     |
-| **Total** |       |                   |                   | **$X.XX** |
+| **Planned subtotal** | | | | **$X.XX** |
+| Risk uplift (folds + reviewer drift; see heuristic below — omit row when no triggers fire) | | | | +$X.XX |
+| **Estimated actual** | | | | **$X.XX** |
 | *All-Sonnet comparison* | | | | *$X.XX* |
 | *All-Opus comparison*   | | | | *$X.XX* |
+
+**Risk uplift heuristic** — set realistic budget expectations vs. plan-vs-actual cost overruns. Apply the uplift row only when ≥1 trigger condition fires:
+
+- **Folds:** +15% of the implementer subtotal per wave with ≥3 cross-file changes. Folds re-run the implementer at full Sonnet input when the reviewer flags `[should-fix]` items requiring code changes; empirically ~30% of cross-file waves trigger a fold cycle.
+- **Reviewer drift:** +15% of the reviewer cost per wave beyond Wave 1 when reviewer reuse spans waves. Cumulative SendMessage context grows ~50-100% per added review (production runs have observed 4.5× growth from Review 1 → Review 5).
 
 ## Stack Distribution
 | Stack | Task Count | Files |

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -322,7 +322,7 @@ the user whether to proceed without codebase context or update ORCHESTRATOR.md f
 | 1.4 | orchestrator (pre-flight build per stack against base branch) | — | PASS or user-prompted (abort / continue / inject Wave 0) |
 | 1.5 | open-pr skill | — | feature branch + draft PR |
 | 2 | implementer-agent per task (parallel within wave, ≤4 per batch) | Haiku / Sonnet / Opus | SUCCESS + commit msg, or FAILURE |
-| 2.1 | code-reviewer-agent (one per wave, reused via SendMessage, cap 8) | Sonnet | PASS or FAIL + issues |
+| 2.1 | code-reviewer-agent (one per wave, reused via SendMessage, cap 4) | Sonnet | PASS or FAIL + issues |
 | 2.2 | implementer-agent (same worktree, escalates Haiku→Sonnet on fix) | Sonnet | SUCCESS, or FAILURE after ≤2 cycles |
 | 3 | orchestrator (commit verbatim per agent, push, record test baseline) | — | commits on PR branch |
 | 3.4 | chrome-ui-test (conditional: `browser-ui` capability + UI files + MCP loadable) | Sonnet | PASS or routes FAIL into 3.5 cycle |
@@ -437,6 +437,11 @@ Prompt: |
 
   ENRICHED SPEC:
   <paste full contents of .claude/tmp/1a-spec.md>
+
+  EFFICIENCY CONSTRAINT: The 1a-spec was produced by reading the files in its
+  "Files & Services In Scope" section. Use the spec's extracts — do NOT re-read
+  those files end-to-end. If you need additional context, read only the specific
+  line ranges you need.
 
   CODEBASE CONTEXT (ORCHESTRATOR.md 1b extract — do not re-read from disk):
   <paste 1b Extract from Step 0.7>
@@ -675,8 +680,10 @@ Message: |
   <list the files the next implementer created/modified>
 ```
 
-**Cap at 8 reviews per agent.** If a wave has more than 8 tasks, launch a fresh reviewer
-agent for tasks 9+. This prevents context window saturation from accumulated review output.
+**Cap at 4 reviews per agent.** If a wave has more than 4 tasks, launch a fresh reviewer
+agent for tasks 5+. This prevents context window saturation from accumulated review output —
+empirically, reviewer SendMessage context grows ~50-100% per added review, so the cap is
+aligned with the wave-size cap (≤4 tasks) to keep cumulative growth bounded.
 
 **After each review returns:**
 
@@ -1093,7 +1100,13 @@ Use the planner's existing Haiku/Sonnet classification rubric
   → **defer** (file to backlog).
 
 Reviewer guidance:
-- `[should-fix]` entries with Haiku-tier fix are fold candidates.
+- `[should-fix]` entries with Haiku-tier fix:
+  - **Trivial patches (≤5 LOC AND single-file): default-defer.** A fold cycle costs
+    ~$0.30 in implementer tokens; trivial patches are cheaper for the user to capture
+    as a follow-up commit than to spawn a fold. Surface the deferred entry at PR
+    finalization so the user can choose to fold before merge.
+  - **Non-trivial patches: fold.** Deferring substantial should-fix items pushes
+    context-rebuilding cost onto a future PR.
 - `[nice-to-have]` entries default-defer regardless of tier.
 - `[simplify]` entries are fold candidates by definition (Haiku-tier,
   single-file, behavior-preserving). The reviewer self-attests behavior


### PR DESCRIPTION
## Summary

Bundle 1 from #66 token-analysis findings — four changes targeting the review/fix cycle and planning overhead, projected ~30% spend reduction on multi-wave runs.

- **F2** — reviewer SendMessage reuse cap 8 → 4. Aligns with wave-size cap (≤4 tasks).
- **F1** — `[should-fix]` Haiku-tier folds default-defer for trivial patches (≤5 LOC AND single-file).
- **F3** — added `EFFICIENCY CONSTRAINT` to the 1b prompt — don't re-read files extracted in the 1a-spec.
- **F4** — extended planner Cost Summary with fold-cycle and reviewer-drift uplift heuristics.

Splits filed: #67 (F1 broken-head), #68 (F3 1a passthrough). F5 (35K overhead floor) closed as working-as-designed in #66 comments.

## Test plan

- [x] `python3 tests/validate_structure.py` — 386 checks pass
- [x] `python3 tests/test_contracts.py` — 80 contract tests pass
- [ ] Validate live behavior on the next consumer-repo `/orchestrate` run that produces ≥3 waves; look for:
  - Only the first 4 reviews share a single agent; the 5th forces a fresh launch
  - Trivial `[should-fix]` items appear as deferred (not folded), surfaced at PR finalization
  - 1b log shows it relied on 1a-spec extracts rather than re-reading scope files
  - Plan output includes the new "Risk uplift" row (or omits it cleanly when no triggers fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)