### PR TITLE
docs(template): trim CLAUDE.md.template workflow rules (closes #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Edit `.claude/local/coding-standards.md` with your rules. These get injected int
 **Q: How do I update the pipeline?**
 Run `/update-pipeline` from Claude Code. It pulls the latest version, shows what changed, validates structural integrity, and commits the submodule bump. If validation fails, it offers to roll back. See [docs/how-to.md](docs/how-to.md#updating-the-pipeline).
 
+Note: `/update-pipeline` regenerates pipeline-managed *symlinks* but does **not** modify your existing `.claude/CLAUDE.md`, `.claude/ORCHESTRATOR.md`, or `.claude/local/*` overlays. `init.sh` skips these files when they already exist (even with `--force`) to preserve consumer customization. To pick up template changes (e.g., the trimmed `Workflow Rules` section), either edit `.claude/CLAUDE.md` manually, or delete it and re-run `init.sh` to regenerate from the latest template.
+
 **Q: What if my project uses multiple stacks?**
 The pipeline supports multiple adapters simultaneously for multi-stack repos. Use `--stack=react --stack=python` with `init.sh`, or let auto-detection handle it. For Flutter apps with native platform code, use `--stack=flutter --stack=swift-ios --stack=android` — file-path routing sends Dart code to the Flutter overlay, Swift to swift-ios, and Kotlin to Android.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Empty files are skipped. Keep content concise — these are injected into every 
 Your project's instructions for Claude Code. The template provides a starting structure. Key sections to customize:
 - **Role**: Your developer persona ("senior React developer", "Python backend engineer")
 - **Context**: What your project does
-- **Workflow Rules**: Project-specific rules (the template includes sensible defaults)
+- **Workflow Rules**: Project-specific rules (template defers to agent definitions in `.claude/agents/` by default — add project-specific rules here if needed)
 - **Build & Test**: Already configured by init.sh to use pipeline skills
 
 ## `.claude/ORCHESTRATOR.md`

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -10,12 +10,7 @@ Setup: At the start of each session, read `.claude/ORCHESTRATOR.md` for architec
 
 ## Workflow Rules
 
-1. Before writing any code, describe your approach and wait for approval.
-2. If requirements are ambiguous, ask clarifying questions before writing code.
-3. After writing code, list edge cases and suggest test cases.
-4. If a task requires changes to more than 3 files, stop and break it into smaller tasks first.
-5. When there's a bug, start by writing a test that reproduces it, then fix it.
-6. Every time I correct you, reflect on what went wrong and plan to avoid repeating it.
+See agent definitions in `.claude/agents/` for per-role guidance (planning, implementation, review, testing).
 
 ## Build & Test (Mandatory Skills)
 


### PR DESCRIPTION
## Summary

- Removes 6 numbered workflow rules from `templates/CLAUDE.md.template` that were duplicated by agent definitions and skill prompts. Replaced with a one-line pointer to `.claude/agents/`.
- Saves ~150-200 tokens per consumer session at session start (CLAUDE.md is auto-loaded by Claude Code on every session, not just `/orchestrate`).
- Build & Test section retained — pipeline-specific, not duplicated.

## Duplication verification (per issue acceptance criteria)

| Rule | Original wording | Coverage |
|------|------------------|----------|
| 1 | Describe approach before code | `agents/implementer-agent.md` + `implementer-contract.md` (FULLY-SPECIFIED, SCOPED briefs) |
| 2 | Ask if ambiguous | `skills/orchestrate/steps/1a-clarify.md` (Step 1a clarification loop) |
| 3 | List edge cases | `agents/test-architect-agent.md` + `code-reviewer-agent.md` |
| 4 | >3 files = break down | `agents/implementer-contract.md` (SINGLE-FILE, BOUNDED <150 LOC) |
| 5 | Bug → repro test first | Partially covered by `skills/fix-defects/SKILL.md` (advisory, not enforced) |
| 6 | Reflect on corrections | Generic LLM self-improvement; not pipeline-specific (deliberate removal per issue) |

Grep confirmed no test or agent references the rule numbering or wording. The "Rule 4/5/6" hits in `implementer-agent.md` and overlays are the implementer's own internal numbering, unrelated to this template.

## Acceptance criteria (from issue #77)

- [x] Template trimmed (Workflow Rules section now 1 line; Build & Test retained)
- [x] Grep verification of duplication completed and documented above
- [ ] CHANGELOG entry added — repo has no CHANGELOG.md (uses `git log --oneline` per `update-pipeline` skill); commit message serves as the changelog entry per repo convention
- [x] README migration note added (FAQ section)
- [x] `tests/validate_structure.py` passes (398/0)

## Migration

`/update-pipeline` and `init.sh` both **skip** pre-existing `.claude/CLAUDE.md` (even with `--force`) to preserve consumer customization. To pick up the trimmed template, consumers can either:
- Edit `.claude/CLAUDE.md` manually to remove the 6 rules, OR
- Delete `.claude/CLAUDE.md` and re-run `init.sh` to regenerate from the latest template.

## Test plan

- [x] `python3 tests/validate_structure.py` → 398/0
- [x] `python3 tests/test_contracts.py` → 104 OK
- [x] `python3 tests/smoke/run_smoke.py` → 36/0
- [x] Code-review pass via Agent — caught a bug in initial README migration note (claimed `init.sh --force` regenerates `CLAUDE.md`, but the file is actually skipped). Fixed pre-merge.
- [x] Second-pass review confirmed README accurately describes `init.sh` behavior; no contradicting docs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)