### PR TITLE
feat(orchestrate): 1a passthrough when user supplies a near-complete spec (closes #68)

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -341,6 +341,36 @@ the user whether to proceed without codebase context or update ORCHESTRATOR.md f
 3. Check ORCHESTRATOR.md "Current State" — note the last known build/test status and date. If the last recorded status is older than the most recent commit, recommend the user run a build/test pass before planning.
 4. Check whether `.claude/tmp/1a-spec.md` already exists. If it does, ask the user: "A previous 1a analysis exists — resume from it or start fresh?"
 
+**1a passthrough detection (orchestrator, before launching the agent):**
+
+Check whether the user's `/orchestrate` request body is structurally a near-complete
+spec — i.e., the user supplied a detailed plan (e.g., an existing `OPTIMIZATION_PLAN.md`)
+rather than a brief request. Detection follows
+`tests/parsers.py::detect_user_supplied_spec` exactly:
+
+- Length ≥ 1500 chars, AND
+- Contains ≥2 of the headers (case-sensitive, exact substring): `## Summary`,
+  `## Acceptance criteria`, `## Out of scope`
+
+If detected, present:
+
+> Treating your input as the 1a-spec — skipping Step 1a (saves ~$0.26 of derivation
+> work that 1a would have largely just verified). Reply `run 1a` to override.
+
+If the user replies `run 1a` (case-insensitive, leading/trailing whitespace ignored),
+discard the detection and proceed with Step 1a normally. Otherwise:
+
+1. Write the user's request body verbatim to `.claude/tmp/1a-spec.md`.
+2. Skip the architect-agent launch + clarification loop below.
+3. Record a passthrough entry in `TOKEN_LEDGER` (step=`1a:passthrough`,
+   agent=`orchestrator`, model=N/A, total_tokens=0, dur_ms=0) for ledger continuity.
+4. Proceed directly to Step 1b.
+
+Detection is intentionally conservative — false positives (skipping 1a when needed)
+are worse than false negatives (running 1a unnecessarily). The override path
+guarantees the user can always force normal 1a execution. Do NOT invent permissive
+header variants; follow the parser's exact header list.
+
 **Launch the architect-agent in 1a mode:**
 
 ```

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -339,9 +339,8 @@ the user whether to proceed without codebase context or update ORCHESTRATOR.md f
 1. Run `git status` — if the working tree is dirty, warn the user before proceeding.
 2. Run `git branch --show-current` — confirm you are on the expected branch.
 3. Check ORCHESTRATOR.md "Current State" — note the last known build/test status and date. If the last recorded status is older than the most recent commit, recommend the user run a build/test pass before planning.
-4. Check whether `.claude/tmp/1a-spec.md` already exists. If it does, ask the user: "A previous 1a analysis exists — resume from it or start fresh?"
 
-**1a passthrough detection (orchestrator, before launching the agent):**
+**1a passthrough detection (orchestrator, runs BEFORE the resume check below):**
 
 Check whether the user's `/orchestrate` request body is structurally a near-complete
 spec — i.e., the user supplied a detailed plan (e.g., an existing `OPTIMIZATION_PLAN.md`)
@@ -358,18 +357,27 @@ If detected, present:
 > work that 1a would have largely just verified). Reply `run 1a` to override.
 
 If the user replies `run 1a` (case-insensitive, leading/trailing whitespace ignored),
-discard the detection and proceed with Step 1a normally. Otherwise:
+discard the detection and fall through to the resume check below. Otherwise:
 
-1. Write the user's request body verbatim to `.claude/tmp/1a-spec.md`.
+1. Write the user's request body verbatim to `.claude/tmp/1a-spec.md` (overwriting any
+   prior file — the user's fresh spec is authoritative; the resume check is bypassed).
 2. Skip the architect-agent launch + clarification loop below.
 3. Record a passthrough entry in `TOKEN_LEDGER` (step=`1a:passthrough`,
-   agent=`orchestrator`, model=N/A, total_tokens=0, dur_ms=0) for ledger continuity.
+   agent=`orchestrator`, model=`—`, total_tokens=0, dur_ms=0) for ledger continuity.
 4. Proceed directly to Step 1b.
 
 Detection is intentionally conservative — false positives (skipping 1a when needed)
 are worse than false negatives (running 1a unnecessarily). The override path
 guarantees the user can always force normal 1a execution. Do NOT invent permissive
 header variants; follow the parser's exact header list.
+
+**Resume check (only if passthrough did not fire):**
+
+Check whether `.claude/tmp/1a-spec.md` already exists from a prior run. If it does,
+ask the user: "A previous 1a analysis exists — resume from it or start fresh?"
+
+- **Resume** → skip the agent launch and proceed directly to Step 1b with the existing spec.
+- **Start fresh** → delete `.claude/tmp/1a-spec.md` and run Step 1a normally below.
 
 **Launch the architect-agent in 1a mode:**
 

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -351,6 +351,32 @@ def parse_plan_stub(output: str) -> dict | None:
     return result
 
 
+SPEC_HEADERS = ("## Summary", "## Acceptance criteria", "## Out of scope")
+SPEC_MIN_LENGTH = 1500
+SPEC_MIN_HEADER_MATCHES = 2
+
+
+def detect_user_supplied_spec(user_input: str) -> bool:
+    """Detect whether a /orchestrate request body is structurally a near-complete spec.
+
+    The orchestrator uses this to decide whether to skip Step 1a entirely (passing
+    the user's input directly to `tmp/1a-spec.md`) or run the analyzer normally.
+
+    Returns True only when BOTH conditions hold:
+    - Length ≥ 1500 chars (briefer requests are not specs)
+    - Contains ≥2 of the documented spec section headers (case-sensitive, exact
+      substring match): `## Summary`, `## Acceptance criteria`, `## Out of scope`
+
+    Conservative by design — false positives (skipping 1a when 1a was needed) are
+    worse than false negatives (running 1a when the user could have skipped). The
+    user override (`run 1a` reply) covers the rare false-positive case.
+    """
+    if len(user_input) < SPEC_MIN_LENGTH:
+        return False
+    matches = sum(1 for header in SPEC_HEADERS if header in user_input)
+    return matches >= SPEC_MIN_HEADER_MATCHES
+
+
 def parse_broken_head_annotation(wave_block: str) -> dict | None:
     """Extract the broken-head annotation from a wave header block in 1b-plan.md.
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -289,6 +289,20 @@ class TestUserSuppliedSpecDetection(unittest.TestCase):
         )
         self.assertFalse(detect_user_supplied_spec(body))
 
