### PR TITLE
feat(orchestrator): non-interactive mode for headless/benchmark runs

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -229,16 +229,6 @@ When `NON_INTERACTIVE=true`, announce once before Step 1a:
 
 > ⚠ Non-interactive mode active (`CLAUDE_PIPELINE_NON_INTERACTIVE=1`). Scope ambiguities will be auto-defaulted; clarification and manual-test loops are skipped. Output protocol is unchanged.
 
-After initializing `TOKEN_LEDGER` in Step 0.6, append a sentinel entry:
-
-```
-step: "0.5:mode", agent: "orchestrator", model: "—", input_chars: 0, output_chars: 0,
-input_tokens: 0, output_tokens: 0, notes: "non-interactive mode"
-```
-
-This sentinel marks every run that used non-interactive mode so post-hoc token analysis can
-distinguish auto-defaulted decisions from user-confirmed ones.
-
 ## Step 0.6: Initialize Token Tracking
 
 Immediately after loading the adapter, initialize the `TOKEN_LEDGER` — an in-session list that
@@ -267,6 +257,15 @@ accumulates token usage data for every agent call throughout the pipeline. Also 
 `---TOKEN_REPORT---` block (compact 3-line format) for `files_read` and `tool_calls`. If the
 TOKEN_REPORT is missing or malformed, leave those fields empty — do not fail. Append the
 entry to `TOKEN_LEDGER`.
+
+**Non-interactive sentinel:** If `NON_INTERACTIVE=true`, append this entry immediately after initializing the empty ledger:
+
+```
+step: "0.5:mode", agent: "orchestrator", model: "—", input_chars: 0, output_chars: 0,
+input_tokens: 0, output_tokens: 0, notes: "non-interactive mode"
+```
+
+This marks every non-interactive run so post-hoc token analysis can distinguish auto-defaulted decisions from user-confirmed ones.
 
 ## Step 0.65: Initialize Backlog Integration State
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -215,6 +215,30 @@ subscription/tenant/user/auth method, caches result as `AZURE_AUTH_STATUS`).
   Azure-dependent skills check `AZURE_AUTH_STATUS` and skip re-validation if already OK.
   Re-validate if the target subscription or resource group changes mid-pipeline.
 
+## Step 0.5: Non-Interactive Mode Detection
+
+Check the `CLAUDE_PIPELINE_NON_INTERACTIVE` environment variable:
+
+```bash
+echo "${CLAUDE_PIPELINE_NON_INTERACTIVE:-0}"
+```
+
+If the result is `1`, set `NON_INTERACTIVE=true`. Otherwise `NON_INTERACTIVE=false`.
+
+When `NON_INTERACTIVE=true`, announce once before Step 1a:
+
+> ⚠ Non-interactive mode active (`CLAUDE_PIPELINE_NON_INTERACTIVE=1`). Scope ambiguities will be auto-defaulted; clarification and manual-test loops are skipped. Output protocol is unchanged.
+
+After initializing `TOKEN_LEDGER` in Step 0.6, append a sentinel entry:
+
+```
+step: "0.5:mode", agent: "orchestrator", model: "—", input_chars: 0, output_chars: 0,
+input_tokens: 0, output_tokens: 0, notes: "non-interactive mode"
+```
+
+This sentinel marks every run that used non-interactive mode so post-hoc token analysis can
+distinguish auto-defaulted decisions from user-confirmed ones.
+
 ## Step 0.6: Initialize Token Tracking
 
 Immediately after loading the adapter, initialize the `TOKEN_LEDGER` — an in-session list that
@@ -585,7 +609,7 @@ PR). If no folds occurred, omit the section entirely.
 - **Does not review code.** That's the code-reviewer's job.
 - **Does not modify commit messages.** Uses them verbatim from the implementer.
 - **Does not merge PRs.** The user decides when to merge.
