### PR TITLE
fix(benchmarks): make --mode=auto actually work headless

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,6 +28,33 @@ The harness supports three modes for invoking the pipeline:
 | `auto`     | Headless run — `claude -p` invokes the pipeline non-interactively | API tokens (~$1-5/run) |
 | `existing` | You already have a project dir with a candidate implementation; just score it | Free |
 
+#### How `--mode=auto` is wired up
+
+The harness invokes:
+
+```bash
+claude -p "/orchestrate <feature-request>" \
+    --permission-mode acceptEdits \
+    --allowedTools "Agent,SendMessage,Read,Edit,Write,Bash,Glob,Grep,TaskCreate,..." \
+    --output-format stream-json \
+    --verbose \
+    --max-turns 120
+```
+
+with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in the env. These flags are required for
+non-interactive operation per the [Claude Code headless docs](https://code.claude.com/docs/en/headless):
+
+- `acceptEdits` skips edit/write permission prompts
+- `--allowedTools` pre-approves Agent (subagent spawn) and SendMessage (agent reuse) so
+  the pipeline can run multi-wave without prompting
+- `stream-json` produces a newline-delimited JSON transcript including tool calls and
+  per-message token usage. `capture_metrics.py` parses this to produce trustworthy
+  token counts (vs. text-only manual logs which fall back to regex)
+- `--max-turns 120` is a safety ceiling for runaway loops; legitimate Tier 1 runs are
+  ~30-50 turns
+
+Override via `--max-turns` or `--timeout-seconds` on `run_benchmark.py` if needed.
+
 ### Quick start (manual mode — recommended for first run)
 
 ```bash
@@ -100,10 +127,14 @@ Exits 1 if correctness drops by more than `REGRESSION_THRESHOLD` (currently 0.05
 }
 ```
 
-Token capture is best-effort: it parses `---TOKEN_REPORT---` blocks from the
-session log. In `--mode=manual`, save the session transcript to
-`benchmarks/runs/<id>/pipeline.log` to populate token metrics; otherwise they
-default to zero and only correctness is meaningful.
+Token capture has two paths:
+
+- **`--mode=auto`** uses `--output-format stream-json`, so `capture_metrics.py` reads
+  precise per-message `usage.input_tokens` / `output_tokens` / `cache_read_input_tokens`,
+  attributed by model. These are reliable.
+- **`--mode=manual`** falls back to regex parsing of `---TOKEN_REPORT---` blocks in the
+  log. Save the session transcript to `benchmarks/runs/<id>/pipeline.log` to populate
+  metrics; otherwise tokens default to zero and only correctness is meaningful.
 
 ## Statistical handling (planned, not yet implemented)
 

--- a/benchmarks/scripts/capture_metrics.py
+++ b/benchmarks/scripts/capture_metrics.py
@@ -1,12 +1,19 @@
 """Best-effort extraction of pipeline metrics from a session log.
 
-The log is whatever stdout the pipeline emitted (claude -p output, or a saved
-manual transcript). Parsing is regex-based and lenient — missing fields default
-to None or zero rather than raising. Refine over time.
+The log is whatever stdout the pipeline emitted. Two formats are supported:
+
+1. **Stream-JSON** (`--output-format stream-json`, used by --mode=auto): newline-
+   delimited JSON events including tool calls, subagent results, and per-message
+   token usage. Preferred — yields trustworthy token counts and turn-level detail.
+2. **Plain text** (--mode=manual transcripts, or older runs): falls back to regex
+   parsing of `---TOKEN_REPORT---` blocks and surface heuristics. Less precise.
+
+Missing fields default to None or zero rather than raising.
 """
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -37,11 +44,94 @@ def _parse_token_report(block: str) -> dict[str, Any]:
     return out
 
 
+def _is_stream_json(text: str) -> bool:
+    """Stream-JSON output starts with one or more '{...}' lines."""
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        return line.startswith("{")
+    return False
+
+
+def _capture_stream_json(text: str) -> dict[str, Any]:
+    """Parse stream-json transcript: aggregate token usage, count tool calls, count subagents."""
+    total_input = 0
+    total_output = 0
+    total_cache_read = 0
+    cache_creation = 0
+    tool_calls = 0
+    agent_spawns = 0
+    sendmessage_calls = 0
+    turns = 0
+    by_model: dict[str, dict[str, int]] = {}
+
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw or not raw.startswith("{"):
+            continue
+        try:
+            evt = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        evt_type = evt.get("type", "")
+        if evt_type == "assistant" or evt_type == "user":
+            turns += 1
+
+        # Per-message usage rolls up under the assistant event in stream-json
+        msg = evt.get("message", {}) if isinstance(evt.get("message"), dict) else {}
+        usage = msg.get("usage", {}) if isinstance(msg.get("usage"), dict) else {}
+        if usage:
+            total_input += int(usage.get("input_tokens", 0) or 0)
+            total_output += int(usage.get("output_tokens", 0) or 0)
+            total_cache_read += int(usage.get("cache_read_input_tokens", 0) or 0)
+            cache_creation += int(usage.get("cache_creation_input_tokens", 0) or 0)
+            model = msg.get("model", "unknown")
+            slot = by_model.setdefault(model, {"input": 0, "output": 0, "cache_read": 0})
+            slot["input"] += int(usage.get("input_tokens", 0) or 0)
+            slot["output"] += int(usage.get("output_tokens", 0) or 0)
+            slot["cache_read"] += int(usage.get("cache_read_input_tokens", 0) or 0)
+
+        # Tool use events
+        content = msg.get("content", []) if isinstance(msg.get("content"), list) else []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                tool_calls += 1
+                name = block.get("name", "")
+                if name == "Agent":
+                    agent_spawns += 1
+                elif name == "SendMessage":
+                    sendmessage_calls += 1
+
+    return {
+        "log_present": True,
+        "log_format": "stream-json",
+        "tokens": {
+            "total_input": total_input,
+            "total_output": total_output,
+            "total_cache_read": total_cache_read,
+            "total_cache_creation": cache_creation,
+            "by_model": by_model,
+        },
+        "pipeline": {
+            "turns": turns,
+            "tool_calls": tool_calls,
+            "agent_spawns": agent_spawns,
+            "sendmessage_calls": sendmessage_calls,
+        },
+    }
+
+
 def capture(log_path: Path) -> dict[str, Any]:
     if not log_path.exists():
         return {"tokens": {}, "pipeline": {}, "log_present": False}
 
     text = log_path.read_text(errors="replace")
+    if _is_stream_json(text):
+        return _capture_stream_json(text)
 
     # Parse TOKEN_REPORT blocks
     reports = [_parse_token_report(m.group(1)) for m in TOKEN_REPORT_RE.finditer(text)]
@@ -61,6 +151,7 @@ def capture(log_path: Path) -> dict[str, Any]:
 
     return {
         "log_present": True,
+        "log_format": "text",
         "tokens": {
             "total_input_estimate": total_input,
             "total_output_estimate": total_output,

--- a/benchmarks/scripts/compare_runs.py
+++ b/benchmarks/scripts/compare_runs.py
@@ -98,14 +98,22 @@ def main() -> int:
     print(f"  {_fmt_int(a.get('wall_time_seconds', 0), b.get('wall_time_seconds', 0))}")
 
     print()
-    print("Tokens (estimate):")
-    a_tok = a.get("tokens", {}).get("total_input_estimate", 0)
-    b_tok = b.get("tokens", {}).get("total_input_estimate", 0)
-    print(f"  input_estimate  {_fmt_int(a_tok, b_tok)}")
+    print("Tokens:")
+    a_tokens = a.get("tokens", {})
+    b_tokens = b.get("tokens", {})
+    a_tok = a_tokens.get("total_input") or a_tokens.get("total_input_estimate") or 0
+    b_tok = b_tokens.get("total_input") or b_tokens.get("total_input_estimate") or 0
+    print(f"  input           {_fmt_int(a_tok, b_tok)}")
+    a_cache = a_tokens.get("total_cache_read", 0)
+    b_cache = b_tokens.get("total_cache_read", 0)
+    if a_cache or b_cache:
+        print(f"  cache_read      {_fmt_int(a_cache, b_cache)}")
 
     print()
     print("Pipeline:")
-    for k in ("waves", "review_fail_rounds", "bug_fix_cycles"):
+    pipeline_keys = ("waves", "review_fail_rounds", "bug_fix_cycles",
+                     "turns", "tool_calls", "agent_spawns", "sendmessage_calls")
+    for k in pipeline_keys:
         av = a.get("pipeline", {}).get(k, 0)
         bv = b.get("pipeline", {}).get(k, 0)
         print(f"  {k:<22} {_fmt_int(av, bv)}")

--- a/benchmarks/scripts/run_benchmark.py
+++ b/benchmarks/scripts/run_benchmark.py
@@ -86,23 +86,71 @@ def setup_skeleton(benchmark: str, work_root: Path) -> Path:
     return project_dir
 
 
-def invoke_pipeline_auto(project_dir: Path, feature_request: str, log_path: Path) -> int:
-    """Run claude -p headlessly. Returns wall seconds."""
+# Tools the orchestrator and its subagents need access to during a headless run.
+# Bash is unrestricted because the pipeline shells out to git, gh, init.sh, build/test runners,
+# and adapter scripts under .claude/scripts/<stack>/. Restricting it would block real work.
+_AUTO_ALLOWED_TOOLS = ",".join([
+    "Agent", "SendMessage", "Read", "Edit", "Write", "Bash",
+    "Glob", "Grep",
+    "TaskCreate", "TaskUpdate", "TaskList", "TaskGet", "TaskStop", "TaskOutput",
+])
+
+# Cap on conversation turns. ~5 waves × 4 tasks × ~3 turns each + planning/review = ~80 turns.
+# A higher ceiling guards against runaway loops without killing legitimate long runs.
+_AUTO_MAX_TURNS = 120
+
+
+def invoke_pipeline_auto(
+    project_dir: Path,
+    feature_request: str,
+    log_path: Path,
+    max_turns: int = _AUTO_MAX_TURNS,
+    timeout_seconds: int = 60 * 60,
+) -> int:
+    """Run claude -p headlessly. Returns wall seconds.
+
+    Configuration follows the headless-mode requirements documented at
+    https://code.claude.com/docs/en/headless:
+      - --permission-mode acceptEdits (no interactive prompts)
+      - --allowedTools (pre-approve Agent, SendMessage, Bash, etc.)
+      - --output-format stream-json (capture full transcript incl. tool calls)
+      - --max-turns (safety ceiling)
+      - --verbose (stream-json requires verbose)
+      - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 (SendMessage between waves)
+    """
     cli = shutil.which("claude")
     if cli is None:
-        raise RuntimeError("`claude` CLI not on PATH; use --mode=manual or set --cli-cmd")
+        raise RuntimeError("`claude` CLI not on PATH; use --mode=manual instead")
+
     prompt = f"/orchestrate\n\n{feature_request}"
+    cmd = [
+        cli, "-p", prompt,
+        "--permission-mode", "acceptEdits",
+        "--allowedTools", _AUTO_ALLOWED_TOOLS,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--max-turns", str(max_turns),
+    ]
+    env = {**os.environ, "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
+
     started = time.time()
-    with log_path.open("w") as logf:
-        proc = subprocess.run(
-            [cli, "-p", prompt],
-            cwd=project_dir,
-            stdout=logf, stderr=subprocess.STDOUT,
-            text=True,
-        )
+    try:
+        with log_path.open("w") as logf:
+            proc = subprocess.run(
+                cmd,
+                cwd=project_dir,
+                stdout=logf, stderr=subprocess.STDOUT,
+                text=True, env=env,
+                timeout=timeout_seconds,
+            )
+    except subprocess.TimeoutExpired:
+        print(f"WARNING: claude run exceeded {timeout_seconds}s timeout; metrics may be partial")
+        return int(time.time() - started)
+
     elapsed = int(time.time() - started)
     if proc.returncode != 0:
-        print(f"WARNING: claude exited {proc.returncode}; metrics may be partial")
+        print(f"WARNING: claude exited {proc.returncode}; metrics may be partial. "
+              f"See {log_path} for the stream-json transcript.")
     return elapsed
 
 

--- a/benchmarks/scripts/score_run.py
+++ b/benchmarks/scripts/score_run.py
@@ -61,6 +61,13 @@ def _load_baseline(benchmark: str) -> dict[str, Any] | None:
         return None
 
 
+def _input_tokens(metrics: dict[str, Any]) -> int:
+    """Total input tokens regardless of log format. Stream-json uses `total_input`,
+    text fallback uses `total_input_estimate`."""
+    tokens = metrics.get("tokens", {})
+    return int(tokens.get("total_input") or tokens.get("total_input_estimate") or 0)
+
+
 def _efficiency(metrics: dict[str, Any]) -> float:
     """1.0 = matches baseline. >1.0 = better (cheaper/faster). <1.0 = regressed."""
     baseline = _load_baseline(metrics.get("benchmark", ""))
@@ -68,10 +75,10 @@ def _efficiency(metrics: dict[str, Any]) -> float:
         return 1.0  # no baseline yet; don't penalize
 
     base_wall = baseline.get("wall_time_seconds", 0) or 1
-    base_tokens = baseline.get("tokens", {}).get("total_input_estimate", 0) or 1
+    base_tokens = _input_tokens(baseline) or 1
 
     wall = metrics.get("wall_time_seconds", 0) or 1
-    tokens = metrics.get("tokens", {}).get("total_input_estimate", 0) or 1
+    tokens = _input_tokens(metrics) or 1
 
     wall_ratio = base_wall / wall if wall else 1.0
     token_ratio = base_tokens / tokens if tokens else 1.0


### PR DESCRIPTION
## Summary

- The Tier 1 harness's `--mode=auto` invocation as shipped (#91) was missing flags required for non-interactive operation per the [Claude Code headless docs](https://code.claude.com/docs/en/headless). It would hang on the first permission prompt and capture only the final assistant message.
- This PR adds the missing flags (`--permission-mode acceptEdits`, `--allowedTools`, `--output-format stream-json`, `--verbose`, `--max-turns 120`) and the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var, then upgrades `capture_metrics.py` to parse stream-json transcripts so token counts and tool-call totals are reliable instead of regex-best-effort.
- Unblocks **#93** (empirical validation), which needs N=10 unattended runs to measure noise floor + catch rate.

## What changed

- `run_benchmark.py` — proper CLI flags + env, timeout (default 1h, override-able), graceful timeout handling.
- `capture_metrics.py` — new stream-json parser: per-message `usage.input_tokens` / `output_tokens` / `cache_read_input_tokens`, aggregated by model. Counts Agent spawns, SendMessage calls, tool calls, and turns. Regex parser kept as fallback for `--mode=manual` text transcripts.
- `score_run.py` + `compare_runs.py` — read tokens via a helper that accepts either the new `total_input` field or the legacy `total_input_estimate`, so this is forward + backward compatible with existing baselines.
- `benchmarks/README.md` — documents the auto-mode flags and the two log-format paths.

## Test plan

- [x] Re-ran `--mode=existing` against a hand-written reference base64 — 4001/4001 property, 8/8 unit, composite 1.000 (no regression from the refactor).
- [ ] First real `--mode=auto` run end-to-end (next step in MILL5/agentic-dev-pipeline#228 — needs API budget approval).
- [ ] Verify stream-json token counts match Anthropic billing usage to within ~5% on the first auto run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)