+    def test_exactly_minimum_length_accepted(self) -> None:
+        # Body of EXACTLY 1500 chars with 2 headers — boundary on the True side.
+        headers = "## Summary\nFoo.\n\n## Acceptance criteria\nBar.\n"
+        body = headers + ("x" * (1500 - len(headers)))
+        self.assertEqual(len(body), 1500)
+        self.assertTrue(detect_user_supplied_spec(body))
+
+    def test_one_below_minimum_length_rejected(self) -> None:
+        # Body of EXACTLY 1499 chars with 2 headers — boundary on the False side.
+        headers = "## Summary\nFoo.\n\n## Acceptance criteria\nBar.\n"
+        body = headers + ("x" * (1499 - len(headers)))
+        self.assertEqual(len(body), 1499)
+        self.assertFalse(detect_user_supplied_spec(body))
+
 
 class TestBuildOutput(unittest.TestCase):
     def test_success_output(self) -> None:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from parsers import (
+    detect_user_supplied_spec,
     parse_azure_auth_output,
     parse_broken_head_annotation,
     parse_build_output,
@@ -225,6 +226,68 @@ class TestBrokenHeadAnnotation(unittest.TestCase):
         result = parse_broken_head_annotation(wave_block)
         self.assertIsNotNone(result)
         self.assertEqual(result["repaired_by"], "5")
+
+
+class TestUserSuppliedSpecDetection(unittest.TestCase):
+    """Step 0 1a-passthrough heuristic — see skills/orchestrate/SKILL.md."""
+
+    def _padded(self, content: str, target_len: int = 1600) -> str:
+        """Pad content to meet the 1500-char minimum without affecting headers."""
+        padding = "\n" + ("Detail line. " * 50)
+        while len(content) < target_len:
+            content += padding
+        return content
+
+    def test_full_match_three_headers(self) -> None:
+        body = self._padded(
+            "## Summary\nFeature does X.\n\n"
+            "## Acceptance criteria\n- [ ] foo\n\n"
+            "## Out of scope\n- bar\n"
+        )
+        self.assertTrue(detect_user_supplied_spec(body))
+
+    def test_minimal_match_two_headers(self) -> None:
+        body = self._padded(
+            "## Summary\nFeature does X.\n\n"
+            "## Acceptance criteria\n- [ ] foo\n"
+        )
+        self.assertTrue(detect_user_supplied_spec(body))
+
+    def test_too_short_rejected(self) -> None:
+        body = (
+            "## Summary\nShort.\n\n"
+            "## Acceptance criteria\n- [ ] foo\n\n"
+            "## Out of scope\n- bar\n"
+        )
+        self.assertLess(len(body), 1500)
+        self.assertFalse(detect_user_supplied_spec(body))
+
+    def test_only_one_header_rejected(self) -> None:
+        body = self._padded("## Summary\nFeature does X.\nOther content here.\n")
+        self.assertFalse(detect_user_supplied_spec(body))
+
+    def test_zero_headers_rejected(self) -> None:
+        body = self._padded("Just a long unstructured description of what to do.\n")
+        self.assertFalse(detect_user_supplied_spec(body))
+
+    def test_empty_input_rejected(self) -> None:
+        self.assertFalse(detect_user_supplied_spec(""))
+
+    def test_case_sensitive_headers(self) -> None:
+        body = self._padded(
+            "## summary\nLowercase header.\n\n"
+            "## acceptance criteria\nLowercase.\n\n"
+            "## out of scope\nLowercase.\n"
+        )
+        self.assertFalse(detect_user_supplied_spec(body))
+
+    def test_partial_header_substring_rejected(self) -> None:
+        # "## Summary" must be present as a literal — "##Summary" without space fails
+        body = self._padded(
+            "##Summary\nMissing space.\n\n"
+            "## Acceptance criteria\nThis one matches.\n"
+        )
+        self.assertFalse(detect_user_supplied_spec(body))
 
 
 class TestBuildOutput(unittest.TestCase):


### PR DESCRIPTION
## Summary

When the user's `/orchestrate` request body is itself structurally a spec (e.g., an existing `OPTIMIZATION_PLAN.md`), Step 1a re-derives content the user already wrote — empirically wasted ~\$0.26 in MILL5/claude-code-pipeline#66's run. This PR adds a conservative detection heuristic that skips Step 1a entirely on first-run when the user-supplied input qualifies.

**Three-part change:**

- **Parser** (`tests/parsers.py`) — new `detect_user_supplied_spec(user_input)` returns True only when BOTH conditions hold:
  - Length ≥ 1500 chars
  - Contains ≥2 of: `## Summary`, `## Acceptance criteria`, `## Out of scope` (case-sensitive)

- **Orchestrator** (`skills/orchestrate/SKILL.md`) — new "1a passthrough detection" sub-step inserted between pre-flight and the architect-agent launch. Override path: user replies `run 1a` (case-insensitive) to force normal Step 1a. Otherwise the input is written verbatim to `tmp/1a-spec.md` and a `1a:passthrough` ledger entry is recorded.

- **Tests** (`tests/test_contracts.py`) — new `TestUserSuppliedSpecDetection` class with 8 tests covering boundary conditions: full match, minimal match, too-short rejection, single/zero header rejection, empty input, case-sensitivity, and partial-substring rejection.

## Acceptance criteria from MILL5/claude-code-pipeline#68

- [x] Step 0 documents the heuristic + override path
- [x] Detection is conservative — false positives worse than false negatives (encoded in spec rationale and parser docstring)
- [x] User can override with single-token reply (`run 1a`, case-insensitive)
- [x] `tests/test_contracts.py` covers the parse + branch decision (8 new tests)

## Test plan

- [x] `python3 tests/validate_structure.py` — 386 checks pass
- [x] `python3 tests/test_contracts.py` — 95 contract tests pass (8 new)
- [ ] Validate live behavior on a future `/orchestrate` invocation where the user supplies a structurally-complete spec body:
  - Detection fires (≥1500 chars + ≥2 headers)
  - Confirmation message appears with the override hint
  - On `run 1a` reply → Step 1a runs normally
  - Otherwise → `tmp/1a-spec.md` written verbatim, ledger entry `1a:passthrough` recorded, Step 1b launches with user spec
- [ ] Negative case: user supplies a brief request (no headers, ~200 chars) — passthrough does NOT fire, Step 1a runs normally

## Related

- MILL5/claude-code-pipeline#66 (parent F3 finding)
- MILL5/agentic-dev-pipeline#224 (defines a candidate `spec.md` schema; the 3 detection headers align with MILL5/agentic-dev-pipeline#224's proposed required sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)