### PR TITLE
feat(benchmarks): Tier 1 base64 regression benchmark

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,3 @@
+# Per-run output is large and not interesting to version-control.
+# Keep baselines/ committed (those are intentional snapshots).
+runs/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,145 @@
+# Pipeline Benchmarks
+
+Regression benchmarks for the orchestration pipeline. Each benchmark runs a
+*frozen* feature request through the pipeline and scores the produced code
+against an objective oracle (property tests + unit tests). Same input + same
+oracle = changes in score reflect changes in the pipeline.
+
+## Why this exists
+
+`tests/validate_structure.py` confirms the pipeline can run. The contract
+tests confirm agents emit the right output format. Neither answers
+"did the pipeline produce *correct* code?" That's what the benchmarks here are for.
+
+## Running Tier 1
+
+The Tier 1 benchmark (`tier1-base64`) asks the pipeline to implement RFC 4648
+base64 encode/decode. The oracle is a round-trip property suite:
+`decode(encode(x)) == x` for 1000 random inputs, plus reference equivalence
+against Python's stdlib `base64`.
+
+### Modes
+
+The harness supports three modes for invoking the pipeline:
+
+| Mode | Use when | Cost |
+|------|----------|------|
+| `manual`   | You want to drive `/orchestrate` interactively and have the harness score the result | Just your time + Claude tokens |
+| `auto`     | Headless run — `claude -p` invokes the pipeline non-interactively | API tokens (~$1-5/run) |
+| `existing` | You already have a project dir with a candidate implementation; just score it | Free |
+
+### Quick start (manual mode — recommended for first run)
+
+```bash
+python3 benchmarks/scripts/run_benchmark.py tier1-base64 --mode=manual
+```
+
+The harness will:
+1. Copy the skeleton into a temp dir, `git init` it, run `init.sh`
+2. Print the path and pause — you `cd` there, open Claude Code, run `/orchestrate`
+3. Press ENTER when finished
+4. Harness runs the property + unit tests against the produced code
+5. Writes `benchmarks/runs/<id>/metrics.json`
+
+### Score-only mode (no pipeline run)
+
+```bash
+python3 benchmarks/scripts/run_benchmark.py tier1-base64 \
+    --mode=existing --project-dir=/path/to/finished/project
+```
+
+Useful for testing the harness itself, or for scoring a hand-written reference
+implementation to seed a baseline.
+
+## Setting a baseline
+
+After a representative run produces good metrics:
+
+```bash
+cp benchmarks/runs/<run_id>/metrics.json benchmarks/baselines/tier1-base64.json
+```
+
+The baseline is the reference for `compare_runs.py` and for the efficiency
+component of subsequent run scores.
+
+## Comparing runs
+
+```bash
+# Compare a run to its baseline
+python3 benchmarks/scripts/compare_runs.py benchmarks/runs/<run_id>
+
+# Compare two runs head-to-head
+python3 benchmarks/scripts/compare_runs.py runs/<run_a> runs/<run_b>
+```
+
+Exits 1 if correctness drops by more than `REGRESSION_THRESHOLD` (currently 0.05).
+
+## Metrics schema
+
+`metrics.json` shape (abridged):
+
+```json
+{
+  "run_id": "20260503-141022-f657850-tier1-base64",
+  "benchmark": "tier1-base64",
+  "pipeline_sha": "f657850",
+  "mode": "manual",
+  "wall_time_seconds": 247,
+  "tokens": {
+    "total_input_estimate": 53000,
+    "total_output_estimate": 13200,
+    "report_count": 7
+  },
+  "pipeline": {"waves": 2, "review_fail_rounds": 0, "bug_fix_cycles": 0},
+  "code_delta": {"files_changed": 3, "lines_added": 187, "lines_deleted": 0},
+  "tests": {
+    "property": {"total_passed": 5000, "total_run": 5000, "pass_pct": 100.0, "...": "..."},
+    "unit":     {"passed": 8, "total": 8, "pass_pct": 100.0, "...": "..."}
+  },
+  "score": {"correctness": 1.0, "efficiency": 1.04, "composite": 0.91}
+}
+```
+
+Token capture is best-effort: it parses `---TOKEN_REPORT---` blocks from the
+session log. In `--mode=manual`, save the session transcript to
+`benchmarks/runs/<id>/pipeline.log` to populate token metrics; otherwise they
+default to zero and only correctness is meaningful.
+
+## Statistical handling (planned, not yet implemented)
+
+LLM output is non-deterministic. A single run can swing 5-10% on tokens or
+wall time. The first iteration of the harness runs once; future work is to
+support `--runs=N` for repeated runs with mean + stddev. Until then, treat
+single-run scores as noisy.
+
+## Adding a new benchmark
+
+A benchmark is a directory under `benchmarks/<name>/` with this layout:
+
+```
+<name>/
+  feature-request.md   # frozen pipeline input
+  spec.md              # acceptance contract — used by the scorer, NOT given to the pipeline
+  skeleton/            # minimal project the pipeline runs in
+    CLAUDE.md
+    ORCHESTRATOR.md
+    pyproject.toml     # or whatever stack config
+    src/
+  fixtures/
+    property_tests.py  # round-trip / metamorphic oracle
+    unit_tests.py      # spec-derived unit tests
+    _discover.py       # helper to find pipeline-produced module
+```
+
+The `_discover.py` pattern lets the pipeline name files freely without the
+fixtures penalizing naming choices.
+
+## Phase 2 (future)
+
+- **Consumer-diag mode**: when invoked from a consuming repo, layer that
+  repo's `.claude/local/*.md` overlays into the harness so the benchmark
+  measures local-context impact (helping vs. hurting baseline).
+- **Statistical mode**: `--runs=N` with mean ± stddev gating.
+- **Mutation testing**: separate tool that mutates pipeline prompts and
+  re-runs benchmarks to identify load-bearing prompt sections. See
+  the GitHub issue tagged `mutation-testing`.

