### PR TITLE
test(validate): bidirectional grep contract for step-file front-matter (closes #82)

### DIFF
--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -975,5 +975,140 @@ class TestReactAdapterParsers(unittest.TestCase):
             _os.remove(bad_path)
 
 
+class TestStepFileBidirectionalContract(unittest.TestCase):
+    """Issue #82: step file front-matter must be bidirectional with body refs."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from validate_structure import _check_step_file_content
+        cls._check = staticmethod(_check_step_file_content)
+
+    def test_undeclared_body_reference_fails(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: []\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "Body references `.claude/tmp/run-log.yml` without declaring it.\n"
+        )
+        failures = self._check("steps/test.md", content)
+        self.assertTrue(
+            any(
+                "body references '.claude/tmp/run-log.yml'" in f
+                and "one-directional contract gap" in f
+                for f in failures
+            ),
+            f"expected bidirectional failure, got: {failures}",
+        )
+
+    def test_declared_body_reference_passes(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: [.claude/tmp/1b-plan.md]\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "Body references `.claude/tmp/1b-plan.md` and declares it.\n"
+        )
+        self.assertEqual(self._check("steps/test.md", content), [])
+
+    def test_directory_only_reference_does_not_trigger(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: []\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "See files in `.claude/tmp/` directory.\n"
+        )
+        self.assertEqual(self._check("steps/test.md", content), [])
+
+    def test_declared_artifact_missing_from_body_still_fails(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: [.claude/tmp/1a-spec.md]\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "Body has no artifact references.\n"
+        )
+        failures = self._check("steps/test.md", content)
+        self.assertTrue(
+            any(
+                "requires declares '.claude/tmp/1a-spec.md'" in f and "drift" in f
+                for f in failures
+            ),
+            f"expected drift failure, got: {failures}",
+        )
+
+    def test_produces_satisfies_body_reference(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: []\n"
+            "produces: [.claude/tmp/1a-spec.md]\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "This step writes `.claude/tmp/1a-spec.md`.\n"
+        )
+        self.assertEqual(self._check("steps/test.md", content), [])
+
+    def test_multiple_undeclared_refs_each_fail_in_sorted_order(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: []\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "Refs `.claude/tmp/zeta.md` and `.claude/tmp/alpha.md` undeclared.\n"
+        )
+        failures = self._check("steps/test.md", content)
+        gap_failures = [f for f in failures if "one-directional contract gap" in f]
+        self.assertEqual(len(gap_failures), 2, f"expected 2 gap failures, got: {failures}")
+        # sorted() in source means alpha appears before zeta
+        self.assertIn(".claude/tmp/alpha.md", gap_failures[0])
+        self.assertIn(".claude/tmp/zeta.md", gap_failures[1])
+
+    def test_drift_and_gap_fire_independently(self) -> None:
+        content = (
+            "---\n"
+            "step: \"test\"\n"
+            "requires: [.claude/tmp/foo.md]\n"
+            "produces: []\n"
+            "sendmessage: n/a\n"
+            "---\n"
+            "\n"
+            "Body refs `.claude/tmp/bar.md` instead.\n"
+        )
+        failures = self._check("steps/test.md", content)
+        self.assertTrue(
+            any(
+                "requires declares '.claude/tmp/foo.md'" in f and "drift" in f
+                for f in failures
+            ),
+            f"expected drift failure for foo.md, got: {failures}",
+        )
+        self.assertTrue(
+            any(
+                "body references '.claude/tmp/bar.md'" in f
+                and "one-directional contract gap" in f
+                for f in failures
+            ),
+            f"expected gap failure for bar.md, got: {failures}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/validate_structure.py
+++ b/tests/validate_structure.py
@@ -1276,6 +1276,55 @@ def _parse_artifact_list(raw: str) -> list[str]:
     return [item.strip().strip('"').strip("'") for item in raw.split(",") if item.strip()]
 
 
+_TMP_ARTIFACT_RE = re.compile(r"\.claude/tmp/[\w.-]+\.\w+")
+
+
+def _check_step_file_content(label: str, content: str) -> list[str]:
+    """Validate a single step file's content. Returns a list of failure messages
+    (empty if the file is well-formed).
+
+    Pure helper used by `check_orchestrate_step_files` and unit-tested directly
+    via tests/test_contracts.py.
+    """
+    failures: list[str] = []
+    fm = _parse_step_frontmatter(content)
+    if fm is None:
+        failures.append(f"{label}: missing or malformed YAML front-matter")
+        return failures
+
+    for key in REQUIRED_STEP_FRONTMATTER_KEYS:
+        if key not in fm:
+            failures.append(f"{label}: front-matter missing required key '{key}'")
+
+    sendmessage = fm.get("sendmessage", "")
+    if sendmessage and sendmessage not in VALID_SENDMESSAGE:
+        failures.append(
+            f"{label}: sendmessage='{sendmessage}' is not one of "
+            f"{sorted(VALID_SENDMESSAGE)}"
+        )
+
+    body_after_fm = re.sub(r"^---\n.*?\n---\n?", "", content, count=1, flags=re.DOTALL)
+
+    declared: set[str] = set()
+    for kind in ("requires", "produces"):
+        for artifact in _parse_artifact_list(fm.get(kind, "[]")):
+            declared.add(artifact)
+            if artifact not in body_after_fm:
+                failures.append(
+                    f"{label}: {kind} declares '{artifact}' but it does not "
+                    f"appear in the step body (drift)"
+                )
+
+    body_refs = set(_TMP_ARTIFACT_RE.findall(body_after_fm))
+    for ref in sorted(body_refs - declared):
+        failures.append(
+            f"{label}: body references '{ref}' but it is not declared in "
+            f"requires/produces (one-directional contract gap)"
+        )
+
+    return failures
+
+
 def check_orchestrate_step_files(result: ValidationResult) -> None:
     """Step files in skills/orchestrate/steps/ must have valid front-matter.
 
@@ -1285,8 +1334,14 @@ def check_orchestrate_step_files(result: ValidationResult) -> None:
         produces: [<artifacts>]
         sendmessage: required | optional | n/a
 
-    Each artifact declared in requires/produces must appear as a substring in
-    the step body (catches drift between front-matter and prose).
+    Bidirectional artifact contract (issue #82):
+        - Declared → body: each artifact in requires/produces must appear as a
+          substring in the step body (catches stale front-matter).
+        - Body → declared: each `.claude/tmp/<file>.<ext>` reference in the
+          step body must be declared in requires or produces (catches
+          undeclared usage). The matching regex `\\.claude/tmp/[\\w.-]+\\.\\w+`
+          requires an extension, so directory-only prose like
+          "files in .claude/tmp/" does not trigger the check.
 
     No-op if steps/ does not exist (pre-Lever-1 state).
     """
@@ -1301,34 +1356,12 @@ def check_orchestrate_step_files(result: ValidationResult) -> None:
 
     for step_file in step_files:
         rel = step_file.relative_to(PIPELINE_ROOT)
-        content = step_file.read_text()
-        fm = _parse_step_frontmatter(content)
-        if fm is None:
-            result.fail(f"{rel}: missing or malformed YAML front-matter")
-            continue
-
-        for key in REQUIRED_STEP_FRONTMATTER_KEYS:
-            if key not in fm:
-                result.fail(f"{rel}: front-matter missing required key '{key}'")
-
-        sendmessage = fm.get("sendmessage", "")
-        if sendmessage and sendmessage not in VALID_SENDMESSAGE:
-            result.fail(
-                f"{rel}: sendmessage='{sendmessage}' is not one of "
-                f"{sorted(VALID_SENDMESSAGE)}"
-            )
-
-        body_after_fm = re.sub(r"^---\n.*?\n---\n?", "", content, count=1, flags=re.DOTALL)
-
-        for kind in ("requires", "produces"):
-            for artifact in _parse_artifact_list(fm.get(kind, "[]")):
-                if artifact not in body_after_fm:
-                    result.fail(
-                        f"{rel}: {kind} declares '{artifact}' but it does not "
-                        f"appear in the step body (drift)"
-                    )
-
-        result.ok(f"{rel}: front-matter valid")
+        failures = _check_step_file_content(str(rel), step_file.read_text())
+        if failures:
+            for f in failures:
+                result.fail(f)
+        else:
+            result.ok(f"{rel}: front-matter valid")
 
 
 REQUIRED_ADAPTER_MANIFEST_FIELDS = ["name", "display_name", "capabilities", "detection", "stack_paths"]


### PR DESCRIPTION
## Summary

- Closes the validator gap that let PR #81's strict-declaration defects ship: previously the front-matter contract was one-directional (declared→body only), so step files referencing `.claude/tmp/X` in their body without declaring it in `requires:` or `produces:` slipped through CI.
- Extends `check_orchestrate_step_files` with a body→declared scan (regex `\.claude/tmp/[\w.-]+\.\w+` — extension required, so directory-only prose like `files in .claude/tmp/` does not trigger).
- Refactors per-file logic into `_check_step_file_content(label, content)` for direct unit testing; adds `TestStepFileBidirectionalContract` with 7 cases.

## Acceptance criteria (from issue #82)

- [x] `check_orchestrate_step_files` extended with the bidirectional check
- [x] Function docstring updated to document both directions explicitly
- [x] Negative test: deliberately-broken step file triggers fail with documented error message
- [x] Existing 12 step files in `skills/orchestrate/steps/` still pass (398/0)
- [x] All test suites pass: `validate_structure.py`, `test_contracts.py` (104 OK), `smoke/run_smoke.py`

## Behavior note

Previously `result.ok("front-matter valid")` was logged at the bottom of every iteration unless `fm is None`. Now it only fires when `failures` is empty — strict improvement (more honest counts), no regression on current state.

## Test plan

- [x] `python3 tests/validate_structure.py` → 398/0
- [x] `python3 tests/test_contracts.py` → 104 OK (added 7 cases under `TestStepFileBidirectionalContract`)
- [x] `python3 tests/smoke/run_smoke.py` → 36/0
- [x] Code-review pass via Agent — addressed 2 should-fix items (multi-undeclared sort test, drift+gap independence test); 1 remaining should-fix (behavior change in ok-logging) noted in commit body as intentional improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)