### PR TITLE
chore(orchestrate): align Step 3.5 bug-fix reviewer cap with Bundle 1 (closes #71)

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -987,8 +987,9 @@ Message: |
   <list the files the fix agent modified>
 ```
 
-**Cap at 8 reviews per agent** (same as wave reviews). If a manual test round produces more
-than 8 bug-fix reviews, launch a fresh reviewer for reviews 9+.
+**Cap at 4 reviews per agent** (same as wave reviews). If a manual test round produces more
+than 4 bug-fix reviews, launch a fresh reviewer for reviews 5+. The cap matches Step 2.1
+to bound SendMessage context drift (empirically ~50-100% growth per added review).
 
 **Token tracking:** Per Step 0.6 — one entry per bug-fix sub-step:
 - `3.5:assess:<bug_id>` — `architect-agent`, `sonnet` (only if blast-radius triggered)

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -776,10 +776,10 @@ def check_orchestrate_reviewer_reuse(result: ValidationResult) -> None:
     else:
         result.fail("Orchestrate missing reviewer reuse (SendMessage + NEW REVIEW)")
 
-    if "Cap at 8 reviews" in content or ("cap" in content.lower() and "8 reviews" in content.lower()):
-        result.ok("Orchestrate documents 8-review cap per reviewer agent")
+    if "Cap at 4 reviews" in content or ("cap" in content.lower() and "4 reviews" in content.lower()):
+        result.ok("Orchestrate documents 4-review cap per reviewer agent")
     else:
-        result.fail("Orchestrate missing 8-review cap documentation")
+        result.fail("Orchestrate missing 4-review cap documentation")
 
 
 def check_init_script(result: ValidationResult) -> None:


### PR DESCRIPTION
## Summary

Bundle 1 (#66, PR #69) lowered the Step 2.1 wave reviewer SendMessage cap from 8 to 4 but missed Step 3.5 (bug-fix reviewer reuse during the manual test loop). This PR closes that gap.

- `skills/orchestrate/SKILL.md:990-992` — cap 8 → 4, threshold 8 → 4, "reviews 9+" → "reviews 5+"; rationale tail matches the Step 2.1 wording
- `tests/validate_structure.py:779-782` — structural check updated from "8 reviews" to "4 reviews". The check was only passing on Bundle 1 because Step 3.5 still held the 8-cap text; now it enforces the post-Bundle-1 value

## Test plan

- [x] `python3 tests/validate_structure.py` — 386 checks pass
- [x] `python3 tests/test_contracts.py` — 80 contract tests pass

## Note on ordering

This PR is independent of #70 (broken-head heuristic) — different file regions, different feature. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)