--- a/benchmarks/scripts/capture_metrics.py
+++ b/benchmarks/scripts/capture_metrics.py
@@ -1,0 +1,77 @@
+"""Best-effort extraction of pipeline metrics from a session log.
+
+The log is whatever stdout the pipeline emitted (claude -p output, or a saved
+manual transcript). Parsing is regex-based and lenient — missing fields default
+to None or zero rather than raising. Refine over time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+TOKEN_REPORT_RE = re.compile(
+    r"-{3,}\s*TOKEN_REPORT\s*-{3,}(.*?)(?=-{3,}|$)",
+    re.DOTALL | re.IGNORECASE,
+)
+KV_RE = re.compile(r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[:=]\s*(.+?)\s*$", re.MULTILINE)
+WAVE_RE = re.compile(r"\b[Ww]ave\s+(\d+)\b")
+REVIEW_FAIL_RE = re.compile(r"\b(?:review[_\s]fail|FAIL\s*\(review\))\b", re.IGNORECASE)
+BUG_FIX_RE = re.compile(r"\bbug[_\s]?fix(?:\s+cycle)?\b", re.IGNORECASE)
+
+
+def _parse_token_report(block: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for m in KV_RE.finditer(block):
+        key = m.group(1).strip()
+        val = m.group(2).strip()
+        # Try numeric coercion
+        try:
+            if "." in val:
+                out[key] = float(val)
+            else:
+                out[key] = int(val)
+        except ValueError:
+            out[key] = val
+    return out
+
+
+def capture(log_path: Path) -> dict[str, Any]:
+    if not log_path.exists():
+        return {"tokens": {}, "pipeline": {}, "log_present": False}
+
+    text = log_path.read_text(errors="replace")
+
+    # Parse TOKEN_REPORT blocks
+    reports = [_parse_token_report(m.group(1)) for m in TOKEN_REPORT_RE.finditer(text)]
+
+    # Aggregate tokens
+    total_input = sum(r.get("input_tokens", r.get("estimated_tokens", 0)) for r in reports)
+    total_output = sum(r.get("output_tokens", 0) for r in reports)
+    files_read = sum(r.get("files_read", 0) for r in reports)
+    tool_calls = sum(r.get("tool_calls", 0) for r in reports)
+
+    # Wave count: highest wave number mentioned (rough heuristic)
+    wave_numbers = [int(m.group(1)) for m in WAVE_RE.finditer(text)]
+    waves = max(wave_numbers) if wave_numbers else 0
+
+    review_fails = len(REVIEW_FAIL_RE.findall(text))
+    bug_fix_cycles = len(BUG_FIX_RE.findall(text))
+
+    return {
+        "log_present": True,
+        "tokens": {
+            "total_input_estimate": total_input,
+            "total_output_estimate": total_output,
+            "files_read_total": files_read,
+            "tool_calls_total": tool_calls,
+            "report_count": len(reports),
+        },
+        "pipeline": {
+            "waves": waves,
+            "review_fail_rounds": review_fails,
+            "bug_fix_cycles": bug_fix_cycles,
+        },
+        "raw_reports": reports,  # kept for debugging
+    }

--- a/benchmarks/scripts/compare_runs.py
+++ b/benchmarks/scripts/compare_runs.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Compare two benchmark metrics.json files (or one against a frozen baseline).
+
+Usage:
+    python3 benchmarks/scripts/compare_runs.py <run_a> <run_b>
+    python3 benchmarks/scripts/compare_runs.py <run_dir>            # vs. baseline
+    python3 benchmarks/scripts/compare_runs.py --baseline=tier1-base64 <run_dir>
+
+Exit codes:
+    0 — no significant regression
+    1 — significant regression (correctness mean drops > REGRESSION_THRESHOLD)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent.parent
+BASELINES_DIR = PIPELINE_ROOT / "benchmarks" / "baselines"
+
+# A correctness drop greater than this is treated as a regression
+REGRESSION_THRESHOLD = 0.05
+
+
+def _load(path_or_name: str) -> dict[str, Any]:
+    """Load a metrics.json. Accepts: a run dir, a metrics.json path, or a baseline name."""
+    p = Path(path_or_name)
+    if p.is_dir():
+        p = p / "metrics.json"
+    if not p.exists():
+        # Try as a baseline name
+        candidate = BASELINES_DIR / f"{path_or_name}.json"
+        if candidate.exists():
+            return json.loads(candidate.read_text())
+        raise FileNotFoundError(f"Cannot resolve metrics file for: {path_or_name}")
+    return json.loads(p.read_text())
+
+
+def _delta(a: float, b: float) -> str:
+    diff = b - a
+    sign = "+" if diff >= 0 else ""
+    return f"{sign}{diff:.3f}"
+
+
+def _fmt_int(a: int, b: int) -> str:
+    diff = b - a
+    sign = "+" if diff >= 0 else ""
+    pct = f" ({sign}{100 * diff / a:.1f}%)" if a else ""
+    return f"{a:>8} → {b:<8}  ({sign}{diff}){pct}"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("run_a", help="First metrics.json or run dir (or omit for baseline)")
+    p.add_argument("run_b", nargs="?", default=None,
+                   help="Second metrics.json or run dir; if omitted, run_a is compared to its baseline")
+    p.add_argument("--baseline", default=None,
+                   help="Force a specific baseline name (overrides metrics.benchmark)")
+    args = p.parse_args()
+
+    if args.run_b is None:
+        # Single arg: compare run_a to its baseline
+        b = _load(args.run_a)
+        baseline_name = args.baseline or b.get("benchmark", "")
+        try:
+            a = _load(baseline_name)
+            label_a = f"baseline:{baseline_name}"
+        except FileNotFoundError:
+            print(f"No baseline found for {baseline_name!r}; nothing to compare against.")
+            print("Tip: copy a metrics.json into benchmarks/baselines/<benchmark>.json to set one.")
+            return 0
+        label_b = f"run:{b.get('run_id', '?')}"
+    else:
+        a = _load(args.run_a)
+        b = _load(args.run_b)
+        label_a = a.get("run_id", args.run_a)
+        label_b = b.get("run_id", args.run_b)
+
+    print(f"A: {label_a}")
+    print(f"B: {label_b}")
+    print()
+
+    a_score = a.get("score", {})
+    b_score = b.get("score", {})
+
+    print("Score:")
+    for k in ("correctness", "efficiency", "composite"):
+        av = a_score.get(k, 0.0)
+        bv = b_score.get(k, 0.0)
+        print(f"  {k:<12} {av:.3f} → {bv:.3f}   ({_delta(av, bv)})")
+
+    print()
+    print("Wall time (seconds):")
+    print(f"  {_fmt_int(a.get('wall_time_seconds', 0), b.get('wall_time_seconds', 0))}")
+
+    print()
+    print("Tokens (estimate):")
+    a_tok = a.get("tokens", {}).get("total_input_estimate", 0)
+    b_tok = b.get("tokens", {}).get("total_input_estimate", 0)
+    print(f"  input_estimate  {_fmt_int(a_tok, b_tok)}")
+
+    print()
+    print("Pipeline:")
+    for k in ("waves", "review_fail_rounds", "bug_fix_cycles"):
+        av = a.get("pipeline", {}).get(k, 0)
+        bv = b.get("pipeline", {}).get(k, 0)
+        print(f"  {k:<22} {_fmt_int(av, bv)}")
+
+    print()
+    print("Code delta:")
+    for k in ("files_changed", "lines_added", "lines_deleted"):
+        av = a.get("code_delta", {}).get(k, 0)
+        bv = b.get("code_delta", {}).get(k, 0)
+        print(f"  {k:<16} {_fmt_int(av, bv)}")
+
+    # Gate
+    correctness_drop = a_score.get("correctness", 0.0) - b_score.get("correctness", 0.0)
+    if correctness_drop > REGRESSION_THRESHOLD:
+        print()
+        print(f"REGRESSION: correctness dropped by {correctness_drop:.3f} (threshold {REGRESSION_THRESHOLD})")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/scripts/run_benchmark.py
+++ b/benchmarks/scripts/run_benchmark.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Run a pipeline benchmark and produce metrics.json.
+
+Three pipeline-invocation modes:
+  --mode=auto      Invoke `claude -p` headlessly. Costs API tokens. Requires claude CLI.
+  --mode=manual    Print instructions, wait for the user to run /orchestrate, then continue.
+  --mode=existing  Skip pipeline run entirely; score whatever is already in --project-dir.
+
+Usage:
+    python3 benchmarks/scripts/run_benchmark.py tier1-base64 --mode=manual
+    python3 benchmarks/scripts/run_benchmark.py tier1-base64 --mode=existing --project-dir=/tmp/already-built
+    python3 benchmarks/scripts/run_benchmark.py tier1-base64 --mode=auto --runs=3
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent.parent
+BENCHMARKS_DIR = PIPELINE_ROOT / "benchmarks"
+RUNS_DIR = BENCHMARKS_DIR / "runs"
+
+sys.path.insert(0, str(BENCHMARKS_DIR / "scripts"))
+from capture_metrics import capture  # noqa: E402
+from score_run import score  # noqa: E402
+
+
+def _now_id() -> str:
+    return dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=PIPELINE_ROOT, text=True, stderr=subprocess.DEVNULL,
+        ).strip()
+        return out or "unknown"
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def setup_skeleton(benchmark: str, work_root: Path) -> Path:
+    """Copy skeleton into work_root, git-init, run init.sh. Return project dir."""
+    skeleton_src = BENCHMARKS_DIR / benchmark / "skeleton"
+    if not skeleton_src.is_dir():
+        raise FileNotFoundError(f"Skeleton missing: {skeleton_src}")
+
+    project_dir = work_root / "project"
+    shutil.copytree(skeleton_src, project_dir)
+
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "benchmark",
+        "GIT_AUTHOR_EMAIL": "benchmark@local",
+        "GIT_COMMITTER_NAME": "benchmark",
+        "GIT_COMMITTER_EMAIL": "benchmark@local",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=project_dir, check=True, env=env)
+    subprocess.run(["git", "add", "."], cwd=project_dir, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", "skeleton baseline"],
+                   cwd=project_dir, check=True, env=env)
+
+    init_sh = PIPELINE_ROOT / "init.sh"
+    proc = subprocess.run(
+        ["bash", str(init_sh), str(project_dir), "--stack=python"],
+        capture_output=True, text=True, timeout=60,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"init.sh failed: {proc.stderr}")
+
+    # Re-commit so post-bootstrap state is the diff baseline for code-delta metrics.
+    subprocess.run(["git", "add", "."], cwd=project_dir, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", "post-bootstrap"],
+                   cwd=project_dir, check=True, env=env, capture_output=True)
+    return project_dir
+
+
+def invoke_pipeline_auto(project_dir: Path, feature_request: str, log_path: Path) -> int:
+    """Run claude -p headlessly. Returns wall seconds."""
+    cli = shutil.which("claude")
+    if cli is None:
+        raise RuntimeError("`claude` CLI not on PATH; use --mode=manual or set --cli-cmd")
+    prompt = f"/orchestrate\n\n{feature_request}"
+    started = time.time()
+    with log_path.open("w") as logf:
+        proc = subprocess.run(
+            [cli, "-p", prompt],
+            cwd=project_dir,
+            stdout=logf, stderr=subprocess.STDOUT,
+            text=True,
+        )
+    elapsed = int(time.time() - started)
+    if proc.returncode != 0:
+        print(f"WARNING: claude exited {proc.returncode}; metrics may be partial")
+    return elapsed
+
+
+def invoke_pipeline_manual(project_dir: Path, log_path: Path) -> int:
+    """Print instructions, wait for user keypress."""
+    print()
+    print("=" * 60)
+    print("MANUAL MODE")
+    print("=" * 60)
+    print(f"  1. cd {project_dir}")
+    print(f"  2. Open Claude Code there and run:")
+    print(f"     /orchestrate {BENCHMARKS_DIR.relative_to(PIPELINE_ROOT)}/<benchmark>/feature-request.md")
+    print(f"     (paste the contents of feature-request.md as the request)")
+    print(f"  3. Save the session transcript to: {log_path}")
+    print(f"     (or leave empty — metrics will be partial without it)")
+    print("=" * 60)
+    started = time.time()
+    input("Press ENTER when /orchestrate has finished... ")
+    elapsed = int(time.time() - started)
+    if not log_path.exists():
+        log_path.write_text("")  # empty placeholder
+    return elapsed
+
+
+def run_tests(project_dir: Path, fixtures_dir: Path, run_dir: Path) -> dict[str, Any]:
+    prop_json = run_dir / "property_results.json"
+    unit_json = run_dir / "unit_results.json"
+
+    prop_proc = subprocess.run(
+        [sys.executable, str(fixtures_dir / "property_tests.py"),
+         "--project", str(project_dir),
+         "--json", str(prop_json),
+         "--runs", "1000"],
+        capture_output=True, text=True, timeout=120,
+    )
+    print(prop_proc.stdout)
+    if prop_proc.returncode == 2:
+        print(f"  Property suite: discovery failed (exit 2)")
+
+    unit_proc = subprocess.run(
+        [sys.executable, str(fixtures_dir / "unit_tests.py"),
+         "--project", str(project_dir),
+         "--json", str(unit_json)],
+        capture_output=True, text=True, timeout=60,
+    )
+    print(unit_proc.stdout)
+
+    prop = json.loads(prop_json.read_text()) if prop_json.exists() else {"error": "missing"}
+    unit = json.loads(unit_json.read_text()) if unit_json.exists() else {"error": "missing"}
+    return {"property": prop, "unit": unit}
+
+
+def collect_code_delta(project_dir: Path) -> dict[str, int]:
+    """Diff against the post-bootstrap commit to count code added by the pipeline.
+
+    Tolerant of non-git project dirs (e.g. --mode=existing on a plain dir).
+    """
+    is_git = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=project_dir, capture_output=True, text=True,
+    ).returncode == 0
+    if not is_git:
+        return {"files_changed": 0, "lines_added": 0, "lines_deleted": 0}
+
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--shortstat", "HEAD"],
+            cwd=project_dir, text=True, stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return {"files_changed": 0, "lines_added": 0, "lines_deleted": 0}
+
+    # Format: " 3 files changed, 187 insertions(+), 4 deletions(-)"
+    files, added, deleted = 0, 0, 0
+    for token in out.replace(",", "").split():
+        if token.isdigit():
+            n = int(token)
+            if "file" in out[out.index(token):out.index(token)+10]:
+                files = files or n
+            elif "insertion" in out[out.index(token):out.index(token)+15]:
+                added = added or n
+            elif "deletion" in out[out.index(token):out.index(token)+15]:
+                deleted = deleted or n
+
+    # Also count untracked files (pipeline may not have committed)
+    try:
+        untracked = subprocess.check_output(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=project_dir, text=True,
+        ).strip().splitlines()
+        for u in untracked:
+            files += 1
+            try:
+                added += sum(1 for _ in (project_dir / u).read_text().splitlines())
+            except (OSError, UnicodeDecodeError):
+                pass
+    except subprocess.CalledProcessError:
+        pass
+
+    return {"files_changed": files, "lines_added": added, "lines_deleted": deleted}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("benchmark", help="Benchmark name (e.g. tier1-base64)")
+    p.add_argument("--mode", choices=["auto", "manual", "existing"], default="manual")
+    p.add_argument("--project-dir", default=None,
+                   help="(--mode=existing) project dir to score; otherwise a temp dir is used")
+    p.add_argument("--runs-dir", default=None,
+                   help="Override runs/ output directory (default: benchmarks/runs/)")
+    p.add_argument("--keep-workdir", action="store_true",
+                   help="Don't delete the work dir at the end")
+    p.add_argument("--log-path", default=None,
+                   help="Path to capture (auto) or read (manual) the pipeline log")
+    args = p.parse_args()
+
+    benchmark_dir = BENCHMARKS_DIR / args.benchmark
+    if not benchmark_dir.is_dir():
+        print(f"ERROR: benchmark not found: {benchmark_dir}")
+        return 1
+
+    runs_dir = Path(args.runs_dir) if args.runs_dir else RUNS_DIR
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_id = f"{_now_id()}-{_git_sha()}-{args.benchmark}"
+    run_dir = runs_dir / run_id
+    run_dir.mkdir()
+
+    log_path = Path(args.log_path) if args.log_path else (run_dir / "pipeline.log")
+
+    # 1. Setup project dir
+    if args.mode == "existing":
+        if not args.project_dir:
+            print("ERROR: --mode=existing requires --project-dir")
+            return 1
+        project_dir = Path(args.project_dir)
+        if not project_dir.is_dir():
+            print(f"ERROR: --project-dir does not exist: {project_dir}")
+            return 1
+        work_root = None
+        wall_seconds = 0
+    else:
+        work_root = Path(tempfile.mkdtemp(prefix=f"bench-{args.benchmark}-"))
+        print(f"Work dir: {work_root}")
+        project_dir = setup_skeleton(args.benchmark, work_root)
+
+        # 2. Run pipeline
+        if args.mode == "auto":
+            wall_seconds = invoke_pipeline_auto(
+                project_dir, (benchmark_dir / "feature-request.md").read_text(), log_path
+            )
+        else:  # manual
+            wall_seconds = invoke_pipeline_manual(project_dir, log_path)
+
+    # 3. Run tests
+    print()
+    print("Running tests against produced code...")
+    test_results = run_tests(project_dir, benchmark_dir / "fixtures", run_dir)
+
+    # 4. Code delta
+    code_delta = collect_code_delta(project_dir)
+
+    # 5. Capture pipeline metrics from log
+    pipeline_metrics = capture(log_path) if log_path.exists() else {
+        "tokens": {}, "pipeline": {}, "log_present": False,
+    }
+
+    # 6. Compose + score
+    metrics = {
+        "run_id": run_id,
+        "benchmark": args.benchmark,
+        "pipeline_sha": _git_sha(),
+        "mode": args.mode,
+        "wall_time_seconds": wall_seconds,
+        "tokens": pipeline_metrics.get("tokens", {}),
+        "pipeline": pipeline_metrics.get("pipeline", {}),
+        "code_delta": code_delta,
+        "tests": test_results,
+    }
+    metrics["score"] = score(metrics)
+
+    metrics_path = run_dir / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics, indent=2))
+    print()
+    print(f"Metrics written: {metrics_path}")
+    print(f"  Correctness: {metrics['score']['correctness']:.3f}")
+    print(f"  Composite:   {metrics['score']['composite']:.3f}")
+
+    # 7. Cleanup work dir
+    if work_root and not args.keep_workdir:
+        # Save artifacts dir under run before nuking
+        artifacts = run_dir / "artifacts"
+        if not artifacts.exists():
+            shutil.copytree(project_dir, artifacts, ignore=shutil.ignore_patterns(".git", ".claude"))
+        shutil.rmtree(work_root, ignore_errors=True)
+    elif work_root:
+        print(f"Kept work dir: {work_root}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/scripts/score_run.py
+++ b/benchmarks/scripts/score_run.py
@@ -1,0 +1,91 @@
+"""Compute a composite score from a metrics dict.
+
+Correctness: weighted average of test-suite pass rates (per spec.md weights).
+Efficiency: tokens + wall time vs. baseline (1.0 if no baseline).
+Composite: 0.7 * correctness + 0.3 * efficiency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent.parent
+BASELINES_DIR = PIPELINE_ROOT / "benchmarks" / "baselines"
+
+SCORING_WEIGHTS = {
+    "property": 0.5,
+    "unit":     0.2,
+    "discovery": 0.3,  # was "functional contract" in spec — module + CLI exist = pipeline produced something
+}
+
+
+def _suite_pct(suite_result: dict[str, Any], key_total: str = "total", key_pass: str = "passed") -> float:
+    """Extract a 0-1 pass rate from a suite result. Returns 0 on errors."""
+    if not suite_result or "error" in suite_result:
+        return 0.0
+    total = suite_result.get(key_total, 0)
+    passed = suite_result.get(key_pass, 0)
+    if not total:
+        return 0.0
+    return passed / total
+
+
+def _correctness(metrics: dict[str, Any]) -> float:
+    tests = metrics.get("tests", {})
+    prop = tests.get("property", {})
+    unit = tests.get("unit", {})
+
+    prop_pct = _suite_pct(prop, "total_run", "total_passed")
+    unit_pct = _suite_pct(unit, "total", "passed")
+
+    # Discovery: if either suite ran successfully (not "error"), the module was discoverable.
+    discovery = 0.0 if (prop.get("error") and unit.get("error")) else 1.0
+
+    score = (
+        SCORING_WEIGHTS["property"] * prop_pct
+        + SCORING_WEIGHTS["unit"] * unit_pct
+        + SCORING_WEIGHTS["discovery"] * discovery
+    )
+    return round(score, 4)
+
+
+def _load_baseline(benchmark: str) -> dict[str, Any] | None:
+    p = BASELINES_DIR / f"{benchmark}.json"
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def _efficiency(metrics: dict[str, Any]) -> float:
+    """1.0 = matches baseline. >1.0 = better (cheaper/faster). <1.0 = regressed."""
+    baseline = _load_baseline(metrics.get("benchmark", ""))
+    if baseline is None:
+        return 1.0  # no baseline yet; don't penalize
+
+    base_wall = baseline.get("wall_time_seconds", 0) or 1
+    base_tokens = baseline.get("tokens", {}).get("total_input_estimate", 0) or 1
+
+    wall = metrics.get("wall_time_seconds", 0) or 1
+    tokens = metrics.get("tokens", {}).get("total_input_estimate", 0) or 1
+
+    wall_ratio = base_wall / wall if wall else 1.0
+    token_ratio = base_tokens / tokens if tokens else 1.0
+    # Average; clip to a reasonable range so a single outlier doesn't dominate
+    eff = (wall_ratio + token_ratio) / 2
+    return round(max(0.1, min(eff, 3.0)), 4)
+
+
+def score(metrics: dict[str, Any]) -> dict[str, float]:
+    correctness = _correctness(metrics)
+    efficiency = _efficiency(metrics)
+    composite = round(0.7 * correctness + 0.3 * min(efficiency, 1.0), 4)
+    return {
+        "correctness": correctness,
+        "efficiency": efficiency,
+        "composite": composite,
+    }

