### PR TITLE
feat(benchmarks): Tier 2 LRU cache benchmark (#97)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,6 +18,37 @@ base64 encode/decode. The oracle is a round-trip property suite:
 `decode(encode(x)) == x` for 1000 random inputs, plus reference equivalence
 against Python's stdlib `base64`.
 
+## Running Tier 2
+
+The Tier 2 benchmark (`tier2-lru-cache`) asks the pipeline to implement a
+fixed-capacity LRU cache (`LRUCache` class with O(1) `get`/`put`). The oracle
+generates 1000 randomized op sequences and compares the candidate's state
+against an `OrderedDict`-backed reference after every op (parity check on
+`len`, `__contains__`, and `get`/KeyError outcomes), plus capacity-invariant
+runs, round-trip checks, and four hand-crafted eviction-order scenarios.
+
+Why Tier 2 exists: Tier 1's N=5 noise floor produced correctness=1.000 ± 0.000
+(see issue #93), confirming Tier 1 is a reliable smoke test but blind to model
+quality differences. Tier 2 targets the "medium hard" zone — the spec forbids
+`OrderedDict` and `functools.lru_cache`, forcing a from-scratch hash-map +
+doubly-linked-list implementation where eviction-order bugs (evicting MRU
+instead of LRU; failing to refresh recency on `get` or re-`put`) are common.
+
+```bash
+# single run, manual mode
+python3 benchmarks/scripts/run_benchmark.py tier2-lru-cache --mode=manual
+
+# N=5 noise floor with the proven config (Sonnet orchestrator)
+python3 benchmarks/scripts/noise_floor.py tier2-lru-cache --n=5
+```
+
+If Tier 2 also shows ceiling effect (correctness always = 1.000), the next
+"knob to turn" is to enforce the no-stdlib-LRU rule statically — add an
+import-source check to `unit_tests.py` so models that take the `OrderedDict`
+shortcut are penalized. See issue #97 for the full validation protocol and
+escalation candidates (B: arithmetic expression evaluator, C: run-length
+encoding).
+
 ### Modes
 
 The harness supports three modes for invoking the pipeline:

--- a/benchmarks/baselines/tier1-base64.json
+++ b/benchmarks/baselines/tier1-base64.json
@@ -1,0 +1,36 @@
+{
+  "_note": "N=5 noise floor mean \u2014 pipeline sha daf5555 \u2014 2026-05-04",
+  "benchmark": "tier1-base64",
+  "pipeline_sha": "daf5555",
+  "n_runs": 5,
+  "wall_time_seconds": 1615,
+  "tokens": {
+    "total_input": 1891,
+    "total_output": 3742,
+    "total_cache_read": 17328091,
+    "total_cache_creation": 767120
+  },
+  "score": {
+    "correctness": 1.0,
+    "efficiency": 1.0,
+    "composite": 1.0
+  },
+  "noise_floor": {
+    "correctness": {
+      "mean": 1.0,
+      "std": 0.0
+    },
+    "wall_seconds": {
+      "mean": 1615.2,
+      "std": 310.40409146788
+    },
+    "cache_read_tokens": {
+      "mean": 17328090.8,
+      "std": 3207297.4595422545
+    },
+    "cost_usd_per_run": {
+      "mean": 8.14,
+      "std": 1.41
+    }
+  }
+}

--- a/benchmarks/scripts/noise_floor.py
+++ b/benchmarks/scripts/noise_floor.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Run N benchmark iterations and report noise-floor statistics (mean ± stddev).
+
+Usage:
+    python3 benchmarks/scripts/noise_floor.py tier1-base64 --n=5
+    python3 benchmarks/scripts/noise_floor.py tier1-base64 --n=5 --orchestrator-model=sonnet
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PIPELINE_ROOT = Path(__file__).resolve().parent.parent.parent
+RUN_SCRIPT = PIPELINE_ROOT / "benchmarks" / "scripts" / "run_benchmark.py"
+
+
+def _run_one(benchmark: str, orchestrator_model: str, run_index: int) -> dict[str, Any] | None:
+    print(f"\n{'='*60}")
+    print(f"RUN {run_index}: {benchmark} (orchestrator={orchestrator_model})")
+    print(f"{'='*60}")
+
+    cmd = [
+        sys.executable, str(RUN_SCRIPT),
+        benchmark,
+        "--mode=auto",
+        f"--orchestrator-model={orchestrator_model}",
+    ]
+    proc = subprocess.run(
+        cmd, cwd=PIPELINE_ROOT, capture_output=False, text=True, timeout=7200,
+    )
+
+    # run_benchmark.py prints "Metrics written: <path>"
+    # We reconstruct the path from runs/ dir by taking the most recent
+    # metrics.json (reliable since runs are sequential)
+    runs_dir = PIPELINE_ROOT / "benchmarks" / "runs"
+    candidates = sorted(
+        runs_dir.glob(f"*-{benchmark}/metrics.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        print(f"  ERROR: no metrics.json found for run {run_index}")
+        return None
+
+    metrics_path = candidates[0]
+    try:
+        return json.loads(metrics_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"  ERROR reading {metrics_path}: {e}")
+        return None
+
+
+def _input_tokens(m: dict[str, Any]) -> int:
+    t = m.get("tokens", {})
+    return int(t.get("total_input") or t.get("total_input_estimate") or 0)
+
+
+def _stats(values: list[float]) -> tuple[float, float]:
+    """Return (mean, stddev). stddev=0 for n<=1."""
+    if not values:
+        return 0.0, 0.0
+    mean = sum(values) / len(values)
+    if len(values) == 1:
+        return mean, 0.0
+    variance = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return mean, math.sqrt(variance)
+
+
+def _fmt(mean: float, std: float, precision: int = 3) -> str:
+    fmt = f".{precision}f"
+    return f"{mean:{fmt}} ± {std:{fmt}}"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("benchmark", default="tier1-base64", nargs="?")
+    p.add_argument("--n", type=int, default=5, help="Number of runs (default: 5)")
+    p.add_argument("--orchestrator-model", default="sonnet",
+                   choices=["sonnet", "opus", "haiku"])
+    args = p.parse_args()
+
+    results: list[dict[str, Any]] = []
+    for i in range(1, args.n + 1):
+        m = _run_one(args.benchmark, args.orchestrator_model, i)
+        if m is not None:
+            results.append(m)
+            sc = m.get("score", {})
+            print(f"  → correctness={sc.get('correctness', 0):.3f}  "
+                  f"efficiency={sc.get('efficiency', 0):.3f}  "
+                  f"composite={sc.get('composite', 0):.3f}  "
+                  f"wall={m.get('wall_time_seconds', 0)}s  "
+                  f"tokens={_input_tokens(m):,}")
+
+    n = len(results)
+    if n == 0:
+        print("\nNo successful runs — cannot compute stats.")
+        return 1
+
+    correctness  = [r.get("score", {}).get("correctness", 0.0) for r in results]
+    efficiency   = [r.get("score", {}).get("efficiency", 0.0)  for r in results]
+    composite    = [r.get("score", {}).get("composite", 0.0)   for r in results]
+    wall_times   = [float(r.get("wall_time_seconds", 0))       for r in results]
+    tokens       = [float(_input_tokens(r))                     for r in results]
+    prop_rates   = [r.get("tests", {}).get("property", {}).get("total_passed", 0) /
+                    max(r.get("tests", {}).get("property", {}).get("total_run", 1), 1)
+                    for r in results]
+    unit_rates   = [r.get("tests", {}).get("unit", {}).get("passed", 0) /
+                    max(r.get("tests", {}).get("unit", {}).get("total", 1), 1)
+                    for r in results]
+
+    print(f"\n{'='*60}")
+    print(f"NOISE FLOOR  n={n}  benchmark={args.benchmark}  orchestrator={args.orchestrator_model}")
+    print(f"{'='*60}")
+    print(f"  correctness   {_fmt(*_stats(correctness))}")
+    print(f"  efficiency    {_fmt(*_stats(efficiency))}")
+    print(f"  composite     {_fmt(*_stats(composite))}")
+    print(f"  wall_time (s) {_fmt(*_stats(wall_times), precision=0)}")
+    print(f"  tokens (in)   {_fmt(*_stats(tokens), precision=0)}")
+    print(f"  prop pass%    {_fmt(*_stats(prop_rates))}")
+    print(f"  unit pass%    {_fmt(*_stats(unit_rates))}")
+    print()
+    print("Per-run correctness:", "  ".join(f"{v:.3f}" for v in correctness))
+    print("Per-run wall_time:  ", "  ".join(f"{int(v)}s" for v in wall_times))
+    print()
+
+    # Save summary alongside the metrics
+    summary = {
+        "n": n,
+        "benchmark": args.benchmark,
+        "orchestrator_model": args.orchestrator_model,
+        "run_ids": [r.get("run_id", "?") for r in results],
+        "stats": {
+            "correctness":  {"mean": _stats(correctness)[0],  "std": _stats(correctness)[1]},
+            "efficiency":   {"mean": _stats(efficiency)[0],   "std": _stats(efficiency)[1]},
+            "composite":    {"mean": _stats(composite)[0],    "std": _stats(composite)[1]},
+            "wall_seconds": {"mean": _stats(wall_times)[0],   "std": _stats(wall_times)[1]},
+            "input_tokens": {"mean": _stats(tokens)[0],       "std": _stats(tokens)[1]},
+            "prop_pass_rate": {"mean": _stats(prop_rates)[0], "std": _stats(prop_rates)[1]},
+            "unit_pass_rate": {"mean": _stats(unit_rates)[0], "std": _stats(unit_rates)[1]},
+        },
+    }
+    out = PIPELINE_ROOT / "benchmarks" / "runs" / f"noise_floor_{args.benchmark}_n{n}.json"
+    out.write_text(json.dumps(summary, indent=2))
+    print(f"Summary saved: {out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tier2-lru-cache/feature-request.md
+++ b/benchmarks/tier2-lru-cache/feature-request.md
@@ -1,0 +1,99 @@
+# Feature Request: LRU cache
+
+Please add a fixed-capacity LRU (Least Recently Used) cache to this Python project.
+
+> **Benchmark mode — no clarifying questions.** This request is the frozen input
+> for the Tier 2 regression benchmark. Every potentially-ambiguous decision is
+> pre-specified below in the `Decisions` section. **Architect 1a must not ask
+> clarifying questions** — proceed directly to spec finalization (1a-spec.md) and
+> on to planning (1b). If a corner case is not explicitly decided here, choose the
+> most idiomatic Python answer and document it in 1a-spec.md without halting.
+
+## Requirements
+
+- Implement an `LRUCache` class with **O(1)** `get` and `put` operations.
+- Fixed capacity, set at construction time. The cache holds up to `capacity`
+  key/value pairs.
+- When a `put` of a *new* key would exceed capacity, evict the
+  **least-recently-used** entry first, then insert.
+- Both `get(key)` and `put(key, value)` mark the key as most-recently-used.
+- A `put` of an *existing* key updates its value AND marks it as
+  most-recently-used. It does not evict anything (count is unchanged).
+- Include unit tests covering normal and edge cases.
+
+## Out of scope
+
+- Thread safety — single-threaded only.
+- TTL / expiration — capacity-only eviction.
+- Persistence to disk — in-memory only.
+- Iteration (`__iter__`, `keys()`, `values()`) — not required.
+
+## Implementation note
+
+Do **not** use `collections.OrderedDict`, `functools.lru_cache`, or any other
+prebuilt LRU mechanism from the standard library. Implement the eviction
+ordering yourself using a hash map plus a doubly-linked list (or any
+equivalent O(1) structure). This is intentional — the project exists to measure
+what is produced from scratch.
+
+## Decisions (frozen — do not re-ask)
+
+These resolve the ambiguities Architect 1a would otherwise surface. Treat as
+final.
+
+### Module layout
+
+- **Module name:** `lru_cache`. The implementation lives at `src/lru_cache.py`
+  and exports an `LRUCache` class. Helper classes (e.g., a `Node` for the
+  linked list) may live in the same file.
+- **Package init:** `src/__init__.py` may stay empty or re-export `LRUCache` —
+  implementation choice.
+- **No CLI.** The benchmark scores a library API; no command-line entry point
+  is required.
+
+### Constructor
+
+- **Signature:** `__init__(self, capacity: int) -> None`.
+- **`capacity <= 0`** raises `ValueError` with a descriptive message.
+  Non-integer capacity (e.g., `0.5`, `"5"`) is allowed to fail however it falls
+  — no defensive type-checking required.
+
+### Operations
+
+- **`get(self, key) -> Any`** — returns the stored value if `key` is present,
+  marking it most-recently-used. Raises `KeyError(key)` when the key is not
+  present (match `dict.__getitem__` behavior, **not** `dict.get` — no implicit
+  default).
+- **`put(self, key, value) -> None`** — inserts when the key is new (and
+  evicts the LRU entry first if `len(self) == capacity`); updates the value
+  and refreshes recency when the key already exists. Returns `None`.
+- **`__len__(self) -> int`** — returns the current entry count
+  (`0 <= len <= capacity`).
+- **`__contains__(self, key) -> bool`** — `key in cache`. Does **not** affect
+  recency. (Peeking is not the same as accessing.)
+
+### Eviction order
+
+- "Least-recently-used" means the entry whose last `get` or `put` happened the
+  longest ago among current entries.
+- Inserting a *new* key when full evicts exactly one entry (the LRU).
+- Updating an *existing* key never causes eviction.
+- `__contains__` does not change recency; only `get` and `put` do.
+
+### Type hints / style
+
+- Type hints required on `__init__`, `get`, `put`, `__len__`, `__contains__`.
+- Mypy strict is enabled. For value types you may use `Any` or generics
+  (`TypeVar`) — both are acceptable.
+- Brief one-line docstrings on `LRUCache`, `get`, and `put`. No multi-paragraph
+  docstrings.
+
+### Tests
+
+- **Coverage:** Thorough case coverage is required; no numeric coverage floor.
+- **Test file:** `test_lru_cache.py` at project root. Pytest is already
+  configured.
+- **Tests must cover:** capacity-1 edge case, eviction order after a sequence
+  of puts and gets, `KeyError` on missing key, `ValueError` on invalid
+  capacity, re-put updating value while keeping length unchanged, recency
+  preservation through `get`, and `__contains__` not refreshing recency.

--- a/benchmarks/tier2-lru-cache/fixtures/_discover.py
+++ b/benchmarks/tier2-lru-cache/fixtures/_discover.py
@@ -1,0 +1,91 @@
+"""Locate the pipeline-produced LRUCache class.
+
+The pipeline is free to name its module anything (src/lru.py, src/cache/lru_cache.py,
+etc.) and free to name the class anything that looks like an LRU cache. The
+fixtures here import via discovery rather than a hardcoded name so the benchmark
+doesn't penalize naming choices.
+
+Discovery rule: under src/, find a class whose `__init__` accepts at least one
+positional argument (capacity) and which exposes both `get` and `put` methods.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _candidate_modules(src_root: Path) -> list[Path]:
+    """All .py files under src/ except __init__ stubs."""
+    out: list[Path] = []
+    for p in src_root.rglob("*.py"):
+        if p.name == "__init__.py":
+            continue
+        out.append(p)
+    return out
+
+
+def _load_module_from_path(path: Path, src_root: Path) -> Any | None:
+    rel = path.relative_to(src_root).with_suffix("")
+    mod_name = "src." + ".".join(rel.parts)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    return mod
+
+
+def _looks_like_lru_class(cls: Any) -> bool:
+    if not inspect.isclass(cls):
+        return False
+    if not (callable(getattr(cls, "get", None)) and callable(getattr(cls, "put", None))):
+        return False
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (ValueError, TypeError):
+        return False
+    params = [
+        p for p in sig.parameters.values()
+        if p.name != "self" and p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    # __init__ should accept at least a capacity positional arg.
+    return len(params) >= 1
+
+
+def discover(project_root: Path) -> type:
+    """Return the discovered LRUCache class, or raise ImportError."""
+    src_root = project_root / "src"
+    if not src_root.is_dir():
+        raise ImportError(f"src/ does not exist under {project_root}")
+
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    for path in _candidate_modules(src_root):
+        mod = _load_module_from_path(path, src_root)
+        if mod is None:
+            continue
+        for name in dir(mod):
+            if name.startswith("_"):
+                continue
+            obj = getattr(mod, name)
+            # Only accept classes defined in this module (not re-exported stdlib).
+            if _looks_like_lru_class(obj) and getattr(obj, "__module__", "") == mod.__name__:
+                return obj
+
+    raise ImportError(
+        "No class under src/ has the shape of an LRU cache "
+        "(class with get/put methods and __init__ accepting capacity). "
+        "The pipeline did not produce a recognizable LRU cache."
+    )

--- a/benchmarks/tier2-lru-cache/fixtures/property_tests.py
+++ b/benchmarks/tier2-lru-cache/fixtures/property_tests.py
@@ -1,0 +1,396 @@
+"""Property-based oracle for the LRU cache benchmark.
+
+Run from the project root:
+    python3 fixtures/property_tests.py [--project=PATH] [--runs=N]
+
+Exit codes:
+    0 — all properties hold
+    1 — at least one property failed
+    2 — class not discoverable
+
+The oracle compares the candidate cache against a reference implementation
+backed by ``collections.OrderedDict``. The candidate is asked (in the frozen
+feature request) not to use OrderedDict, so the reference is independent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+# Allow `python3 fixtures/property_tests.py` to find _discover when cwd != fixtures/
+sys.path.insert(0, str(Path(__file__).parent))
+from _discover import discover  # noqa: E402
+
+
+# ---------- Reference implementation (independent of the candidate) ----------
+
+class ReferenceLRU:
+    """Reference LRU built on OrderedDict. Used only by the oracle."""
+
+    def __init__(self, capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError(f"capacity must be positive, got {capacity}")
+        self.capacity = capacity
+        self._data: "OrderedDict[Any, Any]" = OrderedDict()
+
+    def get(self, key: Any) -> Any:
+        if key not in self._data:
+            raise KeyError(key)
+        self._data.move_to_end(key)
+        return self._data[key]
+
+    def put(self, key: Any, value: Any) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+            self._data[key] = value
+            return
+        if len(self._data) >= self.capacity:
+            self._data.popitem(last=False)  # remove least-recent (front)
+        self._data[key] = value
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __contains__(self, key: Any) -> bool:
+        return key in self._data
+
+
+# ---------- Probes (return structured results so we can compare with ==) ----------
+
+def _probe_get(cache: Any, key: Any) -> tuple[str, Any]:
+    """Try cache.get(key); return ("ok", value) or ("err", exc_class_name)."""
+    try:
+        v = cache.get(key)
+    except KeyError:
+        return ("err", "KeyError")
+    except Exception as e:
+        return ("err", type(e).__name__)
+    return ("ok", v)
+
+
+def _probe_contains(cache: Any, key: Any) -> bool:
+    try:
+        return key in cache
+    except Exception:
+        return False
+
+
+def _probe_len(cache: Any) -> int | None:
+    try:
+        return len(cache)
+    except Exception:
+        return None
+
+
+# ---------- Op generation ----------
+
+def _gen_ops(rng: random.Random, n_ops: int, key_pool: list[int]) -> list[tuple]:
+    """Generate a randomized sequence of put/get ops over a small key pool."""
+    ops: list[tuple] = []
+    for _ in range(n_ops):
+        if rng.random() < 0.6:
+            k = rng.choice(key_pool)
+            v = rng.randint(0, 1000)
+            ops.append(("put", k, v))
+        else:
+            k = rng.choice(key_pool)
+            ops.append(("get", k))
+    return ops
+
+
+# ---------- Suites ----------
+
+def _check_op_sequence_match(LRUClass, n_sequences: int, seed: int) -> tuple[int, list[str]]:
+    """For each random sequence of ops, candidate state must match the reference."""
+    rng = random.Random(seed)
+    fails: list[str] = []
+    passed = 0
+    for seq_id in range(n_sequences):
+        capacity = rng.randint(1, 8)
+        n_ops = rng.randint(8, 40)
+        ops = _gen_ops(rng, n_ops=n_ops, key_pool=list(range(1, 12)))
+        try:
+            candidate = LRUClass(capacity)
+        except Exception as e:
+            fails.append(f"seq {seq_id}: LRUClass({capacity}) raised {type(e).__name__}: {e}")
+            continue
+        ref = ReferenceLRU(capacity)
+        seen: set = set()
+        ok = True
+        for op_idx, op in enumerate(ops):
+            kind = op[0]
+            if kind == "put":
+                _, k, v = op
+                seen.add(k)
+                try:
+                    candidate.put(k, v)
+                except Exception as e:
+                    fails.append(
+                        f"seq {seq_id} op {op_idx} put({k},{v}): "
+                        f"candidate raised {type(e).__name__}: {e}"
+                    )
+                    ok = False
+                    break
+                ref.put(k, v)
+            else:  # "get"
+                _, k = op
+                seen.add(k)
+                cand_r = _probe_get(candidate, k)
+                ref_r = _probe_get(ref, k)
+                if cand_r != ref_r:
+                    fails.append(
+                        f"seq {seq_id} op {op_idx} get({k}): "
+                        f"candidate={cand_r}, reference={ref_r}"
+                    )
+                    ok = False
+                    break
+
+            cand_len = _probe_len(candidate)
+            ref_len = len(ref)
+            if cand_len != ref_len:
+                fails.append(
+                    f"seq {seq_id} op {op_idx} after {op}: "
+                    f"len differs (candidate={cand_len}, reference={ref_len})"
+                )
+                ok = False
+                break
+            membership_diff = [
+                k for k in seen
+                if _probe_contains(candidate, k) != (k in ref)
+            ]
+            if membership_diff:
+                fails.append(
+                    f"seq {seq_id} op {op_idx} after {op}: "
+                    f"membership diverges on keys {sorted(membership_diff)[:5]}"
+                )
+                ok = False
+                break
+        if ok:
+            passed += 1
+    return passed, fails
+
+
+def _check_capacity_invariant(LRUClass, n_sequences: int, seed: int) -> tuple[int, list[str]]:
+    """``len(cache) <= capacity`` after every op."""
+    rng = random.Random(seed + 1)
+    fails: list[str] = []
+    passed = 0
+    for seq_id in range(n_sequences):
+        capacity = rng.randint(1, 6)
+        try:
+            cache = LRUClass(capacity)
+        except Exception as e:
+            fails.append(f"seq {seq_id}: LRUClass({capacity}) raised {type(e).__name__}: {e}")
+            continue
+        ops = _gen_ops(rng, n_ops=rng.randint(10, 30), key_pool=list(range(1, 8)))
+        ok = True
+        for op_idx, op in enumerate(ops):
+            kind = op[0]
+            try:
+                if kind == "put":
+                    cache.put(op[1], op[2])
+                else:
+                    try:
+                        cache.get(op[1])
+                    except KeyError:
+                        pass  # missing-key is fine; we're checking capacity
+            except Exception as e:
+                fails.append(
+                    f"seq {seq_id} op {op_idx} {op}: raised {type(e).__name__}: {e}"
+                )
+                ok = False
+                break
+            n = _probe_len(cache)
+            if n is None or n > capacity:
+                fails.append(
+                    f"seq {seq_id} op {op_idx} after {op}: len={n} > capacity={capacity}"
+                )
+                ok = False
+                break
+        if ok:
+            passed += 1
+    return passed, fails
+
+
+def _check_round_trip_put_get(LRUClass, n_runs: int, seed: int) -> tuple[int, list[str]]:
+    """``put(k, v)`` followed by ``get(k)`` returns ``v``."""
+    rng = random.Random(seed + 2)
+    fails: list[str] = []
+    passed = 0
+    for i in range(n_runs):
+        capacity = rng.randint(1, 8)
+        try:
+            cache = LRUClass(capacity)
+        except Exception as e:
+            fails.append(f"run {i}: LRUClass({capacity}) raised {type(e).__name__}: {e}")
+            continue
+        k = rng.randint(0, 1000)
+        v = rng.randint(0, 1_000_000)
+        try:
+            cache.put(k, v)
+            got = cache.get(k)
+        except Exception as e:
+            fails.append(f"run {i}: put/get round-trip raised {type(e).__name__}: {e}")
+            continue
+        if got != v:
+            fails.append(f"run {i}: put({k},{v}) then get({k}) = {got!r}, expected {v!r}")
+        else:
+            passed += 1
+    return passed, fails
+
+
+def _check_eviction_order(LRUClass) -> tuple[int, list[str]]:
+    """Hand-crafted scenarios targeting the bugs the issue calls out."""
+    fails: list[str] = []
+
+    def s1() -> str | None:
+        # cap=2, put A, B, C → A evicted (basic LRU)
+        c = LRUClass(2)
+        c.put("A", 1)
+        c.put("B", 2)
+        c.put("C", 3)
+        if "A" in c or "B" not in c or "C" not in c:
+            return (
+                f"cap=2 put A,B,C: expected A evicted; "
+                f"got 'A' in c={'A' in c}, 'B' in c={'B' in c}, 'C' in c={'C' in c}"
+            )
+        return None
+
+    def s2() -> str | None:
+        # cap=2, put A, B, get A (touches A), put C → B evicted
+        c = LRUClass(2)
+        c.put("A", 1)
+        c.put("B", 2)
+        c.get("A")
+        c.put("C", 3)
+        if "B" in c or "A" not in c or "C" not in c:
+            return (
+                f"cap=2 put A,B,get A,put C: expected B evicted; "
+                f"got 'A' in c={'A' in c}, 'B' in c={'B' in c}, 'C' in c={'C' in c}"
+            )
+        return None
+
+    def s3() -> str | None:
+        # cap=2, put A, B, re-put A (refresh+update), put C → B evicted; A's value updated
+        c = LRUClass(2)
+        c.put("A", 1)
+        c.put("B", 2)
+        c.put("A", 99)
+        c.put("C", 3)
+        if "B" in c or "A" not in c or "C" not in c:
+            return (
+                f"cap=2 put A,B,re-put A,put C: expected B evicted; "
+                f"got 'A' in c={'A' in c}, 'B' in c={'B' in c}, 'C' in c={'C' in c}"
+            )
+        if c.get("A") != 99:
+            return f"re-put A=99: expected get A == 99, got {c.get('A')!r}"
+        return None
+
+    def s4() -> str | None:
+        # cap=1, put A, put B → only B remains.
+        c = LRUClass(1)
+        c.put("A", 1)
+        c.put("B", 2)
+        if "A" in c or "B" not in c or len(c) != 1:
+            return (
+                f"cap=1 put A,B: expected only B; "
+                f"got 'A' in c={'A' in c}, 'B' in c={'B' in c}, len={len(c)}"
+            )
+        return None
+
+    scenarios = [
+        ("evict_lru_basic", s1),
+        ("get_refreshes_recency", s2),
+        ("reput_refreshes_recency", s3),
+        ("capacity_one", s4),
+    ]
+    passed = 0
+    for name, fn in scenarios:
+        try:
+            err = fn()
+        except Exception as e:
+            err = f"raised {type(e).__name__}: {e}"
+        if err is None:
+            passed += 1
+        else:
+            fails.append(f"{name}: {err}")
+    return passed, fails
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.getcwd(), help="Project root containing src/")
+    parser.add_argument("--runs", type=int, default=1000,
+                        help="Number of randomized runs for the parity suite (others scale down)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--json", default=None, help="Write structured results to this path")
+    parser.add_argument("--max-fails-shown", type=int, default=5)
+    args = parser.parse_args()
+
+    try:
+        LRUClass = discover(Path(args.project))
+    except ImportError as e:
+        print(f"DISCOVERY FAILED: {e}")
+        if args.json:
+            Path(args.json).write_text(json.dumps({"error": "discovery_failed", "detail": str(e)}))
+        return 2
+
+    n_seq_full = args.runs
+    n_seq_inv = max(1, args.runs // 4)
+    n_seq_rt = max(1, args.runs // 2)
+
+    suites = [
+        ("op_sequence_match",  lambda: _check_op_sequence_match(LRUClass, n_seq_full, args.seed),  n_seq_full),
+        ("capacity_invariant", lambda: _check_capacity_invariant(LRUClass, n_seq_inv, args.seed),  n_seq_inv),
+        ("round_trip_put_get", lambda: _check_round_trip_put_get(LRUClass, n_seq_rt, args.seed),   n_seq_rt),
+        ("eviction_order",     lambda: _check_eviction_order(LRUClass),                            4),
+    ]
+
+    suite_results: dict[str, dict] = {}
+    total_pass = 0
+    total_run = 0
+    any_fail = False
+
+    for name, fn, run_count in suites:
+        passed, fails = fn()
+        suite_results[name] = {
+            "passed": passed,
+            "total": run_count,
+            "failures_sample": fails[: args.max_fails_shown],
+            "failure_count": len(fails),
+        }
+        total_pass += passed
+        total_run += run_count
+        if fails:
+            any_fail = True
+
+    pct = 100.0 * total_pass / total_run if total_run else 0.0
+    print(f"Property suite — class: {LRUClass.__module__}.{LRUClass.__name__}")
+    for name, r in suite_results.items():
+        status = "OK" if r["failure_count"] == 0 else f"FAIL ({r['failure_count']})"
+        print(f"  {name:<22} {r['passed']:>5}/{r['total']:<5}  [{status}]")
+        for f in r["failures_sample"]:
+            print(f"      - {f}")
+    print(f"Summary: Passed: {total_pass}/{total_run} ({pct:.1f}%)")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps({
+            "module": f"{LRUClass.__module__}.{LRUClass.__name__}",
+            "suites": suite_results,
+            "total_passed": total_pass,
+            "total_run": total_run,
+            "pass_pct": pct,
+        }, indent=2))
+
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tier2-lru-cache/fixtures/unit_tests.py
+++ b/benchmarks/tier2-lru-cache/fixtures/unit_tests.py
@@ -1,0 +1,177 @@
+"""Unit + functional tests for the pipeline-produced LRU cache.
+
+Run from the project root:
+    python3 fixtures/unit_tests.py [--project=PATH]
+
+Exit codes:
+    0 — all tests pass
+    1 — at least one failed
+    2 — class not discoverable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _discover import discover  # noqa: E402
+
+
+def _run_test(name: str, fn) -> tuple[bool, str]:
+    try:
+        fn()
+        return True, ""
+    except AssertionError as e:
+        return False, f"AssertionError: {e}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", default=os.getcwd())
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    project = Path(args.project)
+    try:
+        LRUClass = discover(project)
+    except ImportError as e:
+        print(f"DISCOVERY FAILED: {e}")
+        if args.json:
+            Path(args.json).write_text(json.dumps({"error": "discovery_failed", "detail": str(e)}))
+        return 2
+
+    def t_class_exists() -> None:
+        assert LRUClass is not None
+
+    def t_init_rejects_zero_capacity() -> None:
+        try:
+            LRUClass(0)
+        except ValueError:
+            return
+        except Exception as e:
+            raise AssertionError(
+                f"expected ValueError for capacity=0, got {type(e).__name__}: {e}"
+            ) from e
+        raise AssertionError("expected ValueError for capacity=0, no exception raised")
+
+    def t_init_rejects_negative_capacity() -> None:
+        try:
+            LRUClass(-1)
+        except ValueError:
+            return
+        except Exception as e:
+            raise AssertionError(
+                f"expected ValueError for capacity=-1, got {type(e).__name__}: {e}"
+            ) from e
+        raise AssertionError("expected ValueError for capacity=-1, no exception raised")
+
+    def t_get_missing_raises_key_error() -> None:
+        c = LRUClass(2)
+        try:
+            c.get("nope")
+        except KeyError:
+            return
+        except Exception as e:
+            raise AssertionError(
+                f"expected KeyError on missing, got {type(e).__name__}: {e}"
+            ) from e
+        raise AssertionError("expected KeyError on missing key, no exception raised")
+
+    def t_len_initial_zero() -> None:
+        c = LRUClass(3)
+        assert len(c) == 0, f"len of empty cache should be 0, got {len(c)}"
+
+    def t_len_grows_to_capacity() -> None:
+        c = LRUClass(3)
+        c.put("a", 1)
+        assert len(c) == 1
+        c.put("b", 2)
+        assert len(c) == 2
+        c.put("c", 3)
+        assert len(c) == 3
+        c.put("d", 4)
+        assert len(c) == 3, f"len should stay at capacity=3 after eviction, got {len(c)}"
+
+    def t_capacity_one_eviction() -> None:
+        c = LRUClass(1)
+        c.put("a", 1)
+        c.put("b", 2)
+        assert "a" not in c, "expected 'a' to be evicted in capacity=1 cache"
+        assert "b" in c, "expected 'b' to remain"
+        assert c.get("b") == 2, f"expected get('b')==2, got {c.get('b')!r}"
+
+    def t_update_existing_key_does_not_grow() -> None:
+        c = LRUClass(2)
+        c.put("a", 1)
+        c.put("a", 2)
+        assert len(c) == 1, f"re-putting same key should not grow length, got len={len(c)}"
+        assert c.get("a") == 2, f"re-put value should be 2, got {c.get('a')!r}"
+
+    def t_get_refreshes_recency() -> None:
+        c = LRUClass(2)
+        c.put("a", 1)
+        c.put("b", 2)
+        c.get("a")           # bump a to MRU
+        c.put("c", 3)        # should evict b, not a
+        assert "a" in c, "get() should have refreshed a's recency"
+        assert "b" not in c, "expected b (not a) to be evicted after get(a)"
+        assert "c" in c
+
+    def t_contains_does_not_touch_recency() -> None:
+        c = LRUClass(2)
+        c.put("a", 1)
+        c.put("b", 2)
+        _ = "a" in c          # peek a; should NOT change recency
+        c.put("c", 3)
+        assert "a" not in c, (
+            "containment check should not refresh recency; "
+            "a was LRU and should have been evicted"
+        )
+        assert "b" in c
+        assert "c" in c
+
+    tests = [
+        ("class_exists",                      t_class_exists),
+        ("init_rejects_zero_capacity",        t_init_rejects_zero_capacity),
+        ("init_rejects_negative_capacity",    t_init_rejects_negative_capacity),
+        ("get_missing_raises_key_error",      t_get_missing_raises_key_error),
+        ("len_initial_zero",                  t_len_initial_zero),
+        ("len_grows_to_capacity",             t_len_grows_to_capacity),
+        ("capacity_one_eviction",             t_capacity_one_eviction),
+        ("update_existing_key_does_not_grow", t_update_existing_key_does_not_grow),
+        ("get_refreshes_recency",             t_get_refreshes_recency),
+        ("contains_does_not_touch_recency",   t_contains_does_not_touch_recency),
+    ]
+
+    results = []
+    passed = 0
+    for name, fn in tests:
+        ok, detail = _run_test(name, fn)
+        results.append({"name": name, "passed": ok, "detail": detail})
+        passed += int(ok)
+        status = "OK" if ok else "FAIL"
+        print(f"  {name:<40} [{status}]" + (f"  {detail}" if not ok else ""))
+
+    pct = 100.0 * passed / len(tests)
+    print(f"Summary: Passed: {passed}/{len(tests)} ({pct:.1f}%)")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps({
+            "module": f"{LRUClass.__module__}.{LRUClass.__name__}",
+            "tests": results,
+            "passed": passed,
+            "total": len(tests),
+            "pass_pct": pct,
+        }, indent=2))
+
+    return 0 if passed == len(tests) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tier2-lru-cache/skeleton/CLAUDE.md
+++ b/benchmarks/tier2-lru-cache/skeleton/CLAUDE.md
@@ -1,0 +1,24 @@
+# Claude Code Instructions
+
+## Session Initialization
+
+Role: You are a senior Python developer.
+
+Context: This is a small Python project used as a pipeline benchmark fixture. It is intentionally minimal so the pipeline's behavior is what's measured, not the surrounding codebase.
+
+Setup: At the start of each session, read `.claude/ORCHESTRATOR.md` for architecture, conventions, and current state.
+
+## Workflow Rules
+
+See agent definitions in `.claude/agents/` for per-role guidance (planning, implementation, review, testing).
+
+## Build & Test (Mandatory Skills)
+
+**PreToolUse hooks enforce these rules — violations are blocked automatically.**
+
+- **Builds:** Use the `build-runner` skill (or `python3 .claude/scripts/python/build.py` for subagents)
+- **Tests:** Use the `test-runner` skill (or `python3 .claude/scripts/python/test.py` for subagents)
+- **Forbidden:** raw `pytest`, `python -m pytest`, `mypy` — all blocked by hook
+- **Also blocked:** `grep`, `cat`, `head`, `tail`, `find`, `sed`, `awk` via Bash — use Grep, Read, Glob, Edit tools instead
+
+When presenting test results: show the Summary line first, then per-target coverage, then failures table (if any). Never invent results.

--- a/benchmarks/tier2-lru-cache/skeleton/ORCHESTRATOR.md
+++ b/benchmarks/tier2-lru-cache/skeleton/ORCHESTRATOR.md
@@ -1,0 +1,72 @@
+# ORCHESTRATOR.md
+
+> Living architecture reference. Updated at the end of each orchestration session.
+
+## Project Overview
+
+**Name:** lrubench
+**Stack:** python
+**Description:** Benchmark fixture project. The pipeline is asked to add a fixed-capacity LRU cache here, and its output is scored on correctness (reference-parity property tests + edge-case unit tests) and efficiency (tokens, time, waves).
+
+## Targets / Entry Points
+
+| Target | Platform | Description |
+|--------|----------|-------------|
+| lrubench | Python 3.9+ | Library |
+
+## Directory Structure
+
+```
+src/             # implementation goes here
+pyproject.toml   # project config
+```
+
+## Architecture
+
+Library-only. Pure-Python implementation of a fixed-capacity LRU cache with
+O(1) `get`/`put`. No CLI.
+
+## Key Services / Modules
+
+| Service | Responsibility | File(s) |
+|---------|---------------|---------|
+| (to be added) | LRU cache | src/ |
+
+## Conventions
+
+### Naming
+- Snake_case for modules; PascalCase for classes (e.g., `LRUCache`).
+
+### Patterns
+- Pure data structure; no global state.
+- Type hints on all public APIs.
+
+### Error Handling
+- `LRUCache(capacity <= 0)` raises `ValueError`.
+- `cache.get(missing_key)` raises `KeyError`.
+
+## Testing
+
+### Structure
+- Test files: `test_*.py` at project root
+- Use pytest
+
+### Coverage Requirements
+- Minimum: 90% for new code
+
+## Known Fragile Areas
+
+| Area | Risk | Mitigation |
+|------|------|------------|
+| (none yet) | | |
+
+## Anti-Patterns (Do NOT)
+
+- Do NOT import `OrderedDict` from `collections` or use `functools.lru_cache` — implement the eviction structure from scratch (hash map + doubly-linked list, or equivalent O(1) design). The benchmark exists to measure what the pipeline produces; reusing a stdlib LRU defeats it.
+
+## Current State
+
+- **Last updated:** initial
+- **Build status:** clean
+- **Test status:** no tests yet
+- **Open work:** add LRU cache class per feature-request.md

--- a/benchmarks/tier2-lru-cache/skeleton/pyproject.toml
+++ b/benchmarks/tier2-lru-cache/skeleton/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "lrubench"
+version = "0.0.1"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+
+[tool.mypy]
+strict = true

--- a/benchmarks/tier2-lru-cache/spec.md
+++ b/benchmarks/tier2-lru-cache/spec.md
@@ -1,0 +1,60 @@
+# Acceptance Spec: tier2-lru-cache
+
+This spec is **not** given to the pipeline. It is the scorer's contract — what "correct output" means.
+
+## Functional contract
+
+- An importable module exists under `src/` exposing a class with an
+  `__init__(capacity: int)` signature, `get(key)`, and `put(key, value)`.
+- The class also supports `__len__` and `__contains__` (per the frozen
+  feature request).
+
+## Property contract (the oracle)
+
+For each randomly generated sequence of `put` / `get` operations against a
+capacity-K cache (with `1 ≤ K ≤ 8`):
+
+1. **Reference parity.** After every op, the candidate's observable state
+   must match a reference implementation backed by `collections.OrderedDict`:
+   - `len(candidate) == len(reference)`
+   - For every key seen so far in the sequence,
+     `key in candidate == key in reference`
+   - `candidate.get(k)` and `reference.get(k)` return the same result (value
+     or `KeyError`) for any seen key
+2. **Capacity invariant.** `len(cache) <= capacity` after every op.
+3. **Round-trip.** `put(k, v)` immediately followed by `get(k)` returns `v`.
+4. **Eviction-order scenarios.** Hand-crafted cases that target the common
+   failure modes the issue calls out:
+   - cap=2, put A/B/C → A evicted (basic LRU)
+   - cap=2, put A/B, get A, put C → B evicted (get refreshes recency)
+   - cap=2, put A/B, re-put A, put C → B evicted (re-put refreshes recency)
+   - cap=1 → every new key evicts the previous one
+
+## Negative contract
+
+- `LRUCache(0)` and `LRUCache(-1)` raise `ValueError`.
+- `cache.get(missing_key)` raises `KeyError`.
+
+## Scoring weights
+
+| Component | Weight |
+|-----------|--------|
+| Property tests (reference parity, capacity invariant, round-trip, eviction-order edge cases) | 0.5 |
+| Unit tests (negative cases, edge cases, recency semantics) | 0.2 |
+| Functional contract (class with right shape is discoverable) | 0.3 |
+
+Composite correctness = weighted average of pass percentages, identical to
+Tier 1's scoring pattern.
+
+## Out of scope (not penalized if absent)
+
+- Thread safety
+- TTL / expiration
+- O(1) enforced statically — required by the feature request but not measured
+  in the oracle (microbenchmarking is too noisy to score; correctness is the
+  signal we want).
+- `__iter__` / iteration order
+- A no-stdlib-LRU static check — the feature request bans `OrderedDict` and
+  `functools.lru_cache`, but if a model uses them, the property tests still
+  score the resulting behavior. (See README "knob to turn" if validation
+  shows ceiling effect.)


### PR DESCRIPTION
## Summary

- New benchmark `benchmarks/tier2-lru-cache/` mirroring the Tier 1 layout — frozen `feature-request.md`, scorer-side `spec.md`, minimal Python skeleton, and three fixtures (`_discover.py`, `property_tests.py`, `unit_tests.py`). 1754 property checks + 10 unit checks per run.
- Oracle compares the candidate cache against an `OrderedDict`-backed reference after every op. The frozen feature request forbids `OrderedDict` and `functools.lru_cache`, forcing a from-scratch hash-map + doubly-linked-list — the difficulty knob the issue calls out.
- Existing harness (`run_benchmark.py`, `noise_floor.py`) is already parameterized on benchmark name, so no harness code changes.
- Includes the prior `c1587d5` commit (noise_floor.py + tier1 baseline) which was on local main but not yet on origin/main; MILL5/claude-code-pipeline#97 builds on it.

## Oracle calibration

Verified end-to-end via `--mode=existing` on two scratch implementations:

| Implementation | Property pass | Unit pass | Correctness |
|----------------|---------------|-----------|-------------|
| Reference (hash map + DLL) | 1754/1754 | 10/10 | **1.000** |
| Planted MRU-eviction bug   | 1056/1754 |  8/10 | **0.761** |

The 24-point gap is the red/green signal MILL5/agentic-dev-pipeline#227 needs. The bug-detection works at the property-test level (membership divergence after random op sequences) and the unit-test level (`get_refreshes_recency`, `contains_does_not_touch_recency`).

## Test plan

- [x] Property tests pass on a known-correct reference impl
- [x] Property tests fail on a planted MRU-eviction bug
- [x] Unit tests pass on the reference; fail on the bug
- [x] `run_benchmark.py tier2-lru-cache --mode=existing` produces a well-formed `metrics.json` with composite scores
- [ ] **Pending (not in this PR, ~\$80):** N=5 validation run via `noise_floor.py tier2-lru-cache --n=5` to confirm `stddev(correctness) > 0` on real pipeline output. If still 0, escalate per the README (enforce no-stdlib-LRU statically, or move to Candidate B/C from MILL5/claude-code-pipeline#97).

Closes MILL5/claude-code-pipeline#97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)