### PR TITLE
feat: broken-head split detection and reviewer pass-through (closes #67)

### DIFF
--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -186,6 +186,20 @@ present:
   - <file>:<line> — <description; will be repaired in Wave N>
   ```
 
+  **Match test** — a finding qualifies as broken-head only when **both** hold:
+  1. The symptom is one of: undefined symbol, missing import, type mismatch at a
+     call site, signature mismatch, or unresolved reference to a renamed/moved/
+     removed identifier.
+  2. The affected file or the specific symbol named in the finding is referenced
+     in the annotation's `Reason:` field, OR the affected file is a downstream
+     consumer of a symbol named in `Reason:` (e.g., `Reason:` mentions
+     `Optimizer.run()`; the finding is in a file that imports `Optimizer`).
+
+  If either condition fails — or condition 2 cannot be determined from the
+  reviewed diff alone — **FAIL the finding per normal protocol**. Pass-through is
+  reserved for breakage the planner explicitly flagged; unrelated symptoms must
+  not slip through under cover of a partial match.
+
 - **Apply normal `PASS`/`FAIL` logic to unrelated findings.** A real CRITICAL/HIGH
   bug that has nothing to do with the broken head still produces `FAIL`. In that
   case, list the broken-head findings under a `--- BROKEN-HEAD NOTES ---` divider

--- a/agents/code-reviewer-agent.md
+++ b/agents/code-reviewer-agent.md
@@ -166,6 +166,35 @@ missing dependency injection, untestable architecture, tight coupling between la
 suggestions for future improvements, naming bikeshedding, SOLID "purity" concerns
 that don't create concrete risk (e.g., a small script that doesn't need DIP).
 
+### Broken-Head Pass-Through
+
+If the orchestrator's prompt includes a `BROKEN HEAD ANNOTATION:` block, the wave
+under review intentionally leaves the codebase in a broken intermediate state — a
+sequential split where the consumer-side update lives in a later wave (see the
+planner skill's "Broken-Head Split Detection" section). When the annotation is
+present:
+
+- **Pass-through findings that match the documented breakage** (callers using the
+  old signature, undefined consumers of a renamed symbol, missing imports for a
+  moved file — the annotation's `Reason:` field names the shape). Emit these as
+  `PASS` with a `--- BROKEN-HEAD NOTES ---` divider and one line per finding:
+
+  ```
+  PASS
+
+  --- BROKEN-HEAD NOTES ---
+  - <file>:<line> — <description; will be repaired in Wave N>
+  ```
+
+- **Apply normal `PASS`/`FAIL` logic to unrelated findings.** A real CRITICAL/HIGH
+  bug that has nothing to do with the broken head still produces `FAIL`. In that
+  case, list the broken-head findings under a `--- BROKEN-HEAD NOTES ---` divider
+  after the OPTIONAL IMPROVEMENTS section.
+
+- **No annotation, no pass-through.** Without a `BROKEN HEAD ANNOTATION:` block,
+  broken-integration symptoms are real bugs — `FAIL` per normal protocol. Never
+  invent a pass-through reason yourself.
+
 ### Protocol Guard
 
 The Pipeline Mode protocol above is the ONLY supported output format. **If your first line

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -426,6 +426,32 @@ to only what the implementer needs to produce code.
   put Task A in an earlier wave and inline its output signature into Task B's brief. Parallel
   tasks that each see only half of a shared contract produce runtime crashes that code review
   cannot catch. If the contract cannot be pre-determined, add a Wave 0 task to define it first.
+- [ ] **Broken-head split detection:** When a logical change must split across waves to fit
+  the 4-file cap AND the head wave's commit will leave the codebase in a broken intermediate
+  state (e.g., a function signature changes in Wave A while consumers in different files
+  update in Wave B), choose ONE of:
+  - **(a) Collapse with cap exemption** — combine the work into a single task even if it
+    touches 5-6 files. Document the exemption inline in the task brief:
+    `Note: 5-file exemption — avoiding broken-head split at wave boundary.`
+    Prefer this option when total file count ≤6 (still Haiku-executable).
+  - **(b) Annotate the head wave** — keep the split, and add a second italic metadata line
+    below the wave description in the format:
+
+    ```
+    ### Wave 4a: [Description]
+    *Tasks in this wave have no inter-dependencies and can execute in parallel.*
+    *Broken head expected: <one-line reason> — repaired by Wave <N>.*
+    ```
+
+    The orchestrator parses this annotation and instructs the reviewer to treat findings
+    matching the documented breakage as pass-through (`PASS` with `--- BROKEN-HEAD NOTES ---`,
+    not `FAIL`), avoiding a wasted fold cycle. Use this option when file count >6 (collapsing
+    would push the task into Sonnet/Opus tier).
+
+  Detection heuristic: a sequential split creates a broken head when one wave modifies a
+  public symbol (function signature, exported interface, type definition) and a later wave
+  updates consumers of that symbol in different files. Inspect each cross-wave file
+  dependency before finalizing the plan.
 
 ## Common Mistakes to Avoid
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -652,6 +652,11 @@ a sequential split intentionally leaves a broken intermediate state (see
 `BROKEN HEAD ANNOTATION:` block entirely. The annotation lives only on the first review
 of the wave — subsequent SendMessage reviews already have it in context.
 
+Use the regex specified by `tests/parsers.py::parse_broken_head_annotation` (literal
+em-dash `—`, italic markers required, trailing period before `*`) — do not invent a
+permissive variant; failing-closed (no annotation detected) is preferable to a parser
+mismatch that drops the `BROKEN HEAD ANNOTATION:` block silently.
+
 **First review in a wave** — determine which stacks appear in the wave's tasks, then
 launch a new code-reviewer agent with those stacks' reviewer overlays:
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -643,6 +643,15 @@ the fix (Step 2.2 completion) uses Sonnet unconditionally.
 **Token tracking note:** When Haiku is selected, record `model: haiku` in the
 TOKEN_LEDGER entry for this review (step `2.1:<task_id>`).
 
+**Wave-level broken-head annotation** — before composing the reviewer prompt, scan the
+current wave's header in `.claude/tmp/1b-plan.md` for an italic metadata line in the form
+`*Broken head expected: <reason> — repaired by Wave <N>.*`. The planner emits this when
+a sequential split intentionally leaves a broken intermediate state (see
+`architect-planner/SKILL.md` "Broken-Head Split Detection"). If present, capture
+`<reason>` and `<N>` for injection into the reviewer prompt below; otherwise omit the
+`BROKEN HEAD ANNOTATION:` block entirely. The annotation lives only on the first review
+of the wave — subsequent SendMessage reviews already have it in context.
+
 **First review in a wave** — determine which stacks appear in the wave's tasks, then
 launch a new code-reviewer agent with those stacks' reviewer overlays:
 
@@ -662,6 +671,18 @@ Prompt: |
   <for each unique stack in this wave's tasks, paste its reviewer-overlay.md under "## <Stack> Review Rules" (apply only to matching files);
    append cross-cutting overlays under "## Cross-Cutting: <name> Review Rules";
    append local overlays for the reviewer role per Step 0.2 matrix (skip empty)>
+
+  [Inject ONLY if the wave is broken-head-annotated; otherwise omit this block entirely:]
+  BROKEN HEAD ANNOTATION:
+  This wave's commit intentionally leaves the codebase in a broken intermediate state.
+  Reason: <reason captured above>
+  Repaired by: Wave <N>
+
+  Distinguish findings that match the documented breakage (e.g., callers passing the old
+  signature, undefined consumers of a renamed symbol, missing imports for a moved file)
+  from unrelated findings. Emit matching findings as `PASS` with a `--- BROKEN-HEAD NOTES ---`
+  divider and a one-line note per finding — do NOT `FAIL` the review for them. Apply
+  normal `PASS`/`FAIL` logic to unrelated findings.
 
   REVIEW THESE CHANGES:
 

--- a/tests/fixtures/reviewer-fail-with-broken-head-notes.txt
+++ b/tests/fixtures/reviewer-fail-with-broken-head-notes.txt
@@ -1,0 +1,19 @@
+FAIL
+ISSUE: CRITICAL
+FILE: src/scheduler.py
+LINE: 89
+PROBLEM: Race condition in async batch job — concurrent writes to shared state cache
+FIX: Wrap the cache mutation in an asyncio.Lock or use a thread-safe map type
+
+--- OPTIONAL IMPROVEMENTS ---
+[should-fix] Cache eviction policy unbounded — risk of growth: cap to N entries with LRU
+[nice-to-have] Logger uses f-strings; project convention is structured logging via `extra=` kwargs
+
+--- BROKEN-HEAD NOTES ---
+- src/scheduler.py:142 — Optimizer.run() callers still pass old args; will be repaired in Wave 4b
+- src/scheduler.py:178 — import of OldConfig type still resolved against the pre-rename symbol; consumer update slated for Wave 4b
+
+---TOKEN_REPORT---
+FILES_READ: src/scheduler.py ~2400; src/optimizer.py ~3200
+TOOL_CALLS: Read=3 Grep=2
+---END_TOKEN_REPORT---

--- a/tests/fixtures/reviewer-pass-with-broken-head-notes.txt
+++ b/tests/fixtures/reviewer-pass-with-broken-head-notes.txt
@@ -1,0 +1,10 @@
+PASS
+
+--- BROKEN-HEAD NOTES ---
+- src/optimizer.py:142 — Optimizer.run() callers in src/scheduler.py still pass old args; will be repaired in Wave 4b
+- src/optimizer.py:198 — exported `OldConfig` type still imported by src/runner.py; consumer update slated for Wave 4b
+
+---TOKEN_REPORT---
+FILES_READ: src/optimizer.py ~3200
+TOOL_CALLS: Read=2 Grep=1
+---END_TOKEN_REPORT---

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -78,7 +78,12 @@ def _parse_optional_entry(raw: str) -> dict:
 
 
 def parse_reviewer_result(output: str) -> dict:
-    """Parse code-reviewer agent output per the documented protocol."""
+    """Parse code-reviewer agent output per the documented protocol.
+
+    Recognizes optional `--- BROKEN-HEAD NOTES ---` divider in both PASS and FAIL
+    paths (emitted when the wave is broken-head-annotated; see code-reviewer-agent.md
+    "Broken-Head Pass-Through"). Collected lines are returned in `broken_head_notes`.
+    """
     lines = output.strip().split("\n")
     if not lines:
         return {"status": "UNKNOWN", "error": "empty output"}
@@ -86,19 +91,36 @@ def parse_reviewer_result(output: str) -> dict:
     first_line = lines[0].strip()
     if first_line == "PASS":
         suggestions: list[dict] = []
+        broken_head_notes: list[str] = []
+        in_broken_head = False
         for line in lines[1:]:
             stripped = line.strip()
             if stripped.startswith("---TOKEN_REPORT---"):
                 break
-            if stripped:
+            if stripped == "--- BROKEN-HEAD NOTES ---":
+                in_broken_head = True
+                continue
+            if not stripped:
+                continue
+            if in_broken_head:
+                note = stripped.lstrip("- ").strip()
+                if note:
+                    broken_head_notes.append(note)
+            else:
                 suggestions.append(_parse_optional_entry(stripped))
-        return {"status": "PASS", "suggestions": suggestions}
+        return {
+            "status": "PASS",
+            "suggestions": suggestions,
+            "broken_head_notes": broken_head_notes,
+        }
 
     elif first_line == "FAIL":
         issues: list[dict] = []
         current_issue: dict = {}
         optional_improvements: list[dict] = []
+        broken_head_notes = []
         in_optional = False
+        in_broken_head = False
         for line in lines[1:]:
             stripped = line.strip()
             if stripped.startswith("---TOKEN_REPORT---"):
@@ -108,6 +130,20 @@ def parse_reviewer_result(output: str) -> dict:
                     issues.append(current_issue)
                     current_issue = {}
                 in_optional = True
+                in_broken_head = False
+                continue
+            if stripped == "--- BROKEN-HEAD NOTES ---":
+                if current_issue:
+                    issues.append(current_issue)
+                    current_issue = {}
+                in_broken_head = True
+                in_optional = False
+                continue
+            if in_broken_head:
+                if stripped:
+                    note = stripped.lstrip("- ").strip()
+                    if note:
+                        broken_head_notes.append(note)
                 continue
             if in_optional:
                 if stripped:
@@ -131,6 +167,7 @@ def parse_reviewer_result(output: str) -> dict:
             "status": "FAIL",
             "issues": issues,
             "optional_improvements": optional_improvements,
+            "broken_head_notes": broken_head_notes,
         }
     else:
         return {"status": "UNKNOWN", "error": f"unexpected first line: {first_line}"}
@@ -312,6 +349,30 @@ def parse_plan_stub(output: str) -> dict | None:
                 pass
 
     return result
+
+
+def parse_broken_head_annotation(wave_block: str) -> dict | None:
+    """Extract the broken-head annotation from a wave header block in 1b-plan.md.
+
+    The planner emits this italic metadata line below the wave description when
+    a sequential split intentionally leaves a broken intermediate state (see
+    `skills/architect-planner/SKILL.md` "Broken-Head Split Detection"):
+
+        *Broken head expected: <reason> — repaired by Wave <N>.*
+
+    Returns {"reason": str, "repaired_by": str} or None if no annotation found.
+    """
+    match = re.search(
+        r'^\*Broken head expected:\s*(.+?)\s*—\s*repaired by Wave\s+(\S+?)\.\*\s*$',
+        wave_block,
+        re.MULTILINE,
+    )
+    if not match:
+        return None
+    return {
+        "reason": match.group(1).strip(),
+        "repaired_by": match.group(2).strip(),
+    }
 
 
 # --- Defect Report Parsing ---

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from parsers import (
     parse_azure_auth_output,
+    parse_broken_head_annotation,
     parse_build_output,
     parse_cost_estimate_output,
     parse_defect_report,
@@ -152,6 +153,61 @@ class TestReviewerProtocol(unittest.TestCase):
         for entry in result["optional_improvements"]:
             self.assertIn("tag", entry)
             self.assertIn("text", entry)
+
+    def test_pass_with_broken_head_notes(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-pass-with-broken-head-notes.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["status"], "PASS")
+        self.assertEqual(result["suggestions"], [])
+        notes = result["broken_head_notes"]
+        self.assertEqual(len(notes), 2)
+        self.assertIn("Optimizer.run()", notes[0])
+        self.assertIn("Wave 4b", notes[0])
+        self.assertNotIn("---", notes[0])
+
+    def test_pass_without_broken_head_notes(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-pass.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["broken_head_notes"], [])
+
+
+class TestBrokenHeadAnnotation(unittest.TestCase):
+    def test_extracts_reason_and_repaired_by(self) -> None:
+        wave_block = (
+            "### Wave 4a: Update optimizer signature\n"
+            "*Tasks in this wave have no inter-dependencies and can execute in parallel.*\n"
+            "*Broken head expected: signature change to Optimizer.run() ships before "
+            "callers update — repaired by Wave 4b.*\n"
+            "\n"
+            "#### Task 4a.1: ...\n"
+        )
+        result = parse_broken_head_annotation(wave_block)
+        self.assertIsNotNone(result)
+        self.assertIn("Optimizer.run()", result["reason"])
+        self.assertEqual(result["repaired_by"], "4b")
+
+    def test_returns_none_when_absent(self) -> None:
+        wave_block = (
+            "### Wave 1: Initial setup\n"
+            "*Tasks in this wave have no inter-dependencies and can execute in parallel.*\n"
+            "\n"
+            "#### Task 1.1: ...\n"
+        )
+        self.assertIsNone(parse_broken_head_annotation(wave_block))
+
+    def test_returns_none_for_malformed(self) -> None:
+        # Missing "repaired by Wave N" suffix
+        wave_block = "*Broken head expected: something is broken.*"
+        self.assertIsNone(parse_broken_head_annotation(wave_block))
+        # Missing italic markers
+        wave_block = "Broken head expected: something — repaired by Wave 2."
+        self.assertIsNone(parse_broken_head_annotation(wave_block))
+
+    def test_handles_numeric_wave_id(self) -> None:
+        wave_block = "*Broken head expected: signature drift — repaired by Wave 5.*"
+        result = parse_broken_head_annotation(wave_block)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["repaired_by"], "5")
 
 
 class TestBuildOutput(unittest.TestCase):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -170,6 +170,23 @@ class TestReviewerProtocol(unittest.TestCase):
         result = parse_reviewer_result(fixture)
         self.assertEqual(result["broken_head_notes"], [])
 
+    def test_fail_with_broken_head_notes(self) -> None:
+        fixture = (FIXTURES_DIR / "reviewer-fail-with-broken-head-notes.txt").read_text()
+        result = parse_reviewer_result(fixture)
+        self.assertEqual(result["status"], "FAIL")
+        self.assertEqual(len(result["issues"]), 1)
+        self.assertEqual(result["issues"][0]["severity"], "CRITICAL")
+        self.assertIn("Race condition", result["issues"][0]["problem"])
+        self.assertEqual(len(result["optional_improvements"]), 2)
+        tags = {entry["tag"] for entry in result["optional_improvements"]}
+        self.assertEqual(tags, {"should-fix", "nice-to-have"})
+        notes = result["broken_head_notes"]
+        self.assertEqual(len(notes), 2)
+        self.assertIn("Optimizer.run()", notes[0])
+        self.assertIn("Wave 4b", notes[1])
+        for note in notes:
+            self.assertNotIn("---", note)
+
 
 class TestBrokenHeadAnnotation(unittest.TestCase):
     def test_extracts_reason_and_repaired_by(self) -> None:


### PR DESCRIPTION
## Summary

Adds a planner heuristic that detects when a 4-file-cap-driven wave split would leave a broken intermediate state, plus a reviewer pass-through path so the head wave's expected breakage doesn't trigger a wasted fold cycle. The Wave 4a/4b cycle in #66 was the canonical trigger — signature change in 4a, callers in 4b, reviewer FAIL on 4a triggered a fold that was just doing the work the planner already split off into 4b.

**Six-part change:**

- **Planner** (`skills/architect-planner/SKILL.md`) — new "Broken-Head Split Detection" rule with two options: (a) collapse with file-count exemption (≤6 files), or (b) annotate the head wave with `*Broken head expected: <reason> — repaired by Wave <N>.*`
- **Orchestrator** (`skills/orchestrate/SKILL.md`) — scans the wave header for the annotation; injects a `BROKEN HEAD ANNOTATION:` block into the reviewer prompt for the first review of the wave
- **Reviewer** (`agents/code-reviewer-agent.md`) — new "Broken-Head Pass-Through" section; broken-head-shape findings emit `PASS` with `--- BROKEN-HEAD NOTES ---` divider instead of `FAIL`. Unrelated `FAIL`-eligible findings still fail per normal logic
- **Parser** (`tests/parsers.py`) — new `parse_broken_head_annotation()`; `parse_reviewer_result()` extended to recognize the BROKEN-HEAD NOTES divider and return `broken_head_notes` in both PASS and FAIL paths
- **Tests** (`tests/test_contracts.py`) — 6 new contract tests across `TestReviewerProtocol` and a new `TestBrokenHeadAnnotation` class
- **Fixture** — new `reviewer-pass-with-broken-head-notes.txt` golden file

**Drive-by note (out of scope):** while editing the reviewer-launch path I noticed `skills/orchestrate/SKILL.md:990` (Step 3.5 bug-fix reviewer) still says "Cap at 8 reviews per agent (same as wave reviews)" but Bundle 1 (#66) lowered wave reviews to cap 4. Filing as a separate cleanup issue.

## Test plan

- [x] `python3 tests/validate_structure.py` — 386 checks pass
- [x] `python3 tests/test_contracts.py` — 86 contract tests pass (6 new)
- [ ] Validate live behavior on a future consumer-repo `/orchestrate` run that produces a broken-head split:
  - Plan output includes the italic `*Broken head expected: ... — repaired by Wave N.*` line on the head wave
  - Reviewer prompt for that wave includes the `BROKEN HEAD ANNOTATION:` block
  - Reviewer emits `PASS` with `--- BROKEN-HEAD NOTES ---` instead of `FAIL` for matching findings
  - Unrelated CRITICAL/HIGH findings still produce `FAIL` (no over-pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)