--- a/benchmarks/tier1-base64/feature-request.md
+++ b/benchmarks/tier1-base64/feature-request.md
@@ -1,0 +1,26 @@
+# Feature Request: base64 module
+
+Please add a base64 encoder/decoder to this Python project.
+
+## Requirements
+
+- Implement standard base64 encoding and decoding per RFC 4648 (the standard alphabet, with `+` and `/`, padding with `=`).
+- Provide two top-level functions in a module under `src/`:
+  - `encode(data: bytes) -> str` — encodes raw bytes to a base64 string
+  - `decode(text: str) -> bytes` — decodes a base64 string back to raw bytes
+- Add a small CLI (`python -m <module>`) with two subcommands:
+  - `encode <file>` — reads the file as bytes, prints base64 to stdout
+  - `decode <file>` — reads the file as base64 text, prints raw bytes to stdout
+- Decoding should raise `ValueError` with a clear message for malformed input (bad characters, wrong padding, etc.).
+- Empty input should round-trip cleanly: `encode(b"") == ""` and `decode("") == b""`.
+- Include unit tests covering normal and edge cases.
+
+## Out of scope
+
+- URL-safe base64 (the `_-` alphabet variant) — not needed.
+- Streaming / chunked APIs — single-call functions are fine.
+- Custom alphabets or padding schemes.
+
+## Implementation note
+
+Do **not** import `base64` from the Python standard library to do the work. Implement the encoding/decoding using bit operations against the standard alphabet. This is intentional — the project exists to measure what is produced from scratch.