-- **Does not skip steps.** Every change goes through the full pipeline.
+- **Does not skip steps.** Every change goes through the full pipeline. (Exception: Step 3.5 is skipped when `NON_INTERACTIVE=true` — see Step 0.5.)
 
 ## Resuming After Interruption
 

--- a/skills/orchestrate/steps/1a-clarify.md
+++ b/skills/orchestrate/steps/1a-clarify.md
@@ -86,6 +86,18 @@ Prompt: |
   <paste 1a Extract from Step 0.7>
 ```
 
+**Non-interactive mode (NON_INTERACTIVE=true):** Before launching the architect-agent, append the following block to the prompt (after `CODEBASE CONTEXT`):
+
+```
+NON_INTERACTIVE MODE: No user is available to answer questions. If scope is ambiguous,
+choose the most idiomatic answer for this stack. Document every auto-defaulted decision
+in a "## Auto-defaulted Decisions" section of 1a-spec.md and include a [NON-INTERACTIVE]
+banner at the top of the file. Do NOT ask questions or halt — produce 1a-spec.md directly.
+```
+
+Then skip the clarification loop below. Record step=`1a` in TOKEN_LEDGER with
+notes=`non-interactive: auto-defaulted`. Proceed to the TOKEN_LEDGER gate.
+
 **Clarification loop:**
 - The 1a agent will output a structured analysis followed by grouped clarifying questions.
 - Present the questions to the user verbatim.

--- a/skills/orchestrate/steps/1a-clarify.md
+++ b/skills/orchestrate/steps/1a-clarify.md
@@ -51,11 +51,11 @@ header variants; follow the parser's exact header list.
 
 **Resume check (only if passthrough did not fire):**
 
-Check whether `.claude/tmp/1a-spec.md` already exists from a prior run. If it does,
-ask the user: "A previous 1a analysis exists — resume from it or start fresh?"
-
-- **Resume** → skip the agent launch and proceed directly to Step 1b with the existing spec.
-- **Start fresh** → delete `.claude/tmp/1a-spec.md` and run Step 1a normally below.
+Check whether `.claude/tmp/1a-spec.md` already exists from a prior run. If it does:
+- **If `NON_INTERACTIVE=true`:** default to **Resume** without asking — a headless run cannot answer the prompt.
+- **Otherwise:** ask the user: "A previous 1a analysis exists — resume from it or start fresh?"
+  - **Resume** → skip the agent launch and proceed directly to Step 1b with the existing spec.
+  - **Start fresh** → delete `.claude/tmp/1a-spec.md` and run Step 1a normally below.
 
 **Launch the architect-agent in 1a mode:**
 

--- a/skills/orchestrate/steps/1b-plan.md
+++ b/skills/orchestrate/steps/1b-plan.md
@@ -58,6 +58,22 @@ Prompt: |
 Note: The 1a-spec already contains project overview, directory structure, fragile areas, and
 current state — the 1b extract omits these to avoid duplication.
 
+**Non-interactive mode (NON_INTERACTIVE=true):** Before launching the architect-agent, append the following block to the prompt (after `CODEBASE CONTEXT`):
+
+```
+NON_INTERACTIVE MODE: No user is available. Skip implementation clarification questions
+entirely. Proceed directly to decomposition and plan generation using the 1a-spec as
+authoritative. If a decision is irreducibly ambiguous, choose the most idiomatic approach
+and document it in the plan.
+```
+
+Then:
+- Skip the implementation clarification loop below — do NOT surface questions or wait for answers.
+- After receiving `PLAN_WRITTEN`, read and validate `.claude/tmp/1b-plan.md` (same quality checks as interactive mode).
+- Process any `## Deferred Items` per the Backlog Integration section.
+- Proceed directly to Step 1.4 — do NOT present the plan to the user or wait for confirmation.
+- Record step=`1b` in TOKEN_LEDGER with notes=`non-interactive: auto-confirmed`.
+
 **Implementation clarification loop:**
 The 1b agent will first analyze the enriched spec against the codebase, then pause to surface
 implementation-specific questions (technical approach, patterns, integration strategy, data
@@ -92,18 +108,3 @@ the plan.
 **Token tracking:** Per Step 0.6 — one entry for the initial launch (step `1b`); one per impl-clarification SendMessage (step `1b:impl-clarify-N`); one per revision (step `1b:revision-N`). agent=`architect-agent`, model=as selected above.
 
 **Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.
-
-**Non-interactive mode (NON_INTERACTIVE=true):** Before launching the architect-agent, append the following block to the prompt (after `CODEBASE CONTEXT`):
-
-```
-NON_INTERACTIVE MODE: No user is available. Skip implementation clarification questions
-entirely. Proceed directly to decomposition and plan generation using the 1a-spec as
-authoritative. If a decision is irreducibly ambiguous, choose the most idiomatic approach
-and document it in the plan.
-```
-
-- Skip the implementation clarification loop — do NOT surface questions or wait for answers.
-- After receiving `PLAN_WRITTEN`, read and validate `.claude/tmp/1b-plan.md` (same quality checks as interactive mode).
-- Process any `## Deferred Items` per the Backlog Integration section.
-- Proceed directly to Step 1.4 — do NOT present the plan to the user or wait for confirmation.
-- Record step=`1b` in TOKEN_LEDGER with notes=`non-interactive: auto-confirmed`.

--- a/skills/orchestrate/steps/1b-plan.md
+++ b/skills/orchestrate/steps/1b-plan.md
@@ -92,3 +92,18 @@ the plan.
 **Token tracking:** Per Step 0.6 — one entry for the initial launch (step `1b`); one per impl-clarification SendMessage (step `1b:impl-clarify-N`); one per revision (step `1b:revision-N`). agent=`architect-agent`, model=as selected above.
 
 **Plan revisions:** If the user requests changes, use **SendMessage** to the 1b agent (do NOT launch a new agent — the architect must remember its own plan). Iterate until confirmed.
+
+**Non-interactive mode (NON_INTERACTIVE=true):** Before launching the architect-agent, append the following block to the prompt (after `CODEBASE CONTEXT`):
+
+```
+NON_INTERACTIVE MODE: No user is available. Skip implementation clarification questions
+entirely. Proceed directly to decomposition and plan generation using the 1a-spec as
+authoritative. If a decision is irreducibly ambiguous, choose the most idiomatic approach
+and document it in the plan.
+```
+
+- Skip the implementation clarification loop — do NOT surface questions or wait for answers.
+- After receiving `PLAN_WRITTEN`, read and validate `.claude/tmp/1b-plan.md` (same quality checks as interactive mode).
+- Process any `## Deferred Items` per the Backlog Integration section.
+- Proceed directly to Step 1.4 — do NOT present the plan to the user or wait for confirmation.
+- Record step=`1b` in TOKEN_LEDGER with notes=`non-interactive: auto-confirmed`.

--- a/skills/orchestrate/steps/3.4-browser-ui.md
+++ b/skills/orchestrate/steps/3.4-browser-ui.md
@@ -68,12 +68,9 @@ Prompt: |
   user-facing prompt for manual test should mention the automated smoke
   passed: "Automated browser smoke test passed (golden path + N edge cases).
   Please test the branch and report any bugs..."
-- **FAIL** — treat the failure as a bug report and route it through the
-  existing Step 3.5.1 (ASSESS) → 3.5.2 (FIX) → 3.5.3 (REVIEW) → 3.5.4
-  (COMMIT) → 3.5.5 (RE-TEST) cycle. Use the skill's "Reproduction" block as
-  the bug report. After the fix is committed, re-run Step 3.4 once before
-  handing back to the user. If Step 3.4 fails twice on the same scenario,
-  stop and present the findings — do NOT loop.
+- **FAIL** —
+  - **If `NON_INTERACTIVE=true`:** log the failure with the skill's "Reproduction" block, then proceed to Step 4. Do NOT route into Step 3.5 (it is skipped in non-interactive mode).
+  - **Otherwise:** treat the failure as a bug report and route it through the existing Step 3.5.1 (ASSESS) → 3.5.2 (FIX) → 3.5.3 (REVIEW) → 3.5.4 (COMMIT) → 3.5.5 (RE-TEST) cycle. Use the skill's "Reproduction" block as the bug report. After the fix is committed, re-run Step 3.4 once before handing back to the user. If Step 3.4 fails twice on the same scenario, stop and present the findings — do NOT loop.
 
 **Token tracking:** Per Step 0.6 — one entry for step `3.4` (re-runs as `3.4:retry-N`). agent=`orchestrator` (skill, not an Agent launch), model=`sonnet`.
 

--- a/skills/orchestrate/steps/3.5-manual-test.md
+++ b/skills/orchestrate/steps/3.5-manual-test.md
@@ -14,6 +14,10 @@ in `SKILL.md` and remain accessible.
 
 The plan referenced throughout this step lives at `.claude/tmp/1b-plan.md`.
 
+**Non-interactive mode (NON_INTERACTIVE=true):** Skip this step entirely. The test harness (CI runner, benchmark oracle) serves as the test gate in headless runs. Log to the user: `Step 3.5 skipped — non-interactive mode.` Proceed directly to Step 4.
+
+---
+
 After all implementation is committed and pushed, prompt the user to test the PR branch:
 
 > "All tasks implemented and pushed to `PR_BRANCH`. Please test the branch and report


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_PIPELINE_NON_INTERACTIVE=1` env-var-gated headless mode to the orchestrator
- Step 1a: architect-agent receives a `NON_INTERACTIVE MODE:` prompt injection telling it to auto-default scope ambiguities and write 1a-spec.md directly (with a `[NON-INTERACTIVE]` banner listing every auto-defaulted decision); clarification loop is skipped
- Step 1b: architect-agent skips impl-clarify questions and proceeds directly to decomposition; plan is auto-confirmed without user confirmation
- Step 3.5: skipped entirely — the external test harness (CI/benchmark oracle) serves as the gate
- `TOKEN_LEDGER` receives a mode sentinel entry (`step: "0.5:mode"`) so post-hoc token analysis can flag auto-defaulted runs
- Output protocol unchanged: `SUCCESS`/`FAILURE`, TOKEN_REPORTs, and recovery artifacts (`1a-spec.md`, `1b-plan.md`) produced identically

## Open review findings (from self-review)

Three items flagged during review that are not yet addressed — noting here for discussion before merge:

1. **Step 0.5 sentinel ordering**: sentinel append is described in Step 0.5 but must happen after Step 0.6 initializes the ledger. The instruction is technically correct ("after initializing TOKEN_LEDGER in Step 0.6…") but reads ambiguously. Consider moving the sentinel instruction into Step 0.6 as a conditional block.
2. **Resume check gap in 1a**: the "A previous 1a-spec exists — resume or start fresh?" prompt (1a-clarify.md line 55) still fires in non-interactive mode. Should default to `resume` without asking.
3. **1b non-interactive block placement**: positioned at end of file; interactive sections (impl-clarify loop, plan confirmation) appear earlier without NON_INTERACTIVE guards. Consider moving before the clarification loop, matching 1a's pattern.

## Test plan

- [x] `python3 tests/validate_structure.py` — 398/398 checks pass
- [ ] Smoke test: run a benchmark with `CLAUDE_PIPELINE_NON_INTERACTIVE=1` and confirm no interactive prompts appear
- [ ] Confirm `1a-spec.md` contains `[NON-INTERACTIVE]` banner on a headless run
- [ ] Confirm `TOKEN_LEDGER` contains `step: "0.5:mode"` sentinel

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)