### PR TITLE
refactor(orchestrate): lazy-load remaining 9 steps (closes #75)

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -332,24 +332,24 @@ the user whether to proceed without codebase context or update ORCHESTRATOR.md f
 
 ## Step Dispatch
 
-The orchestrator runs the steps below in sequence. Steps marked **extracted** have been moved to `skills/orchestrate/steps/<file>.md` for context efficiency — read each one just-in-time, immediately before executing that step. Inline steps remain in this file.
+The orchestrator runs the steps below in sequence. Every step is extracted to `skills/orchestrate/steps/<file>.md` — read each one just-in-time, immediately before executing that step.
 
-| Step | Extracted | Description |
-|------|-----------|-------------|
+| Step | File | Description |
+|------|------|-------------|
 | 1a | `steps/1a-clarify.md` | Analyze user request, surface clarifying Qs, write `1a-spec.md` |
-| 1b | inline | Plan generation from `1a-spec.md` |
-| 1.4 | inline | Pre-flight build verification |
-| 1.5 | inline | Open draft PR |
-| 2 | inline | Implement waves |
+| 1b | `steps/1b-plan.md` | Plan generation from `1a-spec.md` |
+| 1.4 | `steps/1.4-preflight.md` | Pre-flight build verification |
+| 1.5 | `steps/1.5-open-pr.md` | Open draft PR |
+| 2 | `steps/2-implement.md` | Implement waves |
 | 2.1 | `steps/2.1-review.md` | Code review (per-wave reused agent) |
-| 2.2 | inline | Fix issues from review |
-| 3 | inline | Commit + push per task |
-| 3.4 | inline | Browser UI test (conditional) |
+| 2.2 | `steps/2.2-fix.md` | Fix issues from review |
+| 3 | `steps/3-commit.md` | Commit + push per task |
+| 3.4 | `steps/3.4-browser-ui.md` | Browser UI test (conditional) |
 | 3.5 | `steps/3.5-manual-test.md` | Manual test loop with bug fixes |
-| 4 | inline | Finalize PR |
-| 5 | inline | Token analysis (background) |
+| 4 | `steps/4-finalize.md` | Finalize PR |
+| 5 | `steps/5-token-analysis.md` | Token analysis (background) |
 
-**Protocol:** Before executing an extracted step, read its file in full. The file's front-matter declares `step:`, `requires:` (`.claude/tmp/` artifacts that must exist), `produces:` (artifacts written), and `sendmessage:` (required/optional/n/a). If a `requires:` artifact is missing at runtime, halt with a clear error citing the artifact name and the step that produces it.
+**Protocol:** Before executing a step, read its file in full. The file's front-matter declares `step:`, `requires:` (`.claude/tmp/` artifacts that must exist), `produces:` (artifacts written), and `sendmessage:` (required/optional/n/a). If a `requires:` artifact is missing at runtime, halt with a clear error citing the artifact name and the step that produces it.
 
 ## Detailed Steps
 
@@ -359,216 +359,19 @@ The orchestrator runs the steps below in sequence. Steps marked **extracted** ha
 
 ### Step 1b: PLAN
 
-Launch a **fresh** architect-agent in 1b mode. Do NOT use SendMessage from the 1a agent — start a new agent so 1b has a clean context window (~15K tokens of focused signal vs. the full 1a Q&A history).
-
-**Model selection:** Default to **Sonnet**. Escalate to **Opus** only when the 1a-spec indicates
-at least one of:
-- Novel architecture with no existing patterns in the codebase to follow
-- Cross-cutting changes affecting 3+ services/modules with shared state
-- Concurrent/async coordination requiring holistic correctness reasoning
-- Security-critical design where subtle errors have severe consequences
-
-If plan quality is poor on Sonnet (vague briefs, missed dependencies), the user can request a
-re-plan with Opus.
-
-```
-Agent: architect-agent
-Model: <sonnet (default) or opus (if escalation criteria above are met)>
-Prompt: |
-  MODE: 1b — Plan Generation
-
-  Read `.claude/skills/architect-planner/SKILL.md` for your instructions.
-
-  TECH STACK CONTEXT:
-  <paste each STACK_REGISTRY stack's architect-overlay.md under "## <Stack> Architecture Context";
-   append cross-cutting overlays under "## Cross-Cutting: <name> Context";
-   append local overlays for the architect role per Step 0.2 matrix (skip empty)>
-
-  STACK MAPPING (for task assignment — assign each task a stack based on its files):
-  <for each stack, list its stack_paths patterns, e.g.:
-   - react: src/frontend/**
-   - python: src/backend/**
-   - bicep: infra/**>
-
-  ENRICHED SPEC:
-  <paste full contents of .claude/tmp/1a-spec.md>
-
-  EFFICIENCY CONSTRAINT: The 1a-spec was produced by reading the files in its
-  "Files & Services In Scope" section. Use the spec's extracts — do NOT re-read
-  those files end-to-end. If you need additional context, read only the specific
-  line ranges you need.
-
-  CODEBASE CONTEXT (ORCHESTRATOR.md 1b extract — do not re-read from disk):
-  <paste 1b Extract from Step 0.7>
-```
-
-Note: The 1a-spec already contains project overview, directory structure, fragile areas, and
-current state — the 1b extract omits these to avoid duplication.
-
-**Implementation clarification loop:**
-The 1b agent will first analyze the enriched spec against the codebase, then pause to surface
-implementation-specific questions (technical approach, patterns, integration strategy, data
-modeling). See Step 2.5 in the planner skill.
-
-- Present the implementation questions to the user verbatim.
-- Feed user answers back via **SendMessage** to the same agent (do NOT launch a new agent).
-- The agent may ask a second round of follow-up questions if the user's answers reveal new
-  decision points. Maximum TWO rounds total.
-- After receiving answers (or if the agent has no questions), it proceeds to decomposition
-  and plan generation.
-
-**Wait for the `PLAN_WRITTEN` stub.** The architect emits a compact stub (feature, plan type,
-wave sizes, task count, model distribution, estimated cost) instead of the full plan. The
-full plan is written to `.claude/tmp/1b-plan.md` — read that file from disk to access waves,
-context briefs, and task metadata for the rest of the pipeline.
-
-After receiving the `PLAN_WRITTEN` stub, read `.claude/tmp/1b-plan.md` and review:
-- Does it respect the file-per-task limits from CLAUDE.md?
-- Are waves and dependencies sensible?
-- Are context briefs self-contained and free of "see task X" cross-references?
-
-If the plan includes a `## Deferred Items` section, process each entry per the
-**Backlog Integration** section below (fold or defer). Do this before presenting
-the plan to the user so the folded items appear in the wave list.
-
-Present the stub-derived plan summary to the user and wait for confirmation before
-proceeding. For all subsequent steps that need brief content (Step 2, Step 2.2, Step 3.5),
-the orchestrator reads `.claude/tmp/1b-plan.md` directly — never ask the architect to re-emit
-the plan.
-
-**Token tracking:** Per Step 0.6 — one entry for the initial launch (step `1b`); one per impl-clarification SendMessage (step `1b:impl-clarify-N`); one per revision (step `1b:revision-N`). agent=`architect-agent`, model=as selected above.
-
-**Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.
+**Extracted to `steps/1b-plan.md`.** Read that file before executing this step. Front-matter: `requires=[.claude/tmp/1a-spec.md]`, `produces=[.claude/tmp/1b-plan.md]`, `sendmessage=required`.
 
 ### Step 1.4: PRE-FLIGHT BUILD VERIFICATION
 
-Catches pre-existing build breakage on the base branch before Wave 1 launches —
-swaps a multi-task Haiku escalation for a single targeted fix.
-
-**Skip if:** resuming from a recovery artifact, or the user said "skip pre-flight"
-during plan confirmation.
-
-**Procedure:**
-
-1. For each unique stack in `STACK_REGISTRY`, run the stack's build script
-   against the current working tree (which still equals base-branch state at
-   this point — the PR branch hasn't been cut yet):
-
-   ```bash
-   python3 .claude/scripts/<stack>/build.py
-   ```
-
-   Use `Bash` with the default 2-minute timeout. If the build script itself
-   times out, treat as a `FAIL` with note `build script timed out`.
-
-2. Parse the last line of stdout against the build adapter contract:
-   - `BUILD SUCCEEDED  |  N warning(s)` → record `PASS` for that stack
-   - `BUILD FAILED  |  N error(s)  |  M warning(s)` → record `FAIL` with the
-     full stdout/stderr captured for the user prompt
-   - Any other terminating line → record `FAIL` with note `unrecognized build
-     output — check adapter contract`
-
-3. Aggregate results across stacks:
-   - All stacks PASS → proceed silently to Step 1.5.
-   - Any stack FAILED → enter the failure-handling flow below.
-
-**Failure handling:** Present a concise prompt directly (no agent):
-
-> ⚠ Pre-flight build check failed on the base branch. Implementers would hit this in Wave 1.
-> Failing stack(s): `<stack> — N error(s)`. Top errors: ```<first 10 lines of stderr/stdout>```
-> Choose: **(a) abort** (you fix manually then re-run; no PR created yet),
-> **(b) continue anyway** (Haiku may fail and escalate; cost risk $0.20+),
-> **(c) inject Wave 0 fix** (Sonnet task prepended; existing waves shift +1).
-
-Wait for the user's choice:
-- **(a):** exit `/orchestrate` cleanly. Print a 1a/1b summary so the user can resume. Do NOT
-  delete `1a-spec.md` or `1b-plan.md`.
-- **(b):** log a `TOKEN_LEDGER` warning entry (`1.4`, notes `continued with broken build`).
-  Proceed to Step 1.5.
-- **(c):** prepend a new Wave 0 to `.claude/tmp/1b-plan.md` with a single Sonnet implementer
-  task. Brief: "Fix pre-existing build failure on the base branch.
-  BUILD SCRIPT: `python3 .claude/scripts/<failing_stack>/build.py`.
-  BUILD OUTPUT (first 50 lines): <captured>.
-  ACCEPTANCE: build script outputs `BUILD SUCCEEDED | N warning(s)` with zero errors.
-  Smallest viable fix only — do NOT modify unrelated source or introduce new abstractions."
-  Re-number existing waves; original feature work starts at the now-renumbered Wave 1.
-
-**Token tracking:** Per Step 0.6 — one entry per stack build (step `1.4:<stack>`). agent=`orchestrator`, model=`sonnet`. `input_chars=0` (no prompt — direct subprocess), `output_chars`=captured build output length. If failure handling fires, also record `1.4:user-decision` with notes `<a|b|c>`.
-
-Runs pre-PR so `(a) abort` exits cleanly with no GitHub-side cleanup.
+**Extracted to `steps/1.4-preflight.md`.** Read that file before executing this step. Front-matter: `requires=[.claude/tmp/1b-plan.md]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 1.5: OPEN PR
 
-Once the user confirms the plan, follow the `open-pr` skill (`.claude/skills/open-pr/SKILL.md`)
-to create a feature branch and draft PR **before any implementation begins**.
-
-Provide to the skill:
-- **Feature summary** from the plan overview
-- **Plan overview** with waves, task list, and key decisions
-- **Plan type** (feat, fix, refactor, chore, perf)
-
-Record `PR_BRANCH`, `PR_NUMBER`, `PR_URL` for use in later steps.
-All subsequent commits and pushes target this branch.
-
-**Token tracking:** Per Step 0.6 — one entry for step `1.5`. agent=`orchestrator`, model=`sonnet`.
+**Extracted to `steps/1.5-open-pr.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 2: IMPLEMENT
 
-For each wave in the plan, launch implementer agents. **Tasks within a wave run in parallel.**
-Tasks across waves are sequential (wave N+1 waits for wave N to complete).
-
-**Streaming reviews:** Do NOT wait for all tasks in a wave to complete before starting reviews.
-As each implementer returns SUCCESS, immediately send it to the reviewer (via the wave's shared
-reviewer agent). This overlaps review work with still-running implementer tasks, reducing
-wall-clock time. The reviewer agent is launched on the first SUCCESS result; subsequent results
-use SendMessage. Failed implementers are reported to the user immediately without waiting.
-
-**Batch cap:** If a wave has more than 4 tasks at the same model, split into batches of ≤4
-to reduce blast radius and keep individual agent calls under ~50K input tokens. The planner
-should keep waves ≤4 tasks; the orchestrator enforces the cap if not.
-
-For each task (or batch of up to 4 tasks) in the current wave:
-
-1. Read the task's `Stack:` field from the plan to determine `<task_stack>`.
-   If the plan omits the stack field, resolve it from the task's file paths using the
-   `resolve_stack()` algorithm from Step 0.
-2. Look up `<task_stack>` in the STACK_REGISTRY to get the correct overlay.
-3. Compose the prompt:
-
-```
-Agent: implementer-agent
-Model: <model from plan — haiku, sonnet, or opus>
-Isolation: worktree (if multiple parallel agents in same wave touch different files)
-Prompt: |
-  You are being launched by the orchestration pipeline.
-  Follow all rules from your agent definition (output protocol, build/test
-  commands, coverage gate, self-review). No deviations.
-
-  TECH STACK RULES:
-  <paste STACK_REGISTRY[<task_stack>]'s implementer overlay — essential variant for Haiku, full for Sonnet/Opus;
-   append cross-cutting overlays (matching model variant);
-   append local overlays for the implementer role per Step 0.2 matrix (skip empty)>
-
-  BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
-  TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
-
-  TASK CONTEXT BRIEF:
-
-  <paste the context brief from the architect's plan here>
-```
-
-**Overlay selection:** Haiku tasks get the essential variant (~500-800 chars); Sonnet/Opus tasks
-get the full overlay. The reviewer in Step 2.1 has the full overlay and catches any Haiku
-violations. The implementer only loads the overlay for its task's stack — loading all stacks
-would dilute Haiku's signal-to-noise ratio.
-
-**After each implementer returns** (as soon as it completes, not after the full wave):
-
-- If `SUCCESS`: immediately send to the wave's reviewer agent (Step 2.1). If this is the first
-  SUCCESS in the wave, launch the reviewer agent. Otherwise, use SendMessage.
-- If `FAILURE`: report the failure details to the user immediately. Do NOT auto-retry implementation failures — these need human judgment. Do NOT block other tasks' reviews.
-
-**Token tracking:** Per Step 0.6 — one entry per implementer (step `2:<task_id>`, e.g. `2:1.1`). agent=`implementer-agent`, model=as assigned by the plan.
+**Extracted to `steps/2-implement.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=optional`.
 
 ### Step 2.1: REVIEW
 
@@ -576,131 +379,15 @@ would dilute Haiku's signal-to-noise ratio.
 
 ### Step 2.2: FIX
 
-Send the code-reviewer's FAIL output back to the implementer to fix:
-
-```
-Agent: implementer-agent (continue the same agent if possible, otherwise new with same worktree)
-Model: sonnet (escalate from haiku — fixes require more judgment)
-Prompt: |
-  The code-reviewer found issues in your implementation. Fix ALL issues below,
-  then re-build and re-test (coverage must remain >=90%).
-  Follow your standard output protocol (SUCCESS/FAILURE).
-
-  TECH STACK RULES:
-  <paste STACK_REGISTRY[<task_stack>].implementer overlay (full — fixes always get full overlay);
-   append cross-cutting overlays;
-   append local overlays for the implementer role per Step 0.2 matrix (skip empty)>
-
-  BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
-  TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
-
-  CODE REVIEW FINDINGS TO FIX:
-
-  <paste the FAIL output from code-reviewer>
-
-  FILES YOU PREVIOUSLY MODIFIED:
-
-  <list of files>
-```
-
-**After fix returns:**
-- If `SUCCESS`: proceed to Step 3 (commit). The fix agent's self-review + build + test
-  is sufficient — do NOT re-review. Skip the review-fix cycle.
-- If `FAILURE`: report to user with full context.
-
-**Token tracking:** Per Step 0.6 — one entry per fix (step `2.2:<task_id>`). agent=`implementer-agent`, model=`sonnet`, `is_retry=true`. If original task was Haiku, also `is_escalation=true` with notes `escalated from haiku`.
+**Extracted to `steps/2.2-fix.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=optional`.
 
 ### Step 3: COMMIT + PUSH
 
-For each agent that completed successfully (after passing review):
-
-1. Stage the agent's modified files: `git add <files>`
-2. Commit using the agent's SUCCESS message verbatim (everything after the `SUCCESS\n\n` header)
-3. Do NOT modify the commit message — use it exactly as returned
-4. Push to the PR branch: `git push`
-
-If multiple agents completed in the same wave, commit them in task order (1.1 before 1.2, etc.).
-
-```bash
-git add <files from agent>
-git commit -m "<SUCCESS message from agent>"
-git push
-```
-
-Pushing after each commit keeps the draft PR up to date so progress is visible.
-
-**Record test baseline:** After committing all waves, run the full test suite and record
-the total passing test count. This is the regression baseline for Step 3.5.
+**Extracted to `steps/3-commit.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 3.4: AUTOMATED BROWSER UI TEST (conditional)
 
-**Gating rule:** Evaluate these checks in order. Skip Step 3.4 silently at the
-first one that fails — do not run later checks (each is more expensive than
-the last).
-
-1. **Capability check** — `ACTIVE_CAPABILITIES` includes `browser-ui` (at
-   least one active stack's `manifest.json` declares this capability — `react`
-   does by default). Fast in-memory lookup.
-2. **Wave-relevance check** — at least one file in `FILES_MODIFIED` (across
-   all waves this run) resolves via `resolve_stack()` to a stack with the
-   `browser-ui` capability. Pure backend-only runs skip Step 3.4.
-3. **Tool availability check** — probe whether the `claude-in-chrome` MCP
-   tools are authorized in the current session:
-   ```
-   ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp"
-   ```
-   If the result contains a `<function>` schema for that tool, chrome is
-   authorized. If the result is "No matching deferred tools found" (or
-   equivalent empty result), the MCP server is not configured for this
-   session — skip Step 3.4 silently. No flag, no warning: the user simply
-   has not opted into chrome for this session.
-
-The probe in check 3 is the source of truth for "is chrome authorized?" —
-mirroring how `ACTIVE_CAPABILITIES` drives `azure-auth`. There is no
-`--chrome` flag because the MCP tool list is itself the authorization signal:
-if the user added `claude-in-chrome` to their MCP config and approved it,
-the tools are loadable; if they did not, they are not.
-
-**Invocation:**
-
-```
-Skill: chrome-ui-test
-Prompt: |
-  Read `.claude/skills/chrome-ui-test/SKILL.md` for your instructions.
-
-  IMPLEMENTATION_SUMMARY:
-  <one paragraph from the plan + commit messages, focused on user-visible behavior>
-
-  FILES_MODIFIED:
-  <list of files touched across all waves, filtered to browser-ui stacks>
-
-  TASK_BRIEFS:
-  <paste the original context briefs for tasks whose stack has browser-ui capability>
-
-  DEV_SERVER_HINT:
-  <if the project has a `dev` script in package.json, paste the script line and
-   default port; otherwise the skill will inspect package.json itself>
-
-  RECORD_GIF: <true if the user explicitly asked for a recording in their request, else false>
-```
-
-**Outcome handling:**
-
-- **PASS** — record the result in TOKEN_LEDGER and proceed to Step 3.5. The
-  user-facing prompt for manual test should mention the automated smoke
-  passed: "Automated browser smoke test passed (golden path + N edge cases).
-  Please test the branch and report any bugs..."
-- **FAIL** — treat the failure as a bug report and route it through the
-  existing Step 3.5.1 (ASSESS) → 3.5.2 (FIX) → 3.5.3 (REVIEW) → 3.5.4
-  (COMMIT) → 3.5.5 (RE-TEST) cycle. Use the skill's "Reproduction" block as
-  the bug report. After the fix is committed, re-run Step 3.4 once before
-  handing back to the user. If Step 3.4 fails twice on the same scenario,
-  stop and present the findings — do NOT loop.
-
-**Token tracking:** Per Step 0.6 — one entry for step `3.4` (re-runs as `3.4:retry-N`). agent=`orchestrator` (skill, not an Agent launch), model=`sonnet`.
-
-The automated smoke catches wiring failures; the user's manual test in 3.5 remains authoritative
-for UX, copy, and business-rule edge cases.
+**Extracted to `steps/3.4-browser-ui.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 3.5: MANUAL TEST
 
@@ -708,69 +395,11 @@ for UX, copy, and business-rule edge cases.
 
 ### Step 4: FINALIZE
 
-After all tasks are committed and pushed:
-
-1. If the changes affected architecture (new services, new targets, new patterns):
-   - Update `ORCHESTRATOR.md` with the changes
-   - Commit and push the update
-2. Update the PR body's Coverage section with final numbers from the last test run
-3. Check off completed tasks in the PR body's task list
-3.5. If `BACKLOG_ENABLED=true` and `.claude/tmp/run-log.yml` has any entries with
-   `action: folded`, render the "Folded in this run" checklist into the PR body
-   (see the Backlog Integration section for the format). Skip this if no folds
-   occurred.
-4. Mark the PR as ready for review:
-   ```bash
-   gh pr ready <PR_NUMBER>
-   ```
-5. Report final status to user:
-   - PR URL
-   - Number of tasks completed
-   - Number of commits made
-   - Coverage summary from the last test run
-   - Any review findings that were fixed
-
-The orchestrator does NOT merge — the user decides when to merge.
+**Extracted to `steps/4-finalize.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 5: TOKEN ANALYSIS (mandatory)
 
-Launch token analysis **in the background** concurrently with Step 4 finalization — the
-TOKEN_LEDGER is complete after Step 3.5, so analysis can run while ORCHESTRATOR.md is updated
-and `gh pr ready` runs. Always runs, not skippable.
-
-**5.1 Compute Summary.** Record `PIPELINE_END`. Compute `TOKEN_SUMMARY` from `TOKEN_LEDGER`:
-totals across all entries, per-model breakdown (call count + input/output tokens), per-step
-breakdown by prefix (`1a`, `1b`, `1.5`, `2`, `2.1`, `2.2`, `3.5`), estimated cost (Haiku $1/$5,
-Sonnet $3/$15, Opus $15/$75 per M tokens in/out), actual cost-weighted model distribution vs.
-the 70/20/10 target, and counts of `is_escalation`/`is_retry` entries.
-
-**5.2 Derive Pipeline Repo.** `PIPELINE_REMOTE=$(git -C <pipeline_root> remote get-url origin)`.
-Parse SSH (`git@github.com:owner/repo.git`) or HTTPS (`https://github.com/owner/repo.git`),
-strip trailing `.git`.
-
-**5.3 Launch Token Analysis.** Invoke the skill with the ledger, summary, and pipeline context:
-
-```
-Skill: token-analysis
-Prompt: |
-  Read `.claude/skills/token-analysis/SKILL.md` for your instructions.
-
-  TOKEN LEDGER: <paste the full TOKEN_LEDGER as a markdown table>
-  TOKEN SUMMARY: <paste the computed TOKEN_SUMMARY>
-
-  PIPELINE CONTEXT:
-  - Plan file: .claude/tmp/1b-plan.md (planned vs actual model assignments)
-  - Pipeline repo: <owner/repo>
-  - Pipeline root: <pipeline_root>
-  - Target project stacks: <stacks (comma-separated)>
-  - Pipeline duration: <PIPELINE_START> to <PIPELINE_END>
-```
-
-**5.4 Report Results.** `FINDINGS: NONE` → "no significant optimization opportunities found".
-`FINDINGS: FILED` with issue URL → "findings filed as <issue URL>". Skill failure or
-`gh issue create` error → log a warning and report; do NOT mark the pipeline failed.
-
----
+**Extracted to `steps/5-token-analysis.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ## Backlog Integration
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -371,7 +371,7 @@ The orchestrator runs the steps below in sequence. Every step is extracted to `s
 
 ### Step 2: IMPLEMENT
 
-**Extracted to `steps/2-implement.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=optional`.
+**Extracted to `steps/2-implement.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 2.1: REVIEW
 
@@ -395,11 +395,11 @@ The orchestrator runs the steps below in sequence. Every step is extracted to `s
 
 ### Step 4: FINALIZE
 
-**Extracted to `steps/4-finalize.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
+**Extracted to `steps/4-finalize.md`.** Read that file before executing this step. Front-matter: `requires=[.claude/tmp/run-log.yml]`, `produces=[]`, `sendmessage=n/a`.
 
 ### Step 5: TOKEN ANALYSIS (mandatory)
 
-**Extracted to `steps/5-token-analysis.md`.** Read that file before executing this step. Front-matter: `requires=[]`, `produces=[]`, `sendmessage=n/a`.
+**Extracted to `steps/5-token-analysis.md`.** Read that file before executing this step. Front-matter: `requires=[.claude/tmp/1b-plan.md]`, `produces=[]`, `sendmessage=n/a`.
 
 ## Backlog Integration
 

--- a/skills/orchestrate/steps/1.4-preflight.md
+++ b/skills/orchestrate/steps/1.4-preflight.md
@@ -1,0 +1,68 @@
+---
+step: "1.4"
+requires: [.claude/tmp/1b-plan.md]
+produces: []
+sendmessage: n/a
+---
+
+# Step 1.4: PRE-FLIGHT BUILD VERIFICATION
+
+This file is read by the orchestrator just-in-time before executing Step 1.4.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+Catches pre-existing build breakage on the base branch before Wave 1 launches —
+swaps a multi-task Haiku escalation for a single targeted fix.
+
+**Skip if:** resuming from a recovery artifact, or the user said "skip pre-flight"
+during plan confirmation.
+
+**Procedure:**
+
+1. For each unique stack in `STACK_REGISTRY`, run the stack's build script
+   against the current working tree (which still equals base-branch state at
+   this point — the PR branch hasn't been cut yet):
+
+   ```bash
+   python3 .claude/scripts/<stack>/build.py
+   ```
+
+   Use `Bash` with the default 2-minute timeout. If the build script itself
+   times out, treat as a `FAIL` with note `build script timed out`.
+
+2. Parse the last line of stdout against the build adapter contract:
+   - `BUILD SUCCEEDED  |  N warning(s)` → record `PASS` for that stack
+   - `BUILD FAILED  |  N error(s)  |  M warning(s)` → record `FAIL` with the
+     full stdout/stderr captured for the user prompt
+   - Any other terminating line → record `FAIL` with note `unrecognized build
+     output — check adapter contract`
+
+3. Aggregate results across stacks:
+   - All stacks PASS → proceed silently to Step 1.5.
+   - Any stack FAILED → enter the failure-handling flow below.
+
+**Failure handling:** Present a concise prompt directly (no agent):
+
+> ⚠ Pre-flight build check failed on the base branch. Implementers would hit this in Wave 1.
+> Failing stack(s): `<stack> — N error(s)`. Top errors: ```<first 10 lines of stderr/stdout>```
+> Choose: **(a) abort** (you fix manually then re-run; no PR created yet),
+> **(b) continue anyway** (Haiku may fail and escalate; cost risk $0.20+),
+> **(c) inject Wave 0 fix** (Sonnet task prepended; existing waves shift +1).
+
+Wait for the user's choice:
+- **(a):** exit `/orchestrate` cleanly. Print a 1a/1b summary so the user can resume. Do NOT
+  delete `1a-spec.md` or `1b-plan.md`.
+- **(b):** log a `TOKEN_LEDGER` warning entry (`1.4`, notes `continued with broken build`).
+  Proceed to Step 1.5.
+- **(c):** prepend a new Wave 0 to `.claude/tmp/1b-plan.md` with a single Sonnet implementer
+  task. Brief: "Fix pre-existing build failure on the base branch.
+  BUILD SCRIPT: `python3 .claude/scripts/<failing_stack>/build.py`.
+  BUILD OUTPUT (first 50 lines): <captured>.
+  ACCEPTANCE: build script outputs `BUILD SUCCEEDED | N warning(s)` with zero errors.
+  Smallest viable fix only — do NOT modify unrelated source or introduce new abstractions."
+  Re-number existing waves; original feature work starts at the now-renumbered Wave 1.
+
+**Token tracking:** Per Step 0.6 — one entry per stack build (step `1.4:<stack>`). agent=`orchestrator`, model=`sonnet`. `input_chars=0` (no prompt — direct subprocess), `output_chars`=captured build output length. If failure handling fires, also record `1.4:user-decision` with notes `<a|b|c>`.
+
+Runs pre-PR so `(a) abort` exits cleanly with no GitHub-side cleanup.

--- a/skills/orchestrate/steps/1.5-open-pr.md
+++ b/skills/orchestrate/steps/1.5-open-pr.md
@@ -1,0 +1,26 @@
+---
+step: "1.5"
+requires: []
+produces: []
+sendmessage: n/a
+---
+
+# Step 1.5: OPEN PR
+
+This file is read by the orchestrator just-in-time before executing Step 1.5.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+Once the user confirms the plan, follow the `open-pr` skill (`.claude/skills/open-pr/SKILL.md`)
+to create a feature branch and draft PR **before any implementation begins**.
+
+Provide to the skill:
+- **Feature summary** from the plan overview
+- **Plan overview** with waves, task list, and key decisions
+- **Plan type** (feat, fix, refactor, chore, perf)
+
+Record `PR_BRANCH`, `PR_NUMBER`, `PR_URL` for use in later steps.
+All subsequent commits and pushes target this branch.
+
+**Token tracking:** Per Step 0.6 — one entry for step `1.5`. agent=`orchestrator`, model=`sonnet`.

--- a/skills/orchestrate/steps/1b-plan.md
+++ b/skills/orchestrate/steps/1b-plan.md
@@ -1,0 +1,94 @@
+---
+step: "1b"
+requires: [.claude/tmp/1a-spec.md]
+produces: [.claude/tmp/1b-plan.md]
+sendmessage: required
+---
+
+# Step 1b: PLAN
+
+This file is read by the orchestrator just-in-time before executing Step 1b.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+Launch a **fresh** architect-agent in 1b mode. Do NOT use SendMessage from the 1a agent — start a new agent so 1b has a clean context window (~15K tokens of focused signal vs. the full 1a Q&A history).
+
+**Model selection:** Default to **Sonnet**. Escalate to **Opus** only when the 1a-spec indicates
+at least one of:
+- Novel architecture with no existing patterns in the codebase to follow
+- Cross-cutting changes affecting 3+ services/modules with shared state
+- Concurrent/async coordination requiring holistic correctness reasoning
+- Security-critical design where subtle errors have severe consequences
+
+If plan quality is poor on Sonnet (vague briefs, missed dependencies), the user can request a
+re-plan with Opus.
+
+```
+Agent: architect-agent
+Model: <sonnet (default) or opus (if escalation criteria above are met)>
+Prompt: |
+  MODE: 1b — Plan Generation
+
+  Read `.claude/skills/architect-planner/SKILL.md` for your instructions.
+
+  TECH STACK CONTEXT:
+  <paste each STACK_REGISTRY stack's architect-overlay.md under "## <Stack> Architecture Context";
+   append cross-cutting overlays under "## Cross-Cutting: <name> Context";
+   append local overlays for the architect role per Step 0.2 matrix (skip empty)>
+
+  STACK MAPPING (for task assignment — assign each task a stack based on its files):
+  <for each stack, list its stack_paths patterns, e.g.:
+   - react: src/frontend/**
+   - python: src/backend/**
+   - bicep: infra/**>
+
+  ENRICHED SPEC:
+  <paste full contents of .claude/tmp/1a-spec.md>
+
+  EFFICIENCY CONSTRAINT: The 1a-spec was produced by reading the files in its
+  "Files & Services In Scope" section. Use the spec's extracts — do NOT re-read
+  those files end-to-end. If you need additional context, read only the specific
+  line ranges you need.
+
+  CODEBASE CONTEXT (ORCHESTRATOR.md 1b extract — do not re-read from disk):
+  <paste 1b Extract from Step 0.7>
+```
+
+Note: The 1a-spec already contains project overview, directory structure, fragile areas, and
+current state — the 1b extract omits these to avoid duplication.
+
+**Implementation clarification loop:**
+The 1b agent will first analyze the enriched spec against the codebase, then pause to surface
+implementation-specific questions (technical approach, patterns, integration strategy, data
+modeling). See Step 2.5 in the planner skill.
+
+- Present the implementation questions to the user verbatim.
+- Feed user answers back via **SendMessage** to the same agent (do NOT launch a new agent).
+- The agent may ask a second round of follow-up questions if the user's answers reveal new
+  decision points. Maximum TWO rounds total.
+- After receiving answers (or if the agent has no questions), it proceeds to decomposition
+  and plan generation.
+
+**Wait for the `PLAN_WRITTEN` stub.** The architect emits a compact stub (feature, plan type,
+wave sizes, task count, model distribution, estimated cost) instead of the full plan. The
+full plan is written to `.claude/tmp/1b-plan.md` — read that file from disk to access waves,
+context briefs, and task metadata for the rest of the pipeline.
+
+After receiving the `PLAN_WRITTEN` stub, read `.claude/tmp/1b-plan.md` and review:
+- Does it respect the file-per-task limits from CLAUDE.md?
+- Are waves and dependencies sensible?
+- Are context briefs self-contained and free of "see task X" cross-references?
+
+If the plan includes a `## Deferred Items` section, process each entry per the
+**Backlog Integration** section below (fold or defer). Do this before presenting
+the plan to the user so the folded items appear in the wave list.
+
+Present the stub-derived plan summary to the user and wait for confirmation before
+proceeding. For all subsequent steps that need brief content (Step 2, Step 2.2, Step 3.5),
+the orchestrator reads `.claude/tmp/1b-plan.md` directly — never ask the architect to re-emit
+the plan.
+
+**Token tracking:** Per Step 0.6 — one entry for the initial launch (step `1b`); one per impl-clarification SendMessage (step `1b:impl-clarify-N`); one per revision (step `1b:revision-N`). agent=`architect-agent`, model=as selected above.
+
+**Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.

--- a/skills/orchestrate/steps/2-implement.md
+++ b/skills/orchestrate/steps/2-implement.md
@@ -1,0 +1,69 @@
+---
+step: "2"
+requires: []
+produces: []
+sendmessage: optional
+---
+
+# Step 2: IMPLEMENT
+
+This file is read by the orchestrator just-in-time before executing Step 2.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+For each wave in the plan, launch implementer agents. **Tasks within a wave run in parallel.**
+Tasks across waves are sequential (wave N+1 waits for wave N to complete).
+
+**Streaming reviews:** Do NOT wait for all tasks in a wave to complete before starting reviews.
+As each implementer returns SUCCESS, immediately send it to the reviewer (via the wave's shared
+reviewer agent). This overlaps review work with still-running implementer tasks, reducing
+wall-clock time. The reviewer agent is launched on the first SUCCESS result; subsequent results
+use SendMessage. Failed implementers are reported to the user immediately without waiting.
+
+**Batch cap:** If a wave has more than 4 tasks at the same model, split into batches of ≤4
+to reduce blast radius and keep individual agent calls under ~50K input tokens. The planner
+should keep waves ≤4 tasks; the orchestrator enforces the cap if not.
+
+For each task (or batch of up to 4 tasks) in the current wave:
+
+1. Read the task's `Stack:` field from the plan to determine `<task_stack>`.
+   If the plan omits the stack field, resolve it from the task's file paths using the
+   `resolve_stack()` algorithm from Step 0.
+2. Look up `<task_stack>` in the STACK_REGISTRY to get the correct overlay.
+3. Compose the prompt:
+
+```
+Agent: implementer-agent
+Model: <model from plan — haiku, sonnet, or opus>
+Isolation: worktree (if multiple parallel agents in same wave touch different files)
+Prompt: |
+  You are being launched by the orchestration pipeline.
+  Follow all rules from your agent definition (output protocol, build/test
+  commands, coverage gate, self-review). No deviations.
+
+  TECH STACK RULES:
+  <paste STACK_REGISTRY[<task_stack>]'s implementer overlay — essential variant for Haiku, full for Sonnet/Opus;
+   append cross-cutting overlays (matching model variant);
+   append local overlays for the implementer role per Step 0.2 matrix (skip empty)>
+
+  BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
+  TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
+
+  TASK CONTEXT BRIEF:
+
+  <paste the context brief from the architect's plan here>
+```
+
+**Overlay selection:** Haiku tasks get the essential variant (~500-800 chars); Sonnet/Opus tasks
+get the full overlay. The reviewer in Step 2.1 has the full overlay and catches any Haiku
+violations. The implementer only loads the overlay for its task's stack — loading all stacks
+would dilute Haiku's signal-to-noise ratio.
+
+**After each implementer returns** (as soon as it completes, not after the full wave):
+
+- If `SUCCESS`: immediately send to the wave's reviewer agent (Step 2.1). If this is the first
+  SUCCESS in the wave, launch the reviewer agent. Otherwise, use SendMessage.
+- If `FAILURE`: report the failure details to the user immediately. Do NOT auto-retry implementation failures — these need human judgment. Do NOT block other tasks' reviews.
+
+**Token tracking:** Per Step 0.6 — one entry per implementer (step `2:<task_id>`, e.g. `2:1.1`). agent=`implementer-agent`, model=as assigned by the plan.

--- a/skills/orchestrate/steps/2-implement.md
+++ b/skills/orchestrate/steps/2-implement.md
@@ -2,7 +2,7 @@
 step: "2"
 requires: []
 produces: []
-sendmessage: optional
+sendmessage: n/a
 ---
 
 # Step 2: IMPLEMENT

--- a/skills/orchestrate/steps/2.2-fix.md
+++ b/skills/orchestrate/steps/2.2-fix.md
@@ -1,0 +1,47 @@
+---
+step: "2.2"
+requires: []
+produces: []
+sendmessage: optional
+---
+
+# Step 2.2: FIX
+
+This file is read by the orchestrator just-in-time before executing Step 2.2.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+Send the code-reviewer's FAIL output back to the implementer to fix:
+
+```
+Agent: implementer-agent (continue the same agent if possible, otherwise new with same worktree)
+Model: sonnet (escalate from haiku — fixes require more judgment)
+Prompt: |
+  The code-reviewer found issues in your implementation. Fix ALL issues below,
+  then re-build and re-test (coverage must remain >=90%).
+  Follow your standard output protocol (SUCCESS/FAILURE).
+
+  TECH STACK RULES:
+  <paste STACK_REGISTRY[<task_stack>].implementer overlay (full — fixes always get full overlay);
+   append cross-cutting overlays;
+   append local overlays for the implementer role per Step 0.2 matrix (skip empty)>
+
+  BUILD COMMAND: python3 .claude/scripts/<task_stack>/build.py
+  TEST COMMAND: python3 .claude/scripts/<task_stack>/test.py
+
+  CODE REVIEW FINDINGS TO FIX:
+
+  <paste the FAIL output from code-reviewer>
+
+  FILES YOU PREVIOUSLY MODIFIED:
+
+  <list of files>
+```
+
+**After fix returns:**
+- If `SUCCESS`: proceed to Step 3 (commit). The fix agent's self-review + build + test
+  is sufficient — do NOT re-review. Skip the review-fix cycle.
+- If `FAILURE`: report to user with full context.
+
+**Token tracking:** Per Step 0.6 — one entry per fix (step `2.2:<task_id>`). agent=`implementer-agent`, model=`sonnet`, `is_retry=true`. If original task was Haiku, also `is_escalation=true` with notes `escalated from haiku`.

--- a/skills/orchestrate/steps/3-commit.md
+++ b/skills/orchestrate/steps/3-commit.md
@@ -1,0 +1,33 @@
+---
+step: "3"
+requires: []
+produces: []
+sendmessage: n/a
+---
+
+# Step 3: COMMIT + PUSH
+
+This file is read by the orchestrator just-in-time before executing Step 3.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+For each agent that completed successfully (after passing review):
+
+1. Stage the agent's modified files: `git add <files>`
+2. Commit using the agent's SUCCESS message verbatim (everything after the `SUCCESS\n\n` header)
+3. Do NOT modify the commit message — use it exactly as returned
+4. Push to the PR branch: `git push`
+
+If multiple agents completed in the same wave, commit them in task order (1.1 before 1.2, etc.).
+
+```bash
+git add <files from agent>
+git commit -m "<SUCCESS message from agent>"
+git push
+```
+
+Pushing after each commit keeps the draft PR up to date so progress is visible.
+
+**Record test baseline:** After committing all waves, run the full test suite and record
+the total passing test count. This is the regression baseline for Step 3.5.

--- a/skills/orchestrate/steps/3.4-browser-ui.md
+++ b/skills/orchestrate/steps/3.4-browser-ui.md
@@ -1,0 +1,81 @@
+---
+step: "3.4"
+requires: []
+produces: []
+sendmessage: n/a
+---
+
+# Step 3.4: AUTOMATED BROWSER UI TEST (conditional)
+
+This file is read by the orchestrator just-in-time before executing Step 3.4.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+**Gating rule:** Evaluate these checks in order. Skip Step 3.4 silently at the
+first one that fails — do not run later checks (each is more expensive than
+the last).
+
+1. **Capability check** — `ACTIVE_CAPABILITIES` includes `browser-ui` (at
+   least one active stack's `manifest.json` declares this capability — `react`
+   does by default). Fast in-memory lookup.
+2. **Wave-relevance check** — at least one file in `FILES_MODIFIED` (across
+   all waves this run) resolves via `resolve_stack()` to a stack with the
+   `browser-ui` capability. Pure backend-only runs skip Step 3.4.
+3. **Tool availability check** — probe whether the `claude-in-chrome` MCP
+   tools are authorized in the current session:
+   ```
+   ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp"
+   ```
+   If the result contains a `<function>` schema for that tool, chrome is
+   authorized. If the result is "No matching deferred tools found" (or
+   equivalent empty result), the MCP server is not configured for this
+   session — skip Step 3.4 silently. No flag, no warning: the user simply
+   has not opted into chrome for this session.
+
+The probe in check 3 is the source of truth for "is chrome authorized?" —
+mirroring how `ACTIVE_CAPABILITIES` drives `azure-auth`. There is no
+`--chrome` flag because the MCP tool list is itself the authorization signal:
+if the user added `claude-in-chrome` to their MCP config and approved it,
+the tools are loadable; if they did not, they are not.
+
+**Invocation:**
+
+```
+Skill: chrome-ui-test
+Prompt: |
+  Read `.claude/skills/chrome-ui-test/SKILL.md` for your instructions.
+
+  IMPLEMENTATION_SUMMARY:
+  <one paragraph from the plan + commit messages, focused on user-visible behavior>
+
+  FILES_MODIFIED:
+  <list of files touched across all waves, filtered to browser-ui stacks>
+
+  TASK_BRIEFS:
+  <paste the original context briefs for tasks whose stack has browser-ui capability>
+
+  DEV_SERVER_HINT:
+  <if the project has a `dev` script in package.json, paste the script line and
+   default port; otherwise the skill will inspect package.json itself>
+
+  RECORD_GIF: <true if the user explicitly asked for a recording in their request, else false>
+```
+
+**Outcome handling:**
+
+- **PASS** — record the result in TOKEN_LEDGER and proceed to Step 3.5. The
+  user-facing prompt for manual test should mention the automated smoke
+  passed: "Automated browser smoke test passed (golden path + N edge cases).
+  Please test the branch and report any bugs..."
+- **FAIL** — treat the failure as a bug report and route it through the
+  existing Step 3.5.1 (ASSESS) → 3.5.2 (FIX) → 3.5.3 (REVIEW) → 3.5.4
+  (COMMIT) → 3.5.5 (RE-TEST) cycle. Use the skill's "Reproduction" block as
+  the bug report. After the fix is committed, re-run Step 3.4 once before
+  handing back to the user. If Step 3.4 fails twice on the same scenario,
+  stop and present the findings — do NOT loop.
+
+**Token tracking:** Per Step 0.6 — one entry for step `3.4` (re-runs as `3.4:retry-N`). agent=`orchestrator` (skill, not an Agent launch), model=`sonnet`.
+
+The automated smoke catches wiring failures; the user's manual test in 3.5 remains authoritative
+for UX, copy, and business-rule edge cases.

--- a/skills/orchestrate/steps/4-finalize.md
+++ b/skills/orchestrate/steps/4-finalize.md
@@ -1,6 +1,6 @@
 ---
 step: "4"
-requires: []
+requires: [.claude/tmp/run-log.yml]
 produces: []
 sendmessage: n/a
 ---
@@ -12,6 +12,11 @@ The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
 protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
 in `SKILL.md` and remain accessible.
 
+The `.claude/tmp/run-log.yml` artifact (initialized in Step 0.65) is read in
+sub-step 4 below to render the folded-items checklist when backlog integration
+is active. Read is conditional on `BACKLOG_ENABLED=true` but the file is always
+present once Step 0.65 ran.
+
 After all tasks are committed and pushed:
 
 1. If the changes affected architecture (new services, new targets, new patterns):
@@ -19,15 +24,15 @@ After all tasks are committed and pushed:
    - Commit and push the update
 2. Update the PR body's Coverage section with final numbers from the last test run
 3. Check off completed tasks in the PR body's task list
-3.5. If `BACKLOG_ENABLED=true` and `.claude/tmp/run-log.yml` has any entries with
+4. If `BACKLOG_ENABLED=true` and `.claude/tmp/run-log.yml` has any entries with
    `action: folded`, render the "Folded in this run" checklist into the PR body
    (see the Backlog Integration section for the format). Skip this if no folds
    occurred.
-4. Mark the PR as ready for review:
+5. Mark the PR as ready for review:
    ```bash
    gh pr ready <PR_NUMBER>
    ```
-5. Report final status to user:
+6. Report final status to user:
    - PR URL
    - Number of tasks completed
    - Number of commits made

--- a/skills/orchestrate/steps/4-finalize.md
+++ b/skills/orchestrate/steps/4-finalize.md
@@ -1,0 +1,37 @@
+---
+step: "4"
+requires: []
+produces: []
+sendmessage: n/a
+---
+
+# Step 4: FINALIZE
+
+This file is read by the orchestrator just-in-time before executing Step 4.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+After all tasks are committed and pushed:
+
+1. If the changes affected architecture (new services, new targets, new patterns):
+   - Update `ORCHESTRATOR.md` with the changes
+   - Commit and push the update
+2. Update the PR body's Coverage section with final numbers from the last test run
+3. Check off completed tasks in the PR body's task list
+3.5. If `BACKLOG_ENABLED=true` and `.claude/tmp/run-log.yml` has any entries with
+   `action: folded`, render the "Folded in this run" checklist into the PR body
+   (see the Backlog Integration section for the format). Skip this if no folds
+   occurred.
+4. Mark the PR as ready for review:
+   ```bash
+   gh pr ready <PR_NUMBER>
+   ```
+5. Report final status to user:
+   - PR URL
+   - Number of tasks completed
+   - Number of commits made
+   - Coverage summary from the last test run
+   - Any review findings that were fixed
+
+The orchestrator does NOT merge — the user decides when to merge.

--- a/skills/orchestrate/steps/5-token-analysis.md
+++ b/skills/orchestrate/steps/5-token-analysis.md
@@ -1,6 +1,6 @@
 ---
 step: "5"
-requires: []
+requires: [.claude/tmp/1b-plan.md]
 produces: []
 sendmessage: n/a
 ---
@@ -12,15 +12,19 @@ The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
 protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
 in `SKILL.md` and remain accessible.
 
+The `.claude/tmp/1b-plan.md` artifact is read by the orchestrator in sub-step 5.3
+below to inject planned-vs-actual model assignments into the token-analysis prompt.
+
 Launch token analysis **in the background** concurrently with Step 4 finalization — the
 TOKEN_LEDGER is complete after Step 3.5, so analysis can run while ORCHESTRATOR.md is updated
 and `gh pr ready` runs. Always runs, not skippable.
 
 **5.1 Compute Summary.** Record `PIPELINE_END`. Compute `TOKEN_SUMMARY` from `TOKEN_LEDGER`:
 totals across all entries, per-model breakdown (call count + input/output tokens), per-step
-breakdown by prefix (`1a`, `1b`, `1.5`, `2`, `2.1`, `2.2`, `3.5`), estimated cost (Haiku $1/$5,
-Sonnet $3/$15, Opus $15/$75 per M tokens in/out), actual cost-weighted model distribution vs.
-the 70/20/10 target, and counts of `is_escalation`/`is_retry` entries.
+breakdown by prefix (e.g., `1a`, `1b`, `1.4`, `1.5`, `2`, `2.1`, `2.2`, `3`, `3.4`, `3.5`,
+`4`, `5`), estimated cost (Haiku $1/$5, Sonnet $3/$15, Opus $15/$75 per M tokens in/out),
+actual cost-weighted model distribution vs. the 70/20/10 target, and counts of
+`is_escalation`/`is_retry` entries.
 
 **5.2 Derive Pipeline Repo.** `PIPELINE_REMOTE=$(git -C <pipeline_root> remote get-url origin)`.
 Parse SSH (`git@github.com:owner/repo.git`) or HTTPS (`https://github.com/owner/repo.git`),

--- a/skills/orchestrate/steps/5-token-analysis.md
+++ b/skills/orchestrate/steps/5-token-analysis.md
@@ -1,0 +1,49 @@
+---
+step: "5"
+requires: []
+produces: []
+sendmessage: n/a
+---
+
+# Step 5: TOKEN ANALYSIS (mandatory)
+
+This file is read by the orchestrator just-in-time before executing Step 5.
+The orchestrator's residual `SKILL.md` (Step Dispatch table) routes here. Shared
+protocols (SendMessage notes, Step 0.6 token tracking, Backlog Integration) live
+in `SKILL.md` and remain accessible.
+
+Launch token analysis **in the background** concurrently with Step 4 finalization — the
+TOKEN_LEDGER is complete after Step 3.5, so analysis can run while ORCHESTRATOR.md is updated
+and `gh pr ready` runs. Always runs, not skippable.
+
+**5.1 Compute Summary.** Record `PIPELINE_END`. Compute `TOKEN_SUMMARY` from `TOKEN_LEDGER`:
+totals across all entries, per-model breakdown (call count + input/output tokens), per-step
+breakdown by prefix (`1a`, `1b`, `1.5`, `2`, `2.1`, `2.2`, `3.5`), estimated cost (Haiku $1/$5,
+Sonnet $3/$15, Opus $15/$75 per M tokens in/out), actual cost-weighted model distribution vs.
+the 70/20/10 target, and counts of `is_escalation`/`is_retry` entries.
+
+**5.2 Derive Pipeline Repo.** `PIPELINE_REMOTE=$(git -C <pipeline_root> remote get-url origin)`.
+Parse SSH (`git@github.com:owner/repo.git`) or HTTPS (`https://github.com/owner/repo.git`),
+strip trailing `.git`.
+
+**5.3 Launch Token Analysis.** Invoke the skill with the ledger, summary, and pipeline context:
+
+```
+Skill: token-analysis
+Prompt: |
+  Read `.claude/skills/token-analysis/SKILL.md` for your instructions.
+
+  TOKEN LEDGER: <paste the full TOKEN_LEDGER as a markdown table>
+  TOKEN SUMMARY: <paste the computed TOKEN_SUMMARY>
+
+  PIPELINE CONTEXT:
+  - Plan file: .claude/tmp/1b-plan.md (planned vs actual model assignments)
+  - Pipeline repo: <owner/repo>
+  - Pipeline root: <pipeline_root>
+  - Target project stacks: <stacks (comma-separated)>
+  - Pipeline duration: <PIPELINE_START> to <PIPELINE_END>
+```
+
+**5.4 Report Results.** `FINDINGS: NONE` → "no significant optimization opportunities found".
+`FINDINGS: FILED` with issue URL → "findings filed as <issue URL>". Skill failure or
+`gh issue create` error → log a warning and report; do NOT mark the pipeline failed.

--- a/tests/baselines/orchestrator-load.json
+++ b/tests/baselines/orchestrator-load.json
@@ -1,75 +1,75 @@
 {
   "adapter": "python",
   "discovery_mode": "steps_dir",
-  "git_sha": "6fff869786a6d4b4332895ba01650dc82f83e87a",
+  "git_sha": "7d50454e6533151bf67d616ac2426a5a3d01b208",
   "measurements": {
     "initial_load": {
-      "chars": 38972,
-      "est_tokens": 9743
+      "chars": 39012,
+      "est_tokens": 9753
     },
     "step_1.4": {
-      "cumulative_chars": 42270,
+      "cumulative_chars": 42310,
       "delta_chars": 3298,
-      "est_tokens": 10567
+      "est_tokens": 10577
     },
     "step_1.5": {
-      "cumulative_chars": 43208,
+      "cumulative_chars": 43248,
       "delta_chars": 938,
-      "est_tokens": 10802
+      "est_tokens": 10812
     },
     "step_1a": {
-      "cumulative_chars": 49041,
+      "cumulative_chars": 49081,
       "delta_chars": 5833,
-      "est_tokens": 12260
+      "est_tokens": 12270
     },
     "step_1b": {
-      "cumulative_chars": 53698,
+      "cumulative_chars": 53738,
       "delta_chars": 4657,
-      "est_tokens": 13424
+      "est_tokens": 13434
     },
     "step_2": {
-      "cumulative_chars": 57095,
-      "delta_chars": 3397,
-      "est_tokens": 14273
+      "cumulative_chars": 57130,
+      "delta_chars": 3392,
+      "est_tokens": 14282
     },
     "step_2.1": {
-      "cumulative_chars": 63105,
+      "cumulative_chars": 63140,
       "delta_chars": 6010,
-      "est_tokens": 15776
+      "est_tokens": 15785
     },
     "step_2.2": {
-      "cumulative_chars": 64859,
+      "cumulative_chars": 64894,
       "delta_chars": 1754,
-      "est_tokens": 16214
+      "est_tokens": 16223
     },
     "step_3": {
-      "cumulative_chars": 65983,
+      "cumulative_chars": 66018,
       "delta_chars": 1124,
-      "est_tokens": 16495
+      "est_tokens": 16504
     },
     "step_3.4": {
-      "cumulative_chars": 69562,
+      "cumulative_chars": 69597,
       "delta_chars": 3579,
-      "est_tokens": 17390
+      "est_tokens": 17399
     },
     "step_3.5": {
-      "cumulative_chars": 77732,
+      "cumulative_chars": 77767,
       "delta_chars": 8170,
-      "est_tokens": 19433
+      "est_tokens": 19441
     },
     "step_4": {
-      "cumulative_chars": 79025,
-      "delta_chars": 1293,
-      "est_tokens": 19756
+      "cumulative_chars": 79346,
+      "delta_chars": 1579,
+      "est_tokens": 19836
     },
     "step_5": {
-      "cumulative_chars": 81164,
-      "delta_chars": 2139,
-      "est_tokens": 20291
+      "cumulative_chars": 81709,
+      "delta_chars": 2363,
+      "est_tokens": 20427
     },
     "total": {
-      "chars": 81164,
-      "est_tokens": 20291
+      "chars": 81709,
+      "est_tokens": 20427
     }
   },
   "schema_version": 1

--- a/tests/baselines/orchestrator-load.json
+++ b/tests/baselines/orchestrator-load.json
@@ -1,30 +1,75 @@
 {
   "adapter": "python",
   "discovery_mode": "steps_dir",
-  "git_sha": "b532edaff7a916819cceffb5bdb515207038ad2e",
+  "git_sha": "6fff869786a6d4b4332895ba01650dc82f83e87a",
   "measurements": {
     "initial_load": {
-      "chars": 56313,
-      "est_tokens": 14078
+      "chars": 38972,
+      "est_tokens": 9743
+    },
+    "step_1.4": {
+      "cumulative_chars": 42270,
+      "delta_chars": 3298,
+      "est_tokens": 10567
+    },
+    "step_1.5": {
+      "cumulative_chars": 43208,
+      "delta_chars": 938,
+      "est_tokens": 10802
     },
     "step_1a": {
-      "cumulative_chars": 62146,
+      "cumulative_chars": 49041,
       "delta_chars": 5833,
-      "est_tokens": 15536
+      "est_tokens": 12260
+    },
+    "step_1b": {
+      "cumulative_chars": 53698,
+      "delta_chars": 4657,
+      "est_tokens": 13424
+    },
+    "step_2": {
+      "cumulative_chars": 57095,
+      "delta_chars": 3397,
+      "est_tokens": 14273
     },
     "step_2.1": {
-      "cumulative_chars": 68156,
+      "cumulative_chars": 63105,
       "delta_chars": 6010,
-      "est_tokens": 17039
+      "est_tokens": 15776
+    },
+    "step_2.2": {
+      "cumulative_chars": 64859,
+      "delta_chars": 1754,
+      "est_tokens": 16214
+    },
+    "step_3": {
+      "cumulative_chars": 65983,
+      "delta_chars": 1124,
+      "est_tokens": 16495
+    },
+    "step_3.4": {
+      "cumulative_chars": 69562,
+      "delta_chars": 3579,
+      "est_tokens": 17390
     },
     "step_3.5": {
-      "cumulative_chars": 76326,
+      "cumulative_chars": 77732,
       "delta_chars": 8170,
-      "est_tokens": 19081
+      "est_tokens": 19433
+    },
+    "step_4": {
+      "cumulative_chars": 79025,
+      "delta_chars": 1293,
+      "est_tokens": 19756
+    },
+    "step_5": {
+      "cumulative_chars": 81164,
+      "delta_chars": 2139,
+      "est_tokens": 20291
     },
     "total": {
-      "chars": 76326,
-      "est_tokens": 19081
+      "chars": 81164,
+      "est_tokens": 20291
     }
   },
   "schema_version": 1


### PR DESCRIPTION
## Summary

- Lever 1 Phase 2 from #75. Completes the migration started in #74 — extracts the remaining **9 step procedures** (1b, 1.4, 1.5, 2, 2.2, 3, 3.4, 4, 5) into individual step files under `skills/orchestrate/steps/`.
- **Initial orchestrator load: 14,078 → 9,743 est. tokens** (Phase 2 alone: −4,335; **combined with #74: −8,288 / −46% from original baseline**).
- Every pipeline step is now lazy-loaded — the orchestrator's initial context drops to its floor.

## Empirical impact (vs post-Phase-1 baseline at `tests/baselines/orchestrator-load.json`)

```
Step       Loaded                              Chars    Est. Tokens  Δ Tokens
---------  ----------------------------------  -------  -----------  --------
initial    SKILL.md, ORCH.tmpl, ...            38,972    9,743       -4,335
1.4        +steps/1.4-preflight.md             42,270   10,567        (new)
1.5        +steps/1.5-open-pr.md               43,208   10,802        (new)
1a         +steps/1a-clarify.md                49,041   12,260       -3,276 (vs Phase 1)
1b         +steps/1b-plan.md                   53,698   13,424        (new)
2          +steps/2-implement.md               57,095   14,273        (new)
2.1        +steps/2.1-review.md                63,105   15,776       -1,263 (vs Phase 1)
2.2        +steps/2.2-fix.md                   64,859   16,214        (new)
3          +steps/3-commit.md                  65,983   16,495        (new)
3.4        +steps/3.4-browser-ui.md            69,562   17,390        (new)
3.5        +steps/3.5-manual-test.md           77,732   19,433         +352 (vs Phase 1)
4          +steps/4-finalize.md                79,025   19,756        (new)
5          +steps/5-token-analysis.md          81,164   20,291        (new)
total      —                                   81,164   20,291       +1,210
```

## Combined with #74 — total Lever 1 impact

| Metric | Pre-Lever-1 (main pre-#74) | After #74 + #75 | Δ |
|---|---|---|---|
| **Initial load** | 18,031 tok | **9,743 tok** | **−8,288 / −46%** |
| Total all-steps | 18,031 tok | 20,291 tok | +2,260 (frontmatter + dispatch) |
| `SKILL.md` line count | 1,344 | 612 | −732 |

The +2,260 cumulative cost is paid only on full pipeline runs. Aborted/early-exit runs save the most.

## File granularity rule (per #75)

**One step = one file regardless of size.** Small steps (1.5 at 15 lines, 3 at 22 lines, 4 at 26 lines) each get their own file rather than grouping into a `quick-steps.md`. Keeps the dispatch table mechanically uniform; reviewer cost is one extra Read per small step.

## Step Dispatch table

Now lists 12 of 12 steps with `steps/<file>` entries — no more "inline" rows. Renamed the column from "Extracted" to "File" since it's uniform.

## Front-matter contracts (per step)

| Step | requires | produces | sendmessage |
|---|---|---|---|
| 1b | `[.claude/tmp/1a-spec.md]` | `[.claude/tmp/1b-plan.md]` | required |
| 1.4 | `[.claude/tmp/1b-plan.md]` | `[]` | n/a |
| 1.5 | `[]` | `[]` | n/a |
| 2 | `[]` | `[]` | optional |
| 2.2 | `[]` | `[]` | optional |
| 3 | `[]` | `[]` | n/a |
| 3.4 | `[]` | `[]` | n/a |
| 4 | `[]` | `[]` | n/a |
| 5 | `[]` | `[]` | n/a |

(Strict declarations — only artifacts the body actively references. Steps that operate on plan data via inline `<paste from architect's plan>` placeholders aren't declared, since they don't read the file from disk in the step body itself.)

## Test plan

- [x] `tests/validate_structure.py` — **398 / 398 passing** (was 389; +9 new step file front-matter validations)
- [x] `tests/test_contracts.py` — **97 / 97 passing**
- [x] `tests/smoke/run_smoke.py` — **36 / 36 passing**
- [x] All 12 step files have valid front-matter (schema + artifact-grep contract enforced)
- [x] Step Dispatch table lists all 12 steps with file pointers
- [x] Resume dispatch matrix unchanged from #74 (4-case explicit behavior)
- [x] Baseline JSON updated to post-Phase-2 state for future PRs to compare against
- [ ] **Manual:** end-to-end `/orchestrate` run to confirm the orchestrator reads each step file at the correct time. (Not in CI — the smoke `--full` stub remains deferred per #78's out-of-scope list.)

## Out of scope (per #75)

- Step 0.x scriptification (Lever 2 — separate future issue)
- Backlog integration extraction (separate concern)
- CI budget gate via `--budget` flag (deferred to follow-up after baseline data accumulates)

## Rollback

Single-commit revert. Phase 1 contract (#74) remains stable; reverting Phase 2 alone restores the post-#74 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)