--- a/benchmarks/tier1-base64/fixtures/_discover.py
+++ b/benchmarks/tier1-base64/fixtures/_discover.py
@@ -1,0 +1,73 @@
+"""Locate the pipeline-produced base64 module.
+
+The pipeline is free to name its module anything (src/base64encoder.py, src/encoding/b64.py, etc.).
+The fixtures here import via discovery rather than a hardcoded name so the benchmark doesn't
+penalize naming choices.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _candidate_modules(src_root: Path) -> list[Path]:
+    """All .py files under src/ except __init__ stubs."""
+    out: list[Path] = []
+    for p in src_root.rglob("*.py"):
+        if p.name == "__init__.py":
+            continue
+        out.append(p)
+    return out
+
+
+def _load_module_from_path(path: Path, src_root: Path) -> Any | None:
+    rel = path.relative_to(src_root).with_suffix("")
+    mod_name = "src." + ".".join(rel.parts)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    return mod
+
+
+def _looks_like_base64_module(mod: Any) -> bool:
+    enc = getattr(mod, "encode", None)
+    dec = getattr(mod, "decode", None)
+    if not callable(enc) or not callable(dec):
+        return False
+    try:
+        enc_sig = inspect.signature(enc)
+        dec_sig = inspect.signature(dec)
+    except (ValueError, TypeError):
+        return False
+    return len(enc_sig.parameters) == 1 and len(dec_sig.parameters) == 1
+
+
+def discover(project_root: Path) -> Any:
+    """Return the discovered base64 module, or raise ImportError."""
+    src_root = project_root / "src"
+    if not src_root.is_dir():
+        raise ImportError(f"src/ does not exist under {project_root}")
+
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    for path in _candidate_modules(src_root):
+        mod = _load_module_from_path(path, src_root)
+        if mod is not None and _looks_like_base64_module(mod):
+            return mod
+
+    raise ImportError(
+        "No module under src/ exposes encode(x) and decode(x) with the expected signature. "
+        "The pipeline did not produce a recognizable base64 module."
+    )

--- a/benchmarks/tier1-base64/fixtures/property_tests.py
+++ b/benchmarks/tier1-base64/fixtures/property_tests.py
@@ -1,0 +1,197 @@
+"""Property-based oracle for the base64 round-trip benchmark.
+
+Run from the project root:
+    python3 fixtures/property_tests.py [--project=PATH] [--runs=N]
+
+Exit codes:
+    0 — all properties hold
+    1 — at least one property failed
+    2 — module not discoverable
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64 as _stdlib_base64
+import json
+import os
+import random
+import string
+import sys
+from pathlib import Path
+
+# Allow `python3 fixtures/property_tests.py` to find _discover when cwd != fixtures/
+sys.path.insert(0, str(Path(__file__).parent))
+from _discover import discover  # noqa: E402
+
+ALPHABET = set(string.ascii_letters + string.digits + "+/=")
+
+
+def _gen_inputs(n_runs: int, seed: int) -> list[bytes]:
+    rng = random.Random(seed)
+    inputs: list[bytes] = [b""]
+    inputs.extend(bytes([0]) * k for k in range(1, 4))
+    inputs.extend(bytes([0xFF]) * k for k in range(1, 4))
+    inputs.extend(bytes(range(256)) for _ in range(2))
+    while len(inputs) < n_runs:
+        length = rng.randint(0, 256)
+        inputs.append(bytes(rng.randint(0, 255) for _ in range(length)))
+    return inputs[:n_runs]
+
+
+def _check_round_trip(mod, inputs: list[bytes]) -> tuple[int, list[str]]:
+    fails: list[str] = []
+    passed = 0
+    for x in inputs:
+        try:
+            got = mod.decode(mod.encode(x))
+        except Exception as e:
+            fails.append(f"round_trip raised on len={len(x)}: {type(e).__name__}: {e}")
+            continue
+        if got != x:
+            fails.append(f"round_trip mismatch on len={len(x)}: got {got!r}, expected {x!r}")
+        else:
+            passed += 1
+    return passed, fails
+
+
+def _check_alphabet(mod, inputs: list[bytes]) -> tuple[int, list[str]]:
+    fails: list[str] = []
+    passed = 0
+    for x in inputs:
+        try:
+            s = mod.encode(x)
+        except Exception as e:
+            fails.append(f"encode raised on len={len(x)}: {e}")
+            continue
+        bad = [c for c in s if c not in ALPHABET]
+        if bad:
+            fails.append(f"alphabet violation on len={len(x)}: bad chars {bad[:5]}")
+        else:
+            passed += 1
+    return passed, fails
+
+
+def _check_padding(mod, inputs: list[bytes]) -> tuple[int, list[str]]:
+    fails: list[str] = []
+    passed = 0
+    for x in inputs:
+        try:
+            s = mod.encode(x)
+        except Exception as e:
+            fails.append(f"encode raised on len={len(x)}: {e}")
+            continue
+        if len(s) % 4 != 0:
+            fails.append(f"length not multiple of 4 on len={len(x)}: encoded len={len(s)}")
+            continue
+        # Padding `=` may only appear at the end
+        if "=" in s:
+            first_eq = s.index("=")
+            if not all(c == "=" for c in s[first_eq:]):
+                fails.append(f"padding not at end on len={len(x)}: {s!r}")
+                continue
+            if s.count("=") > 2:
+                fails.append(f"too much padding on len={len(x)}: {s!r}")
+                continue
+        passed += 1
+    return passed, fails
+
+
+def _check_empty(mod) -> tuple[int, list[str]]:
+    fails: list[str] = []
+    try:
+        if mod.encode(b"") != "":
+            fails.append(f"encode(b'') != '' (got {mod.encode(b'')!r})")
+        if mod.decode("") != b"":
+            fails.append(f"decode('') != b'' (got {mod.decode('')!r})")
+    except Exception as e:
+        fails.append(f"empty round-trip raised: {type(e).__name__}: {e}")
+    return (1 if not fails else 0), fails
+
+
+def _check_reference(mod, inputs: list[bytes]) -> tuple[int, list[str]]:
+    fails: list[str] = []
+    passed = 0
+    for x in inputs:
+        try:
+            got = mod.encode(x)
+        except Exception as e:
+            fails.append(f"encode raised on len={len(x)}: {e}")
+            continue
+        expected = _stdlib_base64.b64encode(x).decode("ascii")
+        if got != expected:
+            fails.append(f"reference mismatch on len={len(x)}: got {got!r}, expected {expected!r}")
+        else:
+            passed += 1
+    return passed, fails
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.getcwd(), help="Project root containing src/")
+    parser.add_argument("--runs", type=int, default=1000, help="Number of fuzzed inputs")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--json", default=None, help="Write structured results to this path")
+    parser.add_argument("--max-fails-shown", type=int, default=5)
+    args = parser.parse_args()
+
+    try:
+        mod = discover(Path(args.project))
+    except ImportError as e:
+        print(f"DISCOVERY FAILED: {e}")
+        if args.json:
+            Path(args.json).write_text(json.dumps({"error": "discovery_failed", "detail": str(e)}))
+        return 2
+
+    inputs = _gen_inputs(args.runs, args.seed)
+
+    suites = [
+        ("round_trip",         lambda: _check_round_trip(mod, inputs)),
+        ("alphabet",           lambda: _check_alphabet(mod, inputs)),
+        ("padding",            lambda: _check_padding(mod, inputs)),
+        ("empty_round_trip",   lambda: _check_empty(mod)),
+        ("reference_match",    lambda: _check_reference(mod, inputs)),
+    ]
+
+    suite_results: dict[str, dict] = {}
+    total_pass = 0
+    total_run = 0
+    any_fail = False
+
+    for name, fn in suites:
+        passed, fails = fn()
+        run_count = len(inputs) if name != "empty_round_trip" else 1
+        suite_results[name] = {
+            "passed": passed,
+            "total": run_count,
+            "failures_sample": fails[: args.max_fails_shown],
+            "failure_count": len(fails),
+        }
+        total_pass += passed
+        total_run += run_count
+        if fails:
+            any_fail = True
+
+    pct = 100.0 * total_pass / total_run if total_run else 0.0
+    print(f"Property suite — module: {mod.__name__}")
+    for name, r in suite_results.items():
+        status = "OK" if r["failure_count"] == 0 else f"FAIL ({r['failure_count']})"
+        print(f"  {name:<22} {r['passed']:>5}/{r['total']:<5}  [{status}]")
+        for f in r["failures_sample"]:
+            print(f"      - {f}")
+    print(f"Summary: Passed: {total_pass}/{total_run} ({pct:.1f}%)")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps({
+            "module": mod.__name__,
+            "suites": suite_results,
+            "total_passed": total_pass,
+            "total_run": total_run,
+            "pass_pct": pct,
+        }, indent=2))
+
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tier1-base64/fixtures/unit_tests.py
+++ b/benchmarks/tier1-base64/fixtures/unit_tests.py
@@ -1,0 +1,190 @@
+"""Unit + functional tests for the pipeline-produced base64 module.
+
+Run from the project root:
+    python3 fixtures/unit_tests.py [--project=PATH]
+
+Exit codes:
+    0 — all tests pass
+    1 — at least one failed
+    2 — module not discoverable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _discover import discover  # noqa: E402
+
+
+def _run_test(name: str, fn) -> tuple[bool, str]:
+    try:
+        fn()
+        return True, ""
+    except AssertionError as e:
+        return False, f"AssertionError: {e}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.getcwd())
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    project = Path(args.project)
+    try:
+        mod = discover(project)
+    except ImportError as e:
+        print(f"DISCOVERY FAILED: {e}")
+        if args.json:
+            Path(args.json).write_text(json.dumps({"error": "discovery_failed", "detail": str(e)}))
+        return 2
+
+    # The module exposing encode/decode (e.g. "src.b64")
+    mod_dotted = mod.__name__
+    # The CLI is more idiomatically invoked as `python -m <package>`. Pick the
+    # parent package as the preferred CLI target, fall back to the module itself.
+    parent_pkg = mod_dotted.rsplit(".", 1)[0] if "." in mod_dotted else mod_dotted
+    cli_candidates = [parent_pkg, mod_dotted] if parent_pkg != mod_dotted else [mod_dotted]
+
+    def _try_cli(args: list[str], binary_stdout: bool = False) -> tuple[int, bytes, str, str]:
+        """Try each CLI candidate; return (exit_code, stdout_bytes, stderr_text, used_target)."""
+        last_proc = None
+        for target in cli_candidates:
+            proc = subprocess.run(
+                [sys.executable, "-m", target] + args,
+                cwd=project, capture_output=True, timeout=15,
+            )
+            last_proc = (proc, target)
+            err_text = proc.stderr.decode("utf-8", errors="replace")
+            err_low = (err_text + proc.stdout.decode("utf-8", errors="replace")).lower()
+            if "no module named" in err_low or "modulenotfounderror" in err_low:
+                continue
+            return proc.returncode, proc.stdout, err_text, target
+        if last_proc:
+            proc, target = last_proc
+            return (
+                proc.returncode,
+                proc.stdout,
+                proc.stderr.decode("utf-8", errors="replace"),
+                target,
+            )
+        return 1, b"", "no CLI candidates", ""
+
+    def t_module_exists() -> None:
+        assert mod is not None
+
+    def t_decode_rejects_bad_chars() -> None:
+        try:
+            mod.decode("!@#$%^&*")
+        except ValueError:
+            return
+        except Exception as e:
+            raise AssertionError(f"expected ValueError, got {type(e).__name__}: {e}") from e
+        raise AssertionError("expected ValueError, no exception raised")
+
+    def t_decode_rejects_bad_padding() -> None:
+        try:
+            mod.decode("abc")  # length not multiple of 4, no padding
+        except ValueError:
+            return
+        except Exception as e:
+            raise AssertionError(f"expected ValueError, got {type(e).__name__}: {e}") from e
+        raise AssertionError("expected ValueError, no exception raised")
+
+    def t_known_vector_hello() -> None:
+        # "hello" -> "aGVsbG8="
+        assert mod.encode(b"hello") == "aGVsbG8=", f"got {mod.encode(b'hello')!r}"
+        assert mod.decode("aGVsbG8=") == b"hello"
+
+    def t_known_vector_pad1() -> None:
+        # 2-byte input -> 1 char of padding
+        assert mod.encode(b"hi") == "aGk=", f"got {mod.encode(b'hi')!r}"
+
+    def t_known_vector_pad2() -> None:
+        # 1-byte input -> 2 chars of padding
+        assert mod.encode(b"f") == "Zg==", f"got {mod.encode(b'f')!r}"
+
+    def t_cli_module_invocable() -> None:
+        # `python -m <pkg>` should at least not crash with import errors.
+        rc, out, err, target = _try_cli([])
+        combined = (out.decode("utf-8", errors="replace") + err).lower()
+        assert "no module named" not in combined and "modulenotfounderror" not in combined, (
+            f"none of {cli_candidates} are runnable CLIs: {combined[:200]}"
+        )
+
+    def t_cli_encode_decode_round_trip() -> None:
+        original = b"benchmark-content-\x00\x01\x02\xff"
+        with tempfile.NamedTemporaryFile(delete=False, mode="wb") as f:
+            f.write(original)
+            input_path = f.name
+        try:
+            rc, out, err, target = _try_cli(["encode", input_path])
+            if rc != 0:
+                raise AssertionError(f"CLI encode exited {rc} (target={target}): {err[:200]}")
+            encoded = out.decode("ascii", errors="replace").strip()
+            assert encoded, f"CLI encode produced empty output (target={target})"
+
+            with tempfile.NamedTemporaryFile(delete=False, mode="w") as f2:
+                f2.write(encoded)
+                enc_path = f2.name
+
+            rc2, out2, err2, target2 = _try_cli(["decode", enc_path])
+            if rc2 != 0:
+                raise AssertionError(f"CLI decode exited {rc2} (target={target2}): {err2[:200]}")
+            # Trim a single trailing newline if the CLI added one (common with `print()`)
+            decoded = out2[:-1] if out2.endswith(b"\n") and out2[:-1] == original else out2
+            assert decoded == original, (
+                f"CLI round-trip mismatch: got {decoded!r}, expected {original!r} (target={target2})"
+            )
+        finally:
+            try:
+                os.unlink(input_path)
+            except OSError:
+                pass
+
+    tests = [
+        ("module_exists",                 t_module_exists),
+        ("decode_rejects_bad_chars",      t_decode_rejects_bad_chars),
+        ("decode_rejects_bad_padding",    t_decode_rejects_bad_padding),
+        ("known_vector_hello",            t_known_vector_hello),
+        ("known_vector_pad1",             t_known_vector_pad1),
+        ("known_vector_pad2",             t_known_vector_pad2),
+        ("cli_module_invocable",          t_cli_module_invocable),
+        ("cli_round_trip",                t_cli_encode_decode_round_trip),
+    ]
+
+    results = []
+    passed = 0
+    for name, fn in tests:
+        ok, detail = _run_test(name, fn)
+        results.append({"name": name, "passed": ok, "detail": detail})
+        passed += int(ok)
+        status = "OK" if ok else "FAIL"
+        print(f"  {name:<32} [{status}]" + (f"  {detail}" if not ok else ""))
+
+    pct = 100.0 * passed / len(tests)
+    print(f"Summary: Passed: {passed}/{len(tests)} ({pct:.1f}%)")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps({
+            "module": mod_dotted,
+            "tests": results,
+            "passed": passed,
+            "total": len(tests),
+            "pass_pct": pct,
+        }, indent=2))
+
+    return 0 if passed == len(tests) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tier1-base64/skeleton/CLAUDE.md
+++ b/benchmarks/tier1-base64/skeleton/CLAUDE.md
@@ -1,0 +1,24 @@
+# Claude Code Instructions
+
+## Session Initialization
+
+Role: You are a senior Python developer.
+
+Context: This is a small Python project used as a pipeline benchmark fixture. It is intentionally minimal so the pipeline's behavior is what's measured, not the surrounding codebase.
+
+Setup: At the start of each session, read `.claude/ORCHESTRATOR.md` for architecture, conventions, and current state.
+
+## Workflow Rules
+
+See agent definitions in `.claude/agents/` for per-role guidance (planning, implementation, review, testing).
+
+## Build & Test (Mandatory Skills)
+
+**PreToolUse hooks enforce these rules — violations are blocked automatically.**
+
+- **Builds:** Use the `build-runner` skill (or `python3 .claude/scripts/python/build.py` for subagents)
+- **Tests:** Use the `test-runner` skill (or `python3 .claude/scripts/python/test.py` for subagents)
+- **Forbidden:** raw `pytest`, `python -m pytest`, `mypy` — all blocked by hook
+- **Also blocked:** `grep`, `cat`, `head`, `tail`, `find`, `sed`, `awk` via Bash — use Grep, Read, Glob, Edit tools instead
+
+When presenting test results: show the Summary line first, then per-target coverage, then failures table (if any). Never invent results.

--- a/benchmarks/tier1-base64/skeleton/ORCHESTRATOR.md
+++ b/benchmarks/tier1-base64/skeleton/ORCHESTRATOR.md
@@ -1,0 +1,70 @@
+# ORCHESTRATOR.md
+
+> Living architecture reference. Updated at the end of each orchestration session.
+
+## Project Overview
+
+**Name:** base64bench
+**Stack:** python
+**Description:** Benchmark fixture project. The pipeline is asked to add a base64 module here, and its output is scored on correctness (round-trip property tests) and efficiency (tokens, time, waves).
+
+## Targets / Entry Points
+
+| Target | Platform | Description |
+|--------|----------|-------------|
+| base64bench | Python 3.9+ | Library + CLI module |
+
+## Directory Structure
+
+```
+src/             # implementation goes here
+pyproject.toml   # project config
+```
+
+## Architecture
+
+Library-first. Pure-Python implementation of standard base64 (RFC 4648). A small CLI wraps it.
+
+## Key Services / Modules
+
+| Service | Responsibility | File(s) |
+|---------|---------------|---------|
+| (to be added) | base64 encode/decode | src/ |
+
+## Conventions
+
+### Naming
+- Snake_case functions and modules.
+
+### Patterns
+- Pure functions; no global state.
+- Type hints on all public APIs.
+
+### Error Handling
+- Raise `ValueError` with a clear message for invalid base64 input.
+
+## Testing
+
+### Structure
+- Test files: `test_*.py` at project root
+- Use pytest
+
+### Coverage Requirements
+- Minimum: 90% for new code
+
+## Known Fragile Areas
+
+| Area | Risk | Mitigation |
+|------|------|------------|
+| (none yet) | | |
+
+## Anti-Patterns (Do NOT)
+
+- Do NOT call `base64` from the standard library — implement encode/decode from scratch using bit operations on the alphabet. (The benchmark exists to measure what the pipeline produces; wrapping `base64` defeats it.)
+
+## Current State
+
+- **Last updated:** initial
+- **Build status:** clean
+- **Test status:** no tests yet
+- **Open work:** add base64 encode/decode module per feature-request.md

--- a/benchmarks/tier1-base64/skeleton/pyproject.toml
+++ b/benchmarks/tier1-base64/skeleton/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "base64bench"
+version = "0.0.1"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+
+[tool.mypy]
+strict = true

--- a/benchmarks/tier1-base64/spec.md
+++ b/benchmarks/tier1-base64/spec.md
@@ -1,0 +1,41 @@
+# Acceptance Spec: tier1-base64
+
+This spec is **not** given to the pipeline. It is the scorer's contract — what "correct output" means.
+
+## Functional contract
+
+- An importable Python module exists under `src/` exposing `encode(bytes) -> str` and `decode(str) -> bytes`.
+- A CLI is invocable as `python -m <module>` with `encode <file>` and `decode <file>` subcommands.
+
+## Property contract (the oracle)
+
+For arbitrary byte strings `x`:
+
+1. **Round-trip:** `decode(encode(x)) == x` for all `x` (including empty bytes, all-zero bytes, all-0xFF bytes, lengths 1..256).
+2. **Output validity:** `encode(x)` consists only of characters in the standard base64 alphabet (`A-Za-z0-9+/=`).
+3. **Padding correctness:** `len(encode(x)) % 4 == 0` for all `x`; padding `=` only appears at the end.
+4. **Empty round-trip:** `encode(b"") == ""` and `decode("") == b""`.
+5. **Reference equivalence:** `encode(x)` matches Python's stdlib `base64.b64encode(x).decode("ascii")` for all `x`.
+
+## Negative contract
+
+- `decode` raises `ValueError` (not a generic `Exception`) on:
+  - Strings containing non-alphabet characters (e.g., `"!@#$"`).
+  - Strings with invalid padding (e.g., `"abc"` — length not a multiple of 4 with no padding).
+
+## Scoring weights
+
+| Component | Weight |
+|-----------|--------|
+| Property tests (round-trip + validity + padding + empty + reference) | 0.5 |
+| Unit tests (negative cases, CLI smoke) | 0.2 |
+| Functional contract (module exists, CLI exists) | 0.3 |
+
+Composite correctness = weighted average of pass percentages.
+
+## Out of scope (not penalized if absent)
+
+- URL-safe variant
+- Streaming / chunked APIs
+- Performance optimizations
+- Type stub files


### PR DESCRIPTION
## Summary

- Introduces `benchmarks/` — an objective regression-testing harness for the pipeline. Frozen feature request + property-based oracle = changes in score reflect changes in the pipeline, not the input.
- **Tier 1** (`tier1-base64`): pipeline must implement RFC 4648 base64. Oracle is 4001-input round-trip + reference-equivalence + alphabet/padding checks, plus 8 unit/CLI tests. Composite score = 0.7·correctness + 0.3·efficiency.
- Three invocation modes: `auto` (headless `claude -p`, costs tokens), `manual` (pause for `/orchestrate`, then score), `existing` (score an already-built dir — useful for harness validation without API spend).
- Mutation testing of pipeline prompts is filed separately as MILL5/agentic-dev-pipeline#226 (depends on Tier 1 + statistical mode).

## Design notes

- Skeleton is committed under `benchmarks/tier1-base64/skeleton/` (source only — `.claude/` is generated per-run by `init.sh` to avoid relative-symlink portability issues when copying to a temp dir).
- Fixtures use a `_discover.py` helper to find the pipeline-produced module dynamically — the pipeline isn't penalized for naming choices.
- Scoring is configured in `score_run.py`; weights match `spec.md`. Efficiency uses `benchmarks/baselines/<name>.json` as reference (no baseline yet → efficiency = 1.0; gate is correctness-only until a baseline lands).
- Overlay-config seam baked in for planned consumer-diag mode (Phase 2): same harness, layer in a consuming repo's `.claude/local/*.md` to measure local-context impact.

## Test plan

- [x] `--mode=existing` against a hand-written reference base64 → 4001/4001 property tests, 8/8 unit tests, composite **1.000**.
- [x] `init.sh --stack=python` against the skeleton bootstraps cleanly.
- [ ] First real `--mode=manual` run end-to-end (driver: maintainer with API budget).
- [ ] Establish baseline (`benchmarks/baselines/tier1-base64.json`) from the first representative run.
- [ ] Wire into CI (separate PR — needs the baseline + statistical mode first).

## Known follow-ups

- `--runs=N` statistical mode (LLM output is non-deterministic; single-run scores swing 5–15%). README documents this; scoring is best-effort until then.
- Token capture is regex-based on `---TOKEN_REPORT---` blocks in the session log. Empty in `auto` mode if claude CLI doesn't surface intermediate agent output; in `manual` mode, paste a transcript to populate.
- Mutation testing follow-up: MILL5/agentic-dev-pipeline